### PR TITLE
ci: split test triggers by backend and frontend changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,8 @@ name: Test Suite
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
 
 concurrency:
   group: test-${{ github.ref }}
@@ -20,8 +14,35 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'platform-api/**'
+              - 'platform-backend/**'
+              - 'platform-fisco/**'
+              - 'platform-storage/**'
+              - 'pom.xml'
+              - '.github/workflows/**'
+            frontend:
+              - 'platform-frontend/**'
+              - '.github/workflows/**'
+
   backend-test:
     name: Backend Tests
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,6 +92,8 @@ jobs:
 
   frontend-test:
     name: Frontend Tests
+    needs: [changes]
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -118,7 +141,8 @@ jobs:
   contract-consistency:
     name: Contract Consistency
     runs-on: ubuntu-latest
-    needs: [backend-test, frontend-test]
+    needs: [changes, backend-test]
+    if: needs.changes.outputs.backend == 'true'
     permissions:
       contents: read
     steps:
@@ -167,6 +191,8 @@ jobs:
 
   security-scan:
     name: Security Scan
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -186,7 +212,8 @@ jobs:
   build-check:
     name: Build Verification
     runs-on: ubuntu-latest
-    needs: [backend-test, frontend-test, contract-consistency]
+    needs: [changes, backend-test, frontend-test, contract-consistency]
+    if: always() && !failure() && !cancelled() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Split the `changes` job's single `code` output into separate `backend` and `frontend` outputs using `dorny/paths-filter`
- Each test job now only runs when its relevant code paths are changed (backend changes → backend tests, frontend changes → frontend tests)
- `contract-consistency` only depends on `backend-test` since it only needs the OpenAPI artifact
- `build-check` uses `always() && !failure() && !cancelled()` to avoid cascading skips when only one side changes

## Test plan
- [ ] Push only a frontend file change and verify `backend-test` and `contract-consistency` are skipped
- [ ] Push only a backend file change and verify `frontend-test` is skipped
- [ ] Push a workflow file change and verify both sides run
- [ ] Verify `build-check` still runs correctly when upstream jobs are skipped