### PR TITLE
feat: add file version chain support (P2-1)

### DIFF
--- a/platform-backend/backend-common/src/main/java/cn/flying/common/constant/ResultEnum.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/constant/ResultEnum.java
@@ -129,6 +129,12 @@ public enum ResultEnum implements Serializable {
     SHARE_EXPIRED(50012, "分享已过期"),
     /** 配额超限 */
     QUOTA_EXCEEDED(50013, "配额超限"),
+    /** 版本链不存在 */
+    VERSION_CHAIN_NOT_FOUND(50014, "版本链不存在"),
+    /** 版本创建冲突 */
+    VERSION_CONFLICT(50015, "版本创建冲突，请重试"),
+    /** 源文件状态不允许创建新版本 */
+    VERSION_SOURCE_INVALID(50016, "源文件状态不允许创建新版本"),
 
     /* ==================== 消息服务错误：60000-69999 ==================== */
     /** 消息不存在 */

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/event/FileStorageEvent.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/event/FileStorageEvent.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class FileStorageEvent extends ApplicationEvent {
     private final Long tenantId;         // 租户ID
     private final Long uid;              // 用户ID
+    private final Long fileId;           // 目标文件ID（可为空）
     private final String fileName;         // 文件名
     private final String sessionId;        // 上传会话ID
     private final String clientId;         // 客户端ID
@@ -38,9 +39,31 @@ public class FileStorageEvent extends ApplicationEvent {
                             String sessionId, String clientId,
                             List<File> processedFiles, List<String> fileHashes,
                             String fileParam) {
+        this(source, tenantId, uid, null, fileName, sessionId, clientId, processedFiles, fileHashes, fileParam);
+    }
+
+    /**
+     * 构造文件存证事件。
+     *
+     * @param source 事件源
+     * @param tenantId 租户ID
+     * @param uid 用户ID
+     * @param fileId 目标文件ID（可为空）
+     * @param fileName 文件名
+     * @param sessionId 上传会话ID
+     * @param clientId 客户端ID
+     * @param processedFiles 已处理文件列表
+     * @param fileHashes 文件哈希列表
+     * @param fileParam 文件参数
+     */
+    public FileStorageEvent(Object source, Long tenantId, Long uid, Long fileId, String fileName,
+                            String sessionId, String clientId,
+                            List<File> processedFiles, List<String> fileHashes,
+                            String fileParam) {
         super(source);
         this.tenantId = tenantId;
         this.uid = uid;
+        this.fileId = fileId;
         this.fileName = fileName;
         this.sessionId = sessionId;
         this.clientId = clientId;

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/dto/File.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/dto/File.java
@@ -80,6 +80,18 @@ public class File implements Serializable {
     @Schema(description = "逻辑删除字段：0—>未删除 , 1->已删除")
     private Integer deleted;
 
+    @Schema(description = "版本号，从 1 开始")
+    private Integer version;
+
+    @Schema(description = "上一版本文件ID")
+    private Long parentVersionId;
+
+    @Schema(description = "是否最新版本：1=是，0=否")
+    private Integer isLatest;
+
+    @Schema(description = "版本链分组ID")
+    private Long versionGroupId;
+
     @TableField(fill = FieldFill.INSERT)
     @Schema(description = "创建时间")
     private Date createTime;

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/FileMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/FileMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import java.util.Date;
 import java.util.List;
@@ -253,4 +254,35 @@ public interface FileMapper extends BaseMapper<File> {
             GROUP BY uid
             """)
     List<QuotaUserUsageVO> aggregateQuotaUserUsageByTenant(@Param("tenantId") Long tenantId);
+
+    /**
+     * 将版本链中所有文件的 is_latest 置为 0
+     *
+     * @param versionGroupId 版本链分组ID
+     * @param tenantId 租户ID
+     * @return 受影响行数
+     */
+    @Update("UPDATE file SET is_latest = 0 WHERE version_group_id = #{versionGroupId} AND tenant_id = #{tenantId} AND deleted = 0")
+    int clearLatestInChain(@Param("versionGroupId") Long versionGroupId, @Param("tenantId") Long tenantId);
+
+    /**
+     * 查询版本链中所有文件，按版本号倒序
+     *
+     * @param versionGroupId 版本链分组ID
+     * @param tenantId 租户ID
+     * @return 版本链文件列表
+     */
+    @Select("SELECT id, tenant_id, uid, file_name, file_param, file_hash, status, version, parent_version_id, is_latest, version_group_id, create_time " +
+            "FROM file WHERE version_group_id = #{versionGroupId} AND tenant_id = #{tenantId} AND deleted = 0 ORDER BY version DESC")
+    List<File> selectVersionChain(@Param("versionGroupId") Long versionGroupId, @Param("tenantId") Long tenantId);
+
+    /**
+     * 统计版本链中文件数量
+     *
+     * @param versionGroupId 版本链分组ID
+     * @param tenantId 租户ID
+     * @return 版本数量
+     */
+    @Select("SELECT COUNT(*) FROM file WHERE version_group_id = #{versionGroupId} AND tenant_id = #{tenantId} AND deleted = 0")
+    int countVersionsInChain(@Param("versionGroupId") Long versionGroupId, @Param("tenantId") Long tenantId);
 }

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/CreateVersionVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/CreateVersionVO.java
@@ -1,0 +1,19 @@
+package cn.flying.dao.vo.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "创建新版本请求")
+public record CreateVersionVO(
+        @NotBlank(message = "文件名不能为空")
+        @Schema(description = "文件名称", requiredMode = Schema.RequiredMode.REQUIRED)
+        String fileName,
+        @Min(value = 1, message = "文件大小必须大于0")
+        @Schema(description = "文件大小（字节）", requiredMode = Schema.RequiredMode.REQUIRED)
+        long fileSize,
+        @NotBlank(message = "文件类型不能为空")
+        @Schema(description = "文件类型", requiredMode = Schema.RequiredMode.REQUIRED)
+        String contentType
+) {
+}

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileUploadState.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileUploadState.java
@@ -25,6 +25,8 @@ public class FileUploadState {
     private Long userId;
     @Schema(description = "客户端ID（标识唯一的客户端会话）")
     private String clientId;
+    @Schema(description = "目标文件ID（版本上传时用于绑定既有 PREPARE 记录）")
+    private Long targetFileId;
     @Schema(description = "文件名")
     private String fileName;
     @Schema(description = "文件大小")
@@ -55,8 +57,26 @@ public class FileUploadState {
     private volatile boolean prepareStored;
 
     public FileUploadState(Long userId, String fileName, long fileSize, String contentType, String clientId, int chunkSize, int totalChunks) {
+        this(userId, fileName, fileSize, contentType, clientId, chunkSize, totalChunks, null);
+    }
+
+    /**
+     * 构造上传会话状态，支持绑定目标文件ID。
+     *
+     * @param userId 用户ID
+     * @param fileName 文件名
+     * @param fileSize 文件大小
+     * @param contentType 文件类型
+     * @param clientId 客户端会话ID
+     * @param chunkSize 分片大小
+     * @param totalChunks 分片总数
+     * @param targetFileId 目标文件ID
+     */
+    public FileUploadState(Long userId, String fileName, long fileSize, String contentType,
+                           String clientId, int chunkSize, int totalChunks, Long targetFileId) {
         this.userId = userId;
         this.clientId = clientId;
+        this.targetFileId = targetFileId;
         this.fileName = fileName;
         this.fileSize = fileSize;
         this.contentType = contentType;

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileVersionVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileVersionVO.java
@@ -1,0 +1,28 @@
+package cn.flying.dao.vo.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Date;
+
+@Schema(description = "文件版本信息")
+public record FileVersionVO(
+        @Schema(description = "文件ID（外部ID）")
+        String fileId,
+        @Schema(description = "版本号")
+        Integer version,
+        @Schema(description = "文件名称")
+        String fileName,
+        @Schema(description = "文件哈希")
+        String fileHash,
+        @Schema(description = "文件大小（字节）")
+        Long fileSize,
+        @Schema(description = "文件类型")
+        String contentType,
+        @Schema(description = "是否最新版本")
+        Integer isLatest,
+        @Schema(description = "文件状态")
+        Integer status,
+        @Schema(description = "创建时间")
+        Date createTime
+) {
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/FileQueryService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/FileQueryService.java
@@ -2,6 +2,7 @@ package cn.flying.service;
 
 import cn.flying.dao.dto.File;
 import cn.flying.dao.vo.file.FileDecryptInfoVO;
+import cn.flying.dao.vo.file.FileVersionVO;
 import cn.flying.dao.vo.file.UserFileStatsVO;
 import cn.flying.platformapi.response.TransactionVO;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
@@ -145,6 +146,15 @@ public interface FileQueryService {
      * @return 文件统计信息
      */
     UserFileStatsVO getUserFileStats(Long userId);
+
+    /**
+     * 获取文件版本历史
+     *
+     * @param userId 用户ID（用于权限校验）
+     * @param fileId 文件ID（版本链中任意一个文件）
+     * @return 版本历史列表（按版本号倒序）
+     */
+    List<FileVersionVO> getFileVersionHistory(Long userId, Long fileId);
 
     // ==================== 异步查询方法（Virtual Thread 优化）====================
 

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/FileService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/FileService.java
@@ -26,6 +26,17 @@ public interface FileService extends IService<File> {
      * @param fileSize 文件大小（字节），用于配额预占位
      */
     void prepareStoreFile(Long userId, String OriginFileName, long fileSize);
+
+    /**
+     * 在完成分片上传后预存储文件（支持绑定既有 PREPARE 记录）。
+     *
+     * @param userId 用户ID
+     * @param targetFileId 目标文件ID（为空时创建新 PREPARE；非空时复用该记录）
+     * @param originFileName 原始文件名
+     * @param fileSize 文件大小（字节），用于配额预占位
+     */
+    void prepareStoreFile(Long userId, Long targetFileId, String originFileName, long fileSize);
+
     /**
      * 存储文件
      * @param userId 用户ID
@@ -35,6 +46,19 @@ public interface FileService extends IService<File> {
      * @return
      */
     File storeFile(Long userId, String OriginFileName, List<java.io.File> fileList, List<String> fileHashList, String fileParam);
+
+    /**
+     * 存储文件（支持按目标 fileId 精确关联 PREPARE 记录）。
+     *
+     * @param userId 用户ID
+     * @param targetFileId 目标文件ID（为空时按 fileName 回溯 PREPARE）
+     * @param originFileName 原始文件名
+     * @param fileList 加密后的文件分片列表
+     * @param fileHashList 文件分片对应的哈希列表
+     * @param fileParam 文件参数(JSON)
+     * @return 已落库文件信息
+     */
+    File storeFile(Long userId, Long targetFileId, String originFileName, List<java.io.File> fileList, List<String> fileHashList, String fileParam);
 
     /**
      * 修改文件状态
@@ -51,6 +75,15 @@ public interface FileService extends IService<File> {
      * @param fileStatus
      */
     void changeFileStatusByHash(Long userId, String fileHash, Integer fileStatus);
+
+    /**
+     * 根据文件ID修改文件状态。
+     *
+     * @param userId 用户ID
+     * @param fileId 文件ID
+     * @param fileStatus 目标状态
+     */
+    void changeFileStatusById(Long userId, Long fileId, Integer fileStatus);
 
     /**
      * 批量删除文件

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/FileService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/FileService.java
@@ -194,4 +194,17 @@ public interface FileService extends IService<File> {
      */
     FileDecryptInfoVO getSharedFileDecryptInfo(Long userId, String shareCode, String fileHash);
 
+    /**
+     * 创建文件新版本（PREPARE 状态）
+     * 客户端后续拿返回的 fileId 走现有上传流程
+     *
+     * @param userId 用户ID
+     * @param parentFileId 父版本文件ID（内部ID）
+     * @param fileName 新版本文件名
+     * @param fileSize 文件大小（字节）
+     * @param contentType 文件类型
+     * @return PREPARE 状态的新版本 File
+     */
+    File createNewVersion(Long userId, Long parentFileId, String fileName, long fileSize, String contentType);
+
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/FileService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/FileService.java
@@ -86,6 +86,14 @@ public interface FileService extends IService<File> {
     void changeFileStatusById(Long userId, Long fileId, Integer fileStatus);
 
     /**
+     * 将指定文件标记为上传失败，并在版本链场景下恢复上一成功版本为 latest。
+     *
+     * @param userId 用户ID
+     * @param fileId 目标文件ID
+     */
+    void markFileUploadFailed(Long userId, Long fileId);
+
+    /**
      * 批量删除文件
      * 支持通过文件哈希或文件ID进行删除
      * @param userId 用户ID

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/FileUploadService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/FileUploadService.java
@@ -26,6 +26,21 @@ public interface FileUploadService {
      * @return
      */
     StartUploadVO startUpload(Long userId, String fileName, long fileSize, String contentType, String clientId, int chunkSize, int totalChunks);
+
+    /**
+     * 开始上传（支持绑定目标文件ID）。
+     *
+     * @param userId 用户ID
+     * @param fileName 文件名
+     * @param fileSize 文件大小
+     * @param contentType 文件类型
+     * @param clientId 上传客户端ID
+     * @param chunkSize 分片大小
+     * @param totalChunks 分片总数
+     * @param targetFileId 目标文件ID（为空表示普通上传）
+     * @return 上传会话信息
+     */
+    StartUploadVO startUpload(Long userId, String fileName, long fileSize, String contentType, String clientId, int chunkSize, int totalChunks, Long targetFileId);
     /**
      * 上传分片
      * @param uid 用户ID

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileAdminServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileAdminServiceImpl.java
@@ -69,6 +69,7 @@ public class FileAdminServiceImpl implements FileAdminService {
 
         LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<File>()
                 .eq(File::getTenantId, tenantId)
+                .eq(File::getIsLatest, 1)
                 .orderByDesc(File::getCreateTime);
 
         // 关键词搜索

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileQueryServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileQueryServiceImpl.java
@@ -7,6 +7,7 @@ import cn.flying.common.constant.ShareType;
 import cn.flying.common.exception.GeneralException;
 import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.CommonUtils;
+import cn.flying.common.util.IdUtils;
 import cn.flying.common.util.JsonConverter;
 import cn.flying.common.util.SecurityUtils;
 import cn.flying.dao.dto.Account;
@@ -17,6 +18,7 @@ import cn.flying.dao.mapper.FileMapper;
 import cn.flying.dao.mapper.FileShareMapper;
 import cn.flying.dao.vo.file.FileDecryptInfoVO;
 import cn.flying.dao.vo.file.FileShareVO;
+import cn.flying.dao.vo.file.FileVersionVO;
 import cn.flying.dao.vo.file.UserFileStatsVO;
 import cn.flying.platformapi.constant.Result;
 import cn.flying.platformapi.response.FileDetailVO;
@@ -206,7 +208,8 @@ public class FileQueryServiceImpl implements FileQueryService {
         LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<>();
         // 所有用户（包括管理员）只能查询自己的文件
         // 管理员查看所有文件请使用 FileAdminService.getAllFiles()
-        wrapper.eq(File::getUid, userId);
+        wrapper.eq(File::getUid, userId)
+               .eq(File::getIsLatest, 1);
         return fileMapper.selectList(wrapper);
     }
 
@@ -232,7 +235,8 @@ public class FileQueryServiceImpl implements FileQueryService {
         LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<>();
         // 所有用户（包括管理员）只能查询自己的文件
         // 管理员查看所有文件请使用 FileAdminService.getAllFiles()
-        wrapper.eq(File::getUid, userId);
+        wrapper.eq(File::getUid, userId)
+               .eq(File::getIsLatest, 1);
 
         applyKeywordFilter(wrapper, keyword, keywordMode);
 
@@ -522,6 +526,42 @@ public class FileQueryServiceImpl implements FileQueryService {
                 totalStorage != null ? totalStorage : 0L,
                 sharedFiles != null ? sharedFiles : 0L,
                 todayUploads != null ? todayUploads : 0L
+        );
+    }
+
+    @Override
+    public List<FileVersionVO> getFileVersionHistory(Long userId, Long fileId) {
+        File file = fileMapper.selectById(fileId);
+        if (file == null) {
+            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
+        }
+
+        // 权限校验：owner 或 admin
+        if (!SecurityUtils.isAdmin() && !file.getUid().equals(userId)) {
+            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED);
+        }
+
+        Long versionGroupId = file.getVersionGroupId();
+        if (versionGroupId == null) {
+            // 遗留文件，无版本链，返回单条
+            return List.of(toFileVersionVO(file));
+        }
+
+        List<File> chain = fileMapper.selectVersionChain(versionGroupId, file.getTenantId());
+        return chain.stream().map(this::toFileVersionVO).toList();
+    }
+
+    private FileVersionVO toFileVersionVO(File file) {
+        return new FileVersionVO(
+                IdUtils.toExternalId(file.getId()),
+                file.getVersion() != null ? file.getVersion() : 1,
+                file.getFileName(),
+                file.getFileHash(),
+                file.getFileSize(),
+                file.getContentType(),
+                file.getIsLatest() != null ? file.getIsLatest() : 1,
+                file.getStatus(),
+                file.getCreateTime()
         );
     }
 

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
@@ -49,12 +49,14 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -89,20 +91,72 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
     @Resource
     private RedissonClient redissonClient;
 
+    @Resource
+    private TransactionTemplate transactionTemplate;
+
     @Override
     @Transactional(rollbackFor = Exception.class)
     public void prepareStoreFile(Long userId, String OriginFileName, long fileSize) {
+        prepareStoreFile(userId, null, OriginFileName, fileSize);
+    }
+
+    /**
+     * 预存储文件元数据，支持复用既有 PREPARE 记录。
+     *
+     * @param userId 用户ID
+     * @param targetFileId 目标文件ID（为空时创建新 PREPARE）
+     * @param originFileName 原始文件名
+     * @param fileSize 文件大小
+     */
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void prepareStoreFile(Long userId, Long targetFileId, String originFileName, long fileSize) {
+        if (targetFileId != null) {
+            validatePreparedTargetFile(userId, targetFileId, originFileName, fileSize);
+            return;
+        }
+
         Long id = IdUtils.nextEntityId();
         File file = new File()
                 .setId(id)
                 .setUid(userId)
-                .setFileName(OriginFileName)
+                .setFileName(originFileName)
                 .setFileParam(buildPrepareFileParam(fileSize))
                 .setStatus(FileUploadStatus.PREPARE.getCode())
                 .setVersion(1)
                 .setIsLatest(1)
                 .setVersionGroupId(id);
         this.save(file);
+    }
+
+    /**
+     * 校验版本上传场景下绑定的 PREPARE 目标文件是否合法。
+     *
+     * @param userId 用户ID
+     * @param targetFileId 目标文件ID
+     * @param originFileName 原始文件名
+     * @param fileSize 文件大小
+     */
+    private void validatePreparedTargetFile(Long userId, Long targetFileId, String originFileName, long fileSize) {
+        File targetFile = this.getById(targetFileId);
+        if (targetFile == null) {
+            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
+        }
+        if (!Objects.equals(targetFile.getUid(), userId)) {
+            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED);
+        }
+        if (!Objects.equals(targetFile.getStatus(), FileUploadStatus.PREPARE.getCode())) {
+            throw new GeneralException(ResultEnum.VERSION_SOURCE_INVALID, "目标版本状态不允许上传");
+        }
+        if (CommonUtils.isNotEmpty(originFileName) && !Objects.equals(targetFile.getFileName(), originFileName)) {
+            throw new GeneralException(ResultEnum.PARAM_ERROR, "上传文件名与目标版本不一致");
+        }
+
+        Long targetFileSize = targetFile.getFileSize();
+        long resolvedSize = Math.max(0L, fileSize);
+        if (targetFileSize != null && targetFileSize > 0 && targetFileSize.longValue() != resolvedSize) {
+            throw new GeneralException(ResultEnum.PARAM_ERROR, "上传文件大小与目标版本不一致");
+        }
     }
 
     /**
@@ -123,18 +177,29 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
     @Override
     @CacheEvict(cacheNames = "userFiles", key = "#userId")
     public File storeFile(Long userId, String OriginFileName, List<java.io.File> fileList, List<String> fileHashList, String fileParam) {
+        return storeFile(userId, null, OriginFileName, fileList, fileHashList, fileParam);
+    }
+
+    /**
+     * 执行文件分片存储与上链，并将结果回写到目标 PREPARE 记录。
+     *
+     * @param userId 用户ID
+     * @param targetFileId 目标文件ID（为空时按 fileName 查找 PREPARE）
+     * @param originFileName 原始文件名
+     * @param fileList 分片文件列表
+     * @param fileHashList 分片哈希列表
+     * @param fileParam 文件参数
+     * @return 存储成功后的文件记录
+     */
+    @Override
+    @CacheEvict(cacheNames = "userFiles", key = "#userId")
+    public File storeFile(Long userId, Long targetFileId, String originFileName,
+                          List<java.io.File> fileList, List<String> fileHashList, String fileParam) {
         if (CommonUtils.isEmpty(fileList)) {
             throw new GeneralException(ResultEnum.PARAM_ERROR, "File list cannot be empty");
         }
 
-        LambdaQueryWrapper<File> fileQuery = new LambdaQueryWrapper<File>()
-                .eq(File::getUid, userId)
-                .eq(File::getFileName, OriginFileName)
-                .last("LIMIT 1");
-        File existingFile = this.getOne(fileQuery);
-        if (existingFile == null) {
-            throw new GeneralException(ResultEnum.FAIL, "File metadata not initialized for upload");
-        }
+        File existingFile = resolvePrepareFileForStore(userId, targetFileId, originFileName);
 
         String requestId = UUID.randomUUID().toString();
         FileUploadCommand cmd = FileUploadCommand.builder()
@@ -142,7 +207,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
                 .fileId(existingFile.getId())
                 .userId(userId)
                 .tenantId(existingFile.getTenantId())
-                .fileName(OriginFileName)
+                .fileName(existingFile.getFileName())
                 .fileParam(fileParam)
                 .fileList(fileList)
                 .fileHashList(fileHashList)
@@ -163,7 +228,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
 
         File file = new File()
                 .setUid(userId)
-                .setFileName(OriginFileName)
+                .setFileName(existingFile.getFileName())
                 .setFileHash(result.getFileHash())
                 .setTransactionHash(result.getTransactionHash())
                 .setFileParam(fileParam)
@@ -172,11 +237,43 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         boolean updated = this.update(file, wrapper);
         if (!updated) {
             log.warn("文件状态更新失败，可能已被其他操作修改: fileId={}, userId={}, fileName={}",
-                    existingFile.getId(), userId, OriginFileName);
+                    existingFile.getId(), userId, existingFile.getFileName());
             throw new GeneralException(ResultEnum.FAIL, "文件状态更新失败，请重试");
         }
 
         return file;
+    }
+
+    /**
+     * 解析并校验待回写的 PREPARE 记录。
+     *
+     * @param userId 用户ID
+     * @param targetFileId 指定目标文件ID（可为空）
+     * @param originFileName 文件名
+     * @return 匹配到的 PREPARE 记录
+     */
+    private File resolvePrepareFileForStore(Long userId, Long targetFileId, String originFileName) {
+        LambdaQueryWrapper<File> fileQuery = new LambdaQueryWrapper<File>()
+                .eq(File::getUid, userId)
+                .eq(File::getStatus, FileUploadStatus.PREPARE.getCode());
+
+        if (targetFileId != null) {
+            fileQuery.eq(File::getId, targetFileId);
+            if (CommonUtils.isNotEmpty(originFileName)) {
+                fileQuery.eq(File::getFileName, originFileName);
+            }
+        } else {
+            fileQuery.eq(File::getFileName, originFileName)
+                    .orderByDesc(File::getCreateTime)
+                    .orderByDesc(File::getId)
+                    .last("LIMIT 1");
+        }
+
+        File existingFile = this.getOne(fileQuery);
+        if (existingFile == null) {
+            throw new GeneralException(ResultEnum.FAIL, "File metadata not initialized for upload");
+        }
+        return existingFile;
     }
 
     @Override
@@ -201,6 +298,24 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         File file = new File()
                 .setStatus(fileStatus);
         this.update(file,wrapper);
+    }
+
+    /**
+     * 根据文件ID更新文件状态。
+     *
+     * @param userId 用户ID
+     * @param fileId 文件ID
+     * @param fileStatus 目标状态
+     */
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(cacheNames = "userFiles", key = "#userId")
+    public void changeFileStatusById(Long userId, Long fileId, Integer fileStatus) {
+        LambdaUpdateWrapper<File> wrapper = new LambdaUpdateWrapper<File>()
+                .eq(File::getId, fileId)
+                .eq(File::getUid, userId);
+        File file = new File().setStatus(fileStatus);
+        this.update(file, wrapper);
     }
 
     @Override
@@ -1065,17 +1180,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
     @Override
     @CacheEvict(cacheNames = "userFiles", key = "#userId")
     public File createNewVersion(Long userId, Long parentFileId, String fileName, long fileSize, String contentType) {
-        // 校验父文件
-        File parentFile = this.getById(parentFileId);
-        if (parentFile == null) {
-            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
-        }
-        if (!parentFile.getUid().equals(userId)) {
-            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED);
-        }
-        if (parentFile.getStatus() != FileUploadStatus.SUCCESS.getCode()) {
-            throw new GeneralException(ResultEnum.VERSION_SOURCE_INVALID);
-        }
+        File parentFile = validateVersionSourceFile(userId, parentFileId);
 
         Long versionGroupId = parentFile.getVersionGroupId() != null ? parentFile.getVersionGroupId() : parentFile.getId();
         String lockKey = "file:version:" + versionGroupId;
@@ -1086,8 +1191,15 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
                 throw new GeneralException(ResultEnum.VERSION_CONFLICT);
             }
             try {
-                // 事务内操作
-                return doCreateNewVersion(userId, parentFile, versionGroupId, fileName, fileSize, contentType);
+                // 加锁后再次校验，防止并发下基于过期父版本创建新版本。
+                File latestParentFile = validateVersionSourceFile(userId, parentFileId);
+                File createdVersion = transactionTemplate.execute(
+                        status -> doCreateNewVersion(userId, latestParentFile, versionGroupId, fileName, fileSize, contentType)
+                );
+                if (createdVersion == null) {
+                    throw new GeneralException(ResultEnum.FAIL, "创建新版本失败");
+                }
+                return createdVersion;
             } finally {
                 if (lock.isHeldByCurrentThread()) {
                     lock.unlock();
@@ -1099,7 +1211,42 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         }
     }
 
-    @Transactional(rollbackFor = Exception.class)
+    /**
+     * 校验父版本文件是否允许创建新版本。
+     * 仅允许文件所有者基于 SUCCESS 且 is_latest=1 的记录创建新版本。
+     *
+     * @param userId 用户ID
+     * @param parentFileId 父版本文件ID
+     * @return 校验通过的父版本文件
+     */
+    private File validateVersionSourceFile(Long userId, Long parentFileId) {
+        File parentFile = this.getById(parentFileId);
+        if (parentFile == null) {
+            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
+        }
+        if (!parentFile.getUid().equals(userId)) {
+            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED);
+        }
+        if (parentFile.getStatus() != FileUploadStatus.SUCCESS.getCode()) {
+            throw new GeneralException(ResultEnum.VERSION_SOURCE_INVALID);
+        }
+        if (parentFile.getIsLatest() != null && parentFile.getIsLatest() != 1) {
+            throw new GeneralException(ResultEnum.VERSION_SOURCE_INVALID, "只能基于最新版本创建新版本");
+        }
+        return parentFile;
+    }
+
+    /**
+     * 在事务内写入新版本记录，并将版本链中旧记录的 is_latest 置为 0。
+     *
+     * @param userId 用户ID
+     * @param parentFile 父版本文件
+     * @param versionGroupId 版本链分组ID
+     * @param fileName 新版本文件名
+     * @param fileSize 新版本文件大小
+     * @param contentType 新版本文件类型
+     * @return 新创建的版本记录
+     */
     protected File doCreateNewVersion(Long userId, File parentFile, Long versionGroupId,
                                        String fileName, long fileSize, String contentType) {
         // 清除版本链中所有文件的 isLatest
@@ -1108,6 +1255,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         // 创建新版本
         Long newId = IdUtils.nextEntityId();
         String fileParam = JsonConverter.toJson(Map.of("fileSize", Math.max(0L, fileSize), "contentType", contentType));
+        int parentVersion = parentFile.getVersion() != null ? parentFile.getVersion() : 1;
         File newVersion = new File()
                 .setId(newId)
                 .setUid(userId)
@@ -1115,7 +1263,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
                 .setFileName(fileName)
                 .setFileParam(fileParam)
                 .setStatus(FileUploadStatus.PREPARE.getCode())
-                .setVersion(parentFile.getVersion() + 1)
+                .setVersion(parentVersion + 1)
                 .setParentVersionId(parentFile.getId())
                 .setIsLatest(1)
                 .setVersionGroupId(versionGroupId);

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
@@ -318,6 +318,61 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         this.update(file, wrapper);
     }
 
+    /**
+     * 将目标文件标记为失败；若该文件为版本链最新节点，则恢复其父版本为 latest。
+     *
+     * @param userId 用户ID
+     * @param fileId 目标文件ID
+     */
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(cacheNames = "userFiles", key = "#userId")
+    public void markFileUploadFailed(Long userId, Long fileId) {
+        if (fileId == null) {
+            return;
+        }
+
+        File targetFile = this.getById(fileId);
+        if (targetFile == null || !Objects.equals(targetFile.getUid(), userId)) {
+            return;
+        }
+
+        boolean shouldRestoreParentLatest = targetFile.getParentVersionId() != null
+                && Objects.equals(targetFile.getIsLatest(), 1);
+
+        File failUpdate = new File().setStatus(FileUploadStatus.FAIL.getCode());
+        if (shouldRestoreParentLatest) {
+            failUpdate.setIsLatest(0);
+        }
+        LambdaUpdateWrapper<File> failWrapper = new LambdaUpdateWrapper<File>()
+                .eq(File::getId, targetFile.getId())
+                .eq(File::getUid, userId);
+        this.update(failUpdate, failWrapper);
+
+        if (shouldRestoreParentLatest) {
+            restoreParentVersionAsLatest(targetFile);
+        }
+    }
+
+    /**
+     * 将失败版本的父版本恢复为 latest，确保版本链仍有可用的最新成功版本。
+     *
+     * @param failedVersion 失败版本记录
+     */
+    private void restoreParentVersionAsLatest(File failedVersion) {
+        Long parentVersionId = failedVersion.getParentVersionId();
+        if (parentVersionId == null) {
+            return;
+        }
+
+        LambdaUpdateWrapper<File> parentWrapper = new LambdaUpdateWrapper<File>()
+                .eq(File::getId, parentVersionId)
+                .eq(File::getUid, failedVersion.getUid())
+                .eq(File::getStatus, FileUploadStatus.SUCCESS.getCode());
+        File parentUpdate = new File().setIsLatest(1);
+        this.update(parentUpdate, parentWrapper);
+    }
+
     @Override
     @Transactional(rollbackFor = Exception.class)
     @CacheEvict(cacheNames = "userFiles", key = "#userId")

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
@@ -8,6 +8,7 @@ import cn.flying.common.exception.GeneralException;
 import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.CommonUtils;
 import cn.flying.common.util.Const;
+import cn.flying.common.util.IdUtils;
 import cn.flying.common.util.JsonConverter;
 import cn.flying.common.util.SecurityUtils;
 import cn.flying.dao.dto.File;
@@ -38,6 +39,8 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.slf4j.MDC;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -53,6 +56,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @program: RecordPlatform
@@ -82,15 +86,23 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
     @Resource
     private CacheManager cacheManager;
 
+    @Resource
+    private RedissonClient redissonClient;
+
     @Override
     @Transactional(rollbackFor = Exception.class)
     public void prepareStoreFile(Long userId, String OriginFileName, long fileSize) {
+        Long id = IdUtils.nextEntityId();
         File file = new File()
+                .setId(id)
                 .setUid(userId)
                 .setFileName(OriginFileName)
                 .setFileParam(buildPrepareFileParam(fileSize))
-                .setStatus(FileUploadStatus.PREPARE.getCode());
-        this.saveOrUpdate(file);
+                .setStatus(FileUploadStatus.PREPARE.getCode())
+                .setVersion(1)
+                .setIsLatest(1)
+                .setVersionGroupId(id);
+        this.save(file);
     }
 
     /**
@@ -294,7 +306,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<>();
         // 所有用户（包括管理员）只能查询自己的文件
         // 管理员查看所有文件请使用 FileAdminService.getAllFiles()
-        wrapper.eq(File::getUid, userId);
+        wrapper.eq(File::getUid, userId)
+               .eq(File::getIsLatest, 1);
         return this.list(wrapper);
     }
 
@@ -303,7 +316,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<>();
         // 所有用户（包括管理员）只能查询自己的文件
         // 管理员查看所有文件请使用 FileAdminService.getAllFiles()
-        wrapper.eq(File::getUid, userId);
+        wrapper.eq(File::getUid, userId)
+               .eq(File::getIsLatest, 1);
         this.page(page, wrapper);
     }
 
@@ -1046,5 +1060,67 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
      * 分享访问上下文（包含分享拥有者与可选的数据库记录）
      */
     private record ShareAccessContext(Long ownerId, FileShare fileShare) {
+    }
+
+    @Override
+    @CacheEvict(cacheNames = "userFiles", key = "#userId")
+    public File createNewVersion(Long userId, Long parentFileId, String fileName, long fileSize, String contentType) {
+        // 校验父文件
+        File parentFile = this.getById(parentFileId);
+        if (parentFile == null) {
+            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
+        }
+        if (!parentFile.getUid().equals(userId)) {
+            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED);
+        }
+        if (parentFile.getStatus() != FileUploadStatus.SUCCESS.getCode()) {
+            throw new GeneralException(ResultEnum.VERSION_SOURCE_INVALID);
+        }
+
+        Long versionGroupId = parentFile.getVersionGroupId() != null ? parentFile.getVersionGroupId() : parentFile.getId();
+        String lockKey = "file:version:" + versionGroupId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (!lock.tryLock(5, 30, TimeUnit.SECONDS)) {
+                throw new GeneralException(ResultEnum.VERSION_CONFLICT);
+            }
+            try {
+                // 事务内操作
+                return doCreateNewVersion(userId, parentFile, versionGroupId, fileName, fileSize, contentType);
+            } finally {
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new GeneralException(ResultEnum.VERSION_CONFLICT);
+        }
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    protected File doCreateNewVersion(Long userId, File parentFile, Long versionGroupId,
+                                       String fileName, long fileSize, String contentType) {
+        // 清除版本链中所有文件的 isLatest
+        baseMapper.clearLatestInChain(versionGroupId, parentFile.getTenantId());
+
+        // 创建新版本
+        Long newId = IdUtils.nextEntityId();
+        String fileParam = JsonConverter.toJson(Map.of("fileSize", Math.max(0L, fileSize), "contentType", contentType));
+        File newVersion = new File()
+                .setId(newId)
+                .setUid(userId)
+                .setTenantId(parentFile.getTenantId())
+                .setFileName(fileName)
+                .setFileParam(fileParam)
+                .setStatus(FileUploadStatus.PREPARE.getCode())
+                .setVersion(parentFile.getVersion() + 1)
+                .setParentVersionId(parentFile.getId())
+                .setIsLatest(1)
+                .setVersionGroupId(versionGroupId);
+        this.save(newVersion);
+
+        return newVersion;
     }
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
@@ -306,7 +306,27 @@ public class FileUploadServiceImpl implements FileUploadService {
      * @throws GeneralException IO 操作失败
      */
     @Override
-    public StartUploadVO startUpload(Long userId, String fileName, long fileSize, String contentType, String clientId, int chunkSize, int totalChunks) {
+    public StartUploadVO startUpload(Long userId, String fileName, long fileSize, String contentType,
+                                     String clientId, int chunkSize, int totalChunks) {
+        return startUpload(userId, fileName, fileSize, contentType, clientId, chunkSize, totalChunks, null);
+    }
+
+    /**
+     * 处理开始上传请求（支持绑定目标文件ID）。
+     *
+     * @param userId 用户ID
+     * @param fileName 文件名
+     * @param fileSize 文件大小
+     * @param contentType 文件类型
+     * @param clientId 客户端ID
+     * @param chunkSize 分片大小
+     * @param totalChunks 分片总数
+     * @param targetFileId 目标文件ID（版本上传场景可选）
+     * @return 上传会话信息
+     */
+    @Override
+    public StartUploadVO startUpload(Long userId, String fileName, long fileSize, String contentType,
+                                     String clientId, int chunkSize, int totalChunks, Long targetFileId) {
 
         //获取加密后的uid，防止数据泄漏
         String uidStr = String.valueOf(userId);
@@ -330,6 +350,7 @@ public class FileUploadServiceImpl implements FileUploadService {
         if (!isFileTypeAllowed(fileName, contentType)) {
             throw new GeneralException("不支持的文件类型");
         }
+        validateUploadTargetFile(userId, fileName, fileSize, targetFileId);
 
         boolean hasProvidedClientId = !CommonUtils.isBlank(clientId);
 
@@ -340,6 +361,9 @@ public class FileUploadServiceImpl implements FileUploadService {
                 validateUploadOwnership(userId, existingByClientId, clientId);
                 if (!Objects.equals(existingByClientId.getFileName(), fileName) || existingByClientId.getFileSize() != fileSize) {
                     throw new GeneralException("客户端ID与上传会话不匹配");
+                }
+                if (!isSessionTargetMatched(existingByClientId, targetFileId)) {
+                    throw new GeneralException(ResultEnum.PARAM_ERROR, "客户端ID与上传目标不匹配");
                 }
 
                 log.info("发现可恢复的上传会话(显式 clientId): 客户端ID={}, 文件客户端键={}", clientId, fileClientKey);
@@ -360,15 +384,21 @@ public class FileUploadServiceImpl implements FileUploadService {
                         existingState = null;
                     }
                 }
-                if (existingState != null && existingState.getFileSize() == fileSize) {
+                if (existingState != null && existingState.getFileSize() == fileSize
+                        && isSessionTargetMatched(existingState, targetFileId)) {
                     log.info("发现可恢复的上传会话: 客户端ID={}, 文件客户端键={}", existClientId, fileClientKey);
                     redisStateManager.removePausedSession(existClientId); // 恢复会话（如果之前暂停了）
                     redisStateManager.updateLastActivityTime(existClientId);
                     // 返回恢复成功的 DTO
                     return createResumeDto(existingState);
                 } else {
-                    log.warn("发现旧会话但无法恢复 (状态丢失或文件大小不匹配): 旧客户端ID={}, 文件客户端键={}", existClientId, fileClientKey);
-                    if (existingState != null) {
+                    if (existingState != null && existingState.getFileSize() == fileSize
+                            && !isSessionTargetMatched(existingState, targetFileId)) {
+                        log.info("发现旧会话但目标文件不匹配，跳过恢复: 旧客户端ID={}, 文件客户端键={}", existClientId, fileClientKey);
+                    } else {
+                        log.warn("发现旧会话但无法恢复 (状态丢失或文件大小不匹配): 旧客户端ID={}, 文件客户端键={}", existClientId, fileClientKey);
+                    }
+                    if (existingState != null && existingState.getFileSize() != fileSize) {
                         cleanupUploadSessionInternal(SUID, existClientId); // 主动清理旧状态
                     }
                 }
@@ -386,7 +416,9 @@ public class FileUploadServiceImpl implements FileUploadService {
 
         // --- 创建新会话 ---
         try {
-            FileUploadState newState = new FileUploadState(userId, fileName, fileSize, contentType, clientId, chunkSize, totalChunks);
+            FileUploadState newState = new FileUploadState(
+                    userId, fileName, fileSize, contentType, clientId, chunkSize, totalChunks, targetFileId
+            );
             newState.setTenantId(tenantId);
             redisStateManager.saveNewState(newState, SUID);
 
@@ -403,6 +435,63 @@ public class FileUploadServiceImpl implements FileUploadService {
             // 包装成自定义异常，方便 Controller 统一处理
             throw new GeneralException("创建上传会话失败: " + e.getMessage());
         }
+    }
+
+    /**
+     * 校验版本上传场景中绑定的目标文件是否合法。
+     *
+     * @param userId 用户ID
+     * @param fileName 上传文件名
+     * @param fileSize 上传文件大小
+     * @param targetFileId 目标文件ID
+     */
+    private void validateUploadTargetFile(Long userId, String fileName, long fileSize, Long targetFileId) {
+        if (targetFileId == null) {
+            return;
+        }
+        cn.flying.dao.dto.File targetFile = fileService.getById(targetFileId);
+        if (targetFile == null) {
+            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
+        }
+        if (!Objects.equals(targetFile.getUid(), userId)) {
+            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED);
+        }
+        if (!Objects.equals(targetFile.getStatus(), FileUploadStatus.PREPARE.getCode())) {
+            throw new GeneralException(ResultEnum.VERSION_SOURCE_INVALID, "目标版本状态不允许上传");
+        }
+        if (!Objects.equals(targetFile.getFileName(), fileName)) {
+            throw new GeneralException(ResultEnum.PARAM_ERROR, "上传文件名与目标版本不一致");
+        }
+
+        Long targetFileSize = targetFile.getFileSize();
+        if (targetFileSize != null && targetFileSize > 0 && targetFileSize.longValue() != fileSize) {
+            throw new GeneralException(ResultEnum.PARAM_ERROR, "上传文件大小与目标版本不一致");
+        }
+    }
+
+    /**
+     * 判断上传会话绑定的目标文件是否与当前请求一致。
+     *
+     * @param state 上传会话状态
+     * @param targetFileId 请求中目标文件ID
+     * @return 是否一致
+     */
+    private boolean isSessionTargetMatched(FileUploadState state, Long targetFileId) {
+        return Objects.equals(state.getTargetFileId(), targetFileId);
+    }
+
+    /**
+     * 将上传目标文件回写为失败状态。
+     *
+     * @param userId 用户ID
+     * @param state 上传会话状态
+     */
+    private void markUploadTargetFailed(Long userId, FileUploadState state) {
+        if (state.getTargetFileId() != null) {
+            fileService.changeFileStatusById(userId, state.getTargetFileId(), FileUploadStatus.FAIL.getCode());
+            return;
+        }
+        fileService.changeFileStatusByName(userId, state.getFileName(), FileUploadStatus.FAIL.getCode());
     }
 
     /**
@@ -631,7 +720,7 @@ public class FileUploadServiceImpl implements FileUploadService {
             if (processedFiles == null) {
                 log.error("收集处理后的文件失败，无法继续存证流程: 客户端ID={}, 文件名={}", clientId, state.getFileName());
                 // 更新文件状态为失败
-                fileService.changeFileStatusByName(userId, state.getFileName(), FileUploadStatus.FAIL.getCode());
+                markUploadTargetFailed(userId, state);
                 // 清理Redis状态
                 redisStateManager.removeSession(state.getClientId(), SUID);
                 throw new GeneralException("收集处理后的文件失败，文件存证中止");
@@ -641,7 +730,7 @@ public class FileUploadServiceImpl implements FileUploadService {
             if (fileHashes == null) {
                 log.error("收集文件哈希值失败，无法继续存证流程: 客户端ID={}, 文件名={}", clientId, state.getFileName());
                 // 更新文件状态为失败
-                fileService.changeFileStatusByName(userId, state.getFileName(), FileUploadStatus.FAIL.getCode());
+                markUploadTargetFailed(userId, state);
                 // 清理Redis状态
                 redisStateManager.removeSession(state.getClientId(), SUID);
                 throw new GeneralException("收集文件哈希值失败，文件存证中止");
@@ -652,7 +741,7 @@ public class FileUploadServiceImpl implements FileUploadService {
                 log.error("处理后的文件数量({})与哈希值数量({})不匹配: 客户端ID={}, 文件名={}",
                         processedFiles.size(), fileHashes.size(), clientId, state.getFileName());
                 // 更新文件状态为失败
-                fileService.changeFileStatusByName(userId, state.getFileName(), FileUploadStatus.FAIL.getCode());
+                markUploadTargetFailed(userId, state);
                 // 清理Redis状态
                 redisStateManager.removeSession(state.getClientId(), SUID);
                 throw new GeneralException("文件数量与哈希数量不匹配，文件存证中止");
@@ -667,6 +756,7 @@ public class FileUploadServiceImpl implements FileUploadService {
                         this,
                         state.getTenantId(),
                         userId,
+                        state.getTargetFileId(),
                         state.getFileName(),
                         SUID,
                         state.getClientId(),
@@ -687,7 +777,7 @@ public class FileUploadServiceImpl implements FileUploadService {
             } else {
                 log.error("事件发布器未初始化，无法发送文件存证事件: 客户端ID={}, 文件名={}", clientId, state.getFileName());
                 // 更新文件状态为失败
-                fileService.changeFileStatusByName(userId, state.getFileName(), FileUploadStatus.FAIL.getCode());
+                markUploadTargetFailed(userId, state);
                 // 事件发布器未初始化时也清理Redis状态
                 redisStateManager.removeSession(state.getClientId(), SUID);
                 throw new GeneralException("事件发布器未初始化，文件存证中止");
@@ -739,7 +829,12 @@ public class FileUploadServiceImpl implements FileUploadService {
             }
 
             quotaService.checkUploadQuota(tenantId, userId, latestState.getFileSize());
-            fileService.prepareStoreFile(userId, latestState.getFileName(), latestState.getFileSize());
+            fileService.prepareStoreFile(
+                    userId,
+                    latestState.getTargetFileId(),
+                    latestState.getFileName(),
+                    latestState.getFileSize()
+            );
             latestState.setPrepareStored(true);
             redisStateManager.updateState(latestState);
         } finally {

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
@@ -408,8 +408,8 @@ public class FileUploadServiceImpl implements FileUploadService {
             clientId = UidEncoder.encodeCid(SUID);
         }
 
-        // 仅在创建新上传会话时执行配额检查；恢复会话不重复计入。
-        quotaService.checkUploadQuota(tenantId, userId, fileSize);
+        // 仅在创建新上传会话时执行配额检查；版本续传（绑定 targetFileId）已完成预占位，不重复计费。
+        checkQuotaForNewUploadSession(tenantId, userId, fileSize, targetFileId);
 
         log.info("处理上传开始请求: 文件名={}, 文件大小={}, 内容类型={}, 用户SUID={}, 客户端ID={}",
                 fileName, fileSize, contentType, SUID, clientId);
@@ -488,7 +488,7 @@ public class FileUploadServiceImpl implements FileUploadService {
      */
     private void markUploadTargetFailed(Long userId, FileUploadState state) {
         if (state.getTargetFileId() != null) {
-            fileService.changeFileStatusById(userId, state.getTargetFileId(), FileUploadStatus.FAIL.getCode());
+            fileService.markFileUploadFailed(userId, state.getTargetFileId());
             return;
         }
         fileService.changeFileStatusByName(userId, state.getFileName(), FileUploadStatus.FAIL.getCode());
@@ -828,7 +828,9 @@ public class FileUploadServiceImpl implements FileUploadService {
                 return;
             }
 
-            quotaService.checkUploadQuota(tenantId, userId, latestState.getFileSize());
+            if (shouldCheckQuotaForSession(latestState)) {
+                quotaService.checkUploadQuota(tenantId, userId, latestState.getFileSize());
+            }
             fileService.prepareStoreFile(
                     userId,
                     latestState.getTargetFileId(),
@@ -875,7 +877,9 @@ public class FileUploadServiceImpl implements FileUploadService {
         RLock lock = redissonClient.getLock(lockKey);
         lock.lock(QUOTA_COMPLETE_LOCK_LEASE_SECONDS, TimeUnit.SECONDS);
         try {
-            quotaService.checkUploadQuota(tenantId, userId, state.getFileSize());
+            if (shouldCheckQuotaForSession(state)) {
+                quotaService.checkUploadQuota(tenantId, userId, state.getFileSize());
+            }
         } finally {
             if (lock.isHeldByCurrentThread()) {
                 try {
@@ -885,6 +889,33 @@ public class FileUploadServiceImpl implements FileUploadService {
                 }
             }
         }
+    }
+
+    /**
+     * 对新建上传会话执行配额校验。
+     * 版本续传场景使用既有 PREPARE 记录，不再重复执行增量配额校验。
+     *
+     * @param tenantId 租户ID
+     * @param userId 用户ID
+     * @param fileSize 文件大小
+     * @param targetFileId 目标文件ID（版本续传场景）
+     */
+    private void checkQuotaForNewUploadSession(Long tenantId, Long userId, long fileSize, Long targetFileId) {
+        if (targetFileId != null) {
+            return;
+        }
+        quotaService.checkUploadQuota(tenantId, userId, fileSize);
+    }
+
+    /**
+     * 判断当前会话是否需要执行增量配额校验。
+     * 当会话绑定了目标版本文件时，配额已由既有 PREPARE 记录体现，应跳过重复校验。
+     *
+     * @param state 上传会话状态
+     * @return true 表示需要执行配额校验
+     */
+    private boolean shouldCheckQuotaForSession(FileUploadState state) {
+        return state != null && state.getTargetFileId() == null;
     }
 
     /**

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
@@ -1,13 +1,16 @@
 package cn.flying.service.impl;
 
+import cn.flying.common.constant.FileUploadStatus;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.exception.GeneralException;
+import cn.flying.common.util.IdUtils;
 import cn.flying.common.util.SecurityUtils;
 import cn.flying.dao.dto.Account;
 import cn.flying.dao.dto.File;
 import cn.flying.dao.mapper.AccountMapper;
 import cn.flying.dao.mapper.FileMapper;
 import cn.flying.dao.mapper.FileShareMapper;
+import cn.flying.dao.vo.file.FileVersionVO;
 import cn.flying.service.FriendFileShareService;
 import cn.flying.service.remote.FileRemoteClient;
 import cn.flying.test.builders.AccountTestBuilder;
@@ -555,6 +558,156 @@ class FileQueryServiceTest {
 
                 assertEquals(ResultEnum.FAIL.getCode(), ex.getResultEnum().getCode());
             }
+        }
+    }
+
+    // ================== File Version History Tests ==================
+
+    @Nested
+    @DisplayName("File Version History")
+    class FileVersionHistory {
+
+        @Test
+        @DisplayName("owner should view version history")
+        void ownerShouldViewVersionHistory() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class);
+                 MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                // Given
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                idUtilsMock.when(() -> IdUtils.toExternalId(any())).thenReturn("ext_id");
+
+                Long versionGroupId = 10L;
+                File file = FileTestBuilder.aFile(f -> {
+                    f.setId(FILE_ID);
+                    f.setUid(USER_ID);
+                    f.setTenantId(1L);
+                    f.setVersionGroupId(versionGroupId);
+                    f.setVersion(2);
+                    f.setIsLatest(1);
+                });
+
+                File v1 = FileTestBuilder.aFile(f -> {
+                    f.setId(2L);
+                    f.setUid(USER_ID);
+                    f.setTenantId(1L);
+                    f.setVersionGroupId(versionGroupId);
+                    f.setVersion(1);
+                    f.setIsLatest(0);
+                    f.setFileName("v1.txt");
+                    f.setStatus(FileUploadStatus.SUCCESS.getCode());
+                });
+
+                when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+                when(fileMapper.selectVersionChain(versionGroupId, 1L)).thenReturn(List.of(file, v1));
+
+                // When
+                List<FileVersionVO> result = fileQueryService.getFileVersionHistory(USER_ID, FILE_ID);
+
+                // Then
+                assertNotNull(result);
+                assertEquals(2, result.size());
+                assertEquals(2, result.get(0).version());
+                assertEquals(1, result.get(1).version());
+            }
+        }
+
+        @Test
+        @DisplayName("admin should view any user's version history")
+        void adminShouldViewAnyVersionHistory() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class);
+                 MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                // Given
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(true);
+                idUtilsMock.when(() -> IdUtils.toExternalId(any())).thenReturn("ext_id");
+
+                Long versionGroupId = 10L;
+                File file = FileTestBuilder.aFile(f -> {
+                    f.setId(FILE_ID);
+                    f.setUid(OTHER_USER_ID); // Different user
+                    f.setTenantId(1L);
+                    f.setVersionGroupId(versionGroupId);
+                    f.setVersion(1);
+                    f.setIsLatest(1);
+                });
+
+                when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+                when(fileMapper.selectVersionChain(versionGroupId, 1L)).thenReturn(List.of(file));
+
+                // When
+                List<FileVersionVO> result = fileQueryService.getFileVersionHistory(USER_ID, FILE_ID);
+
+                // Then
+                assertNotNull(result);
+                assertEquals(1, result.size());
+            }
+        }
+
+        @Test
+        @DisplayName("non-owner non-admin should be rejected")
+        void nonOwnerNonAdminShouldBeRejected() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class)) {
+                // Given
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+
+                File file = FileTestBuilder.aFile(f -> {
+                    f.setId(FILE_ID);
+                    f.setUid(OTHER_USER_ID); // Different user
+                    f.setVersionGroupId(10L);
+                });
+
+                when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+
+                // When & Then
+                GeneralException ex = assertThrows(GeneralException.class, () ->
+                        fileQueryService.getFileVersionHistory(USER_ID, FILE_ID));
+
+                assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED.getCode(), ex.getResultEnum().getCode());
+            }
+        }
+
+        @Test
+        @DisplayName("legacy file without versionGroupId should return single entry")
+        void legacyFileShouldReturnSingleEntry() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class);
+                 MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                // Given
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                idUtilsMock.when(() -> IdUtils.toExternalId(any())).thenReturn("ext_id");
+
+                File file = FileTestBuilder.aFile(f -> {
+                    f.setId(FILE_ID);
+                    f.setUid(USER_ID);
+                    f.setVersionGroupId(null); // Legacy file
+                    f.setVersion(null);
+                    f.setIsLatest(null);
+                });
+
+                when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+
+                // When
+                List<FileVersionVO> result = fileQueryService.getFileVersionHistory(USER_ID, FILE_ID);
+
+                // Then
+                assertNotNull(result);
+                assertEquals(1, result.size());
+                assertEquals(1, result.get(0).version()); // Default to 1
+                assertEquals(1, result.get(0).isLatest()); // Default to 1
+                // Should not call selectVersionChain
+                verify(fileMapper, never()).selectVersionChain(any(), any());
+            }
+        }
+
+        @Test
+        @DisplayName("should throw FILE_NOT_EXIST when file not found")
+        void shouldThrowWhenFileNotFound() {
+            // Given
+            when(fileMapper.selectById(999L)).thenReturn(null);
+
+            // When & Then
+            GeneralException ex = assertThrows(GeneralException.class, () ->
+                    fileQueryService.getFileVersionHistory(USER_ID, 999L));
+
+            assertEquals(ResultEnum.FILE_NOT_EXIST.getCode(), ex.getResultEnum().getCode());
         }
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
@@ -1,9 +1,11 @@
 package cn.flying.service.impl;
 
+import cn.flying.common.constant.FileUploadStatus;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.exception.GeneralException;
 import cn.flying.common.lock.DistributedLock;
 import cn.flying.common.util.UidEncoder;
+import cn.flying.dao.dto.File;
 import cn.flying.dao.vo.file.FileUploadState;
 import cn.flying.dao.vo.file.ProgressVO;
 import cn.flying.dao.vo.file.ResumeUploadVO;
@@ -32,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -127,6 +130,38 @@ class FileUploadServiceTest {
             assertTrue(result.getProcessedChunks().isEmpty());
 
             verify(redisStateManager).saveNewState(any(FileUploadState.class), eq(SUID));
+        }
+
+        /**
+         * 验证版本续传（绑定 targetFileId）创建会话时不会重复执行增量配额校验。
+         */
+        @Test
+        @DisplayName("should skip quota check for target version upload session")
+        void shouldSkipQuotaCheckForTargetVersionUploadSession() {
+            String fileName = "version-v2.txt";
+            long fileSize = 2048L;
+            Long targetFileId = 9527L;
+
+            File targetFile = new File()
+                    .setId(targetFileId)
+                    .setUid(USER_ID)
+                    .setStatus(FileUploadStatus.PREPARE.getCode())
+                    .setFileName(fileName)
+                    .setFileParam("{\"fileSize\":2048,\"contentType\":\"text/plain\"}");
+
+            when(redisStateManager.getSessionIdByFileClientKey(anyString(), anyString())).thenReturn(null);
+            when(fileService.getById(targetFileId)).thenReturn(targetFile);
+
+            StartUploadVO result = fileUploadService.startUpload(
+                    USER_ID, fileName, fileSize, "text/plain", null, 256, 8, targetFileId
+            );
+
+            assertNotNull(result);
+            verify(quotaService, never()).checkUploadQuota(anyLong(), anyLong(), anyLong());
+            verify(redisStateManager).saveNewState(
+                    argThat(state -> Objects.equals(state.getTargetFileId(), targetFileId)),
+                    eq(SUID)
+            );
         }
 
         @Test
@@ -530,7 +565,7 @@ class FileUploadServiceTest {
 
             invokeReserveQuotaAndPrepareStoreFile(USER_ID, state);
 
-            verify(quotaService).checkUploadQuota(77L, USER_ID, 4096L);
+            verify(quotaService, never()).checkUploadQuota(anyLong(), anyLong(), anyLong());
             verify(fileService).prepareStoreFile(USER_ID, 9527L, "version-v2.bin", 4096L);
             verify(redisStateManager).updateState(argThat(FileUploadState::isPrepareStored));
             verify(quotaLock).unlock();

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
@@ -469,7 +469,7 @@ class FileUploadServiceTest {
             assertEquals(ResultEnum.QUOTA_EXCEEDED, ex.getResultEnum());
             verify(quotaLock).lock(60L, TimeUnit.SECONDS);
             verify(quotaService).checkUploadQuota(77L, USER_ID, 1024L);
-            verify(fileService, never()).prepareStoreFile(anyLong(), anyString(), anyLong());
+            verify(fileService, never()).prepareStoreFile(anyLong(), any(), anyString(), anyLong());
             verify(quotaLock).unlock();
         }
 
@@ -499,7 +499,39 @@ class FileUploadServiceTest {
             invokeReserveQuotaAndPrepareStoreFile(USER_ID, state);
 
             verify(quotaService).checkUploadQuota(77L, USER_ID, 2048L);
-            verify(fileService).prepareStoreFile(USER_ID, "prepare-once.bin", 2048L);
+            verify(fileService).prepareStoreFile(USER_ID, null, "prepare-once.bin", 2048L);
+            verify(redisStateManager).updateState(argThat(FileUploadState::isPrepareStored));
+            verify(quotaLock).unlock();
+        }
+
+        /**
+         * 验证版本上传场景会将 PREPARE 预占位绑定到目标 fileId。
+         */
+        @Test
+        @DisplayName("should bind prepare reserve to target file id")
+        void shouldBindPrepareReserveToTargetFileId() throws Exception {
+            FileUploadState state = new FileUploadState(
+                    USER_ID,
+                    "version-v2.bin",
+                    4096L,
+                    "application/octet-stream",
+                    "version-client",
+                    256,
+                    0,
+                    9527L
+            );
+            state.setTenantId(77L);
+            state.setPrepareStored(false);
+
+            when(redissonClient.getLock("distributed:lock:upload:quota:complete:tenant:77"))
+                    .thenReturn(quotaLock);
+            when(quotaLock.isHeldByCurrentThread()).thenReturn(true);
+            when(redisStateManager.getState("version-client")).thenReturn(state);
+
+            invokeReserveQuotaAndPrepareStoreFile(USER_ID, state);
+
+            verify(quotaService).checkUploadQuota(77L, USER_ID, 4096L);
+            verify(fileService).prepareStoreFile(USER_ID, 9527L, "version-v2.bin", 4096L);
             verify(redisStateManager).updateState(argThat(FileUploadState::isPrepareStored));
             verify(quotaLock).unlock();
         }
@@ -530,7 +562,7 @@ class FileUploadServiceTest {
             invokeReserveQuotaAndPrepareStoreFile(USER_ID, state);
 
             verify(quotaService, never()).checkUploadQuota(anyLong(), anyLong(), anyLong());
-            verify(fileService, never()).prepareStoreFile(anyLong(), anyString(), anyLong());
+            verify(fileService, never()).prepareStoreFile(anyLong(), any(), anyString(), anyLong());
             verify(redisStateManager, never()).updateState(any(FileUploadState.class));
             verify(quotaLock).unlock();
         }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileVersionServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileVersionServiceTest.java
@@ -22,6 +22,9 @@ import org.mockito.quality.Strictness;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.concurrent.TimeUnit;
 
@@ -46,6 +49,9 @@ class FileVersionServiceTest {
     @Mock
     private RLock rLock;
 
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
     @InjectMocks
     private FileServiceImpl fileService;
 
@@ -63,6 +69,11 @@ class FileVersionServiceTest {
     void setUp() {
         FileTestBuilder.resetIdCounter();
         ReflectionTestUtils.setField(fileService, "baseMapper", fileMapper);
+        lenient().when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            TransactionCallback<File> callback = invocation.getArgument(0);
+            return callback.doInTransaction(mock(TransactionStatus.class));
+        });
     }
 
     @Nested
@@ -183,6 +194,34 @@ class FileVersionServiceTest {
                     fileService.createNewVersion(USER_ID, 1L, "new.txt", 1024, "text/plain"));
 
             assertEquals(ResultEnum.VERSION_CONFLICT.getCode(), ex.getResultEnum().getCode());
+        }
+
+        @Test
+        @DisplayName("should throw VERSION_SOURCE_INVALID when parent is not latest")
+        void shouldThrowWhenParentIsNotLatest() throws Exception {
+            // Given
+            File parentFile = FileTestBuilder.aFile(f -> {
+                f.setId(1L);
+                f.setUid(USER_ID);
+                f.setTenantId(TENANT_ID);
+                f.setVersion(1);
+                f.setVersionGroupId(1L);
+                f.setStatus(FileUploadStatus.SUCCESS.getCode());
+                f.setIsLatest(0);
+            });
+
+            when(fileMapper.selectById(1L)).thenReturn(parentFile);
+            when(redissonClient.getLock(anyString())).thenReturn(rLock);
+            when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+            when(rLock.isHeldByCurrentThread()).thenReturn(true);
+
+            // When & Then
+            GeneralException ex = assertThrows(GeneralException.class, () ->
+                    fileService.createNewVersion(USER_ID, 1L, "new.txt", 1024, "text/plain"));
+
+            assertEquals(ResultEnum.VERSION_SOURCE_INVALID.getCode(), ex.getResultEnum().getCode());
+            verify(fileMapper, never()).clearLatestInChain(anyLong(), anyLong());
+            verify(fileMapper, never()).insert(any(File.class));
         }
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileVersionServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileVersionServiceTest.java
@@ -6,7 +6,6 @@ import cn.flying.common.exception.GeneralException;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.dto.File;
 import cn.flying.dao.mapper.FileMapper;
-import cn.flying.service.saga.FileSagaOrchestrator;
 import cn.flying.test.builders.FileTestBuilder;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
@@ -15,6 +14,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -26,6 +26,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -222,6 +223,70 @@ class FileVersionServiceTest {
             assertEquals(ResultEnum.VERSION_SOURCE_INVALID.getCode(), ex.getResultEnum().getCode());
             verify(fileMapper, never()).clearLatestInChain(anyLong(), anyLong());
             verify(fileMapper, never()).insert(any(File.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Mark Upload Failed")
+    class MarkUploadFailed {
+
+        /**
+         * 验证版本上传失败时，会将失败版本降级并恢复父版本为 latest。
+         */
+        @Test
+        @DisplayName("should restore parent as latest when version upload fails")
+        void shouldRestoreParentAsLatestWhenVersionUploadFails() {
+            File failedVersion = FileTestBuilder.aFile(f -> {
+                f.setId(10L);
+                f.setUid(USER_ID);
+                f.setStatus(FileUploadStatus.PREPARE.getCode());
+                f.setIsLatest(1);
+                f.setParentVersionId(9L);
+            });
+            File parentVersion = FileTestBuilder.aFile(f -> {
+                f.setId(9L);
+                f.setUid(USER_ID);
+                f.setStatus(FileUploadStatus.SUCCESS.getCode());
+                f.setIsLatest(0);
+            });
+
+            when(fileMapper.selectById(10L)).thenReturn(failedVersion);
+            when(fileMapper.selectById(9L)).thenReturn(parentVersion);
+            when(fileMapper.update(any(File.class), any())).thenReturn(1);
+
+            fileService.markFileUploadFailed(USER_ID, 10L);
+
+            ArgumentCaptor<File> updateCaptor = ArgumentCaptor.forClass(File.class);
+            verify(fileMapper, times(2)).update(updateCaptor.capture(), any());
+
+            List<File> updates = updateCaptor.getAllValues();
+            File failedUpdate = updates.get(0);
+            File parentUpdate = updates.get(1);
+            assertEquals(FileUploadStatus.FAIL.getCode(), failedUpdate.getStatus());
+            assertEquals(0, failedUpdate.getIsLatest());
+            assertNull(parentUpdate.getStatus());
+            assertEquals(1, parentUpdate.getIsLatest());
+        }
+
+        /**
+         * 验证普通文件失败仅更新状态，不触发父版本 latest 恢复。
+         */
+        @Test
+        @DisplayName("should only set fail status for non-version file")
+        void shouldOnlySetFailStatusForNonVersionFile() {
+            File normalFile = FileTestBuilder.aFile(f -> {
+                f.setId(20L);
+                f.setUid(USER_ID);
+                f.setParentVersionId(null);
+                f.setIsLatest(1);
+            });
+            when(fileMapper.selectById(20L)).thenReturn(normalFile);
+            when(fileMapper.update(any(File.class), any())).thenReturn(1);
+
+            fileService.markFileUploadFailed(USER_ID, 20L);
+
+            verify(fileMapper, times(1)).update(any(File.class), any());
+            verify(fileMapper, times(1)).selectById(20L);
         }
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileVersionServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileVersionServiceTest.java
@@ -1,0 +1,188 @@
+package cn.flying.service.impl;
+
+import cn.flying.common.constant.FileUploadStatus;
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.common.util.IdUtils;
+import cn.flying.dao.dto.File;
+import cn.flying.dao.mapper.FileMapper;
+import cn.flying.service.saga.FileSagaOrchestrator;
+import cn.flying.test.builders.FileTestBuilder;
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for file version chain feature in FileServiceImpl.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("File Version Service Tests")
+class FileVersionServiceTest {
+
+    @Mock
+    private FileMapper fileMapper;
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock rLock;
+
+    @InjectMocks
+    private FileServiceImpl fileService;
+
+    private static final Long USER_ID = 100L;
+    private static final Long TENANT_ID = 1L;
+
+    @BeforeAll
+    static void initTableInfo() {
+        MybatisConfiguration configuration = new MybatisConfiguration();
+        MapperBuilderAssistant assistant = new MapperBuilderAssistant(configuration, "");
+        TableInfoHelper.initTableInfo(assistant, File.class);
+    }
+
+    @BeforeEach
+    void setUp() {
+        FileTestBuilder.resetIdCounter();
+        ReflectionTestUtils.setField(fileService, "baseMapper", fileMapper);
+    }
+
+    @Nested
+    @DisplayName("Create New Version")
+    class CreateNewVersion {
+
+        @Test
+        @DisplayName("should create new version successfully")
+        void shouldCreateNewVersionSuccessfully() throws Exception {
+            try (MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                // Given
+                File parentFile = FileTestBuilder.aFile(f -> {
+                    f.setId(1L);
+                    f.setUid(USER_ID);
+                    f.setTenantId(TENANT_ID);
+                    f.setVersion(1);
+                    f.setVersionGroupId(1L);
+                    f.setStatus(FileUploadStatus.SUCCESS.getCode());
+                });
+
+                idUtilsMock.when(IdUtils::nextEntityId).thenReturn(100L);
+
+                when(fileMapper.selectById(1L)).thenReturn(parentFile);
+                when(redissonClient.getLock(anyString())).thenReturn(rLock);
+                when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(true);
+                when(rLock.isHeldByCurrentThread()).thenReturn(true);
+                when(fileMapper.clearLatestInChain(1L, TENANT_ID)).thenReturn(1);
+                when(fileMapper.insert(any(File.class))).thenReturn(1);
+
+                // When
+                File result = fileService.createNewVersion(USER_ID, 1L, "new_version.txt", 2048, "text/plain");
+
+                // Then
+                assertNotNull(result);
+                assertEquals(2, result.getVersion());
+                assertEquals(1L, result.getParentVersionId());
+                assertEquals(1, result.getIsLatest());
+                assertEquals(1L, result.getVersionGroupId());
+                assertEquals(FileUploadStatus.PREPARE.getCode(), result.getStatus());
+                assertEquals("new_version.txt", result.getFileName());
+
+                // Verify clearLatestInChain was called
+                verify(fileMapper).clearLatestInChain(1L, TENANT_ID);
+                // Verify lock was acquired and released
+                verify(rLock).tryLock(5, 30, TimeUnit.SECONDS);
+                verify(rLock).unlock();
+            }
+        }
+
+        @Test
+        @DisplayName("should throw FILE_NOT_EXIST when parent file not found")
+        void shouldThrowWhenParentNotFound() {
+            // Given
+            when(fileMapper.selectById(999L)).thenReturn(null);
+
+            // When & Then
+            GeneralException ex = assertThrows(GeneralException.class, () ->
+                    fileService.createNewVersion(USER_ID, 999L, "new.txt", 1024, "text/plain"));
+
+            assertEquals(ResultEnum.FILE_NOT_EXIST.getCode(), ex.getResultEnum().getCode());
+        }
+
+        @Test
+        @DisplayName("should throw PERMISSION_UNAUTHORIZED when not owner")
+        void shouldThrowWhenNotOwner() {
+            // Given
+            File parentFile = FileTestBuilder.aFile(f -> {
+                f.setId(1L);
+                f.setUid(200L); // Different user
+                f.setStatus(FileUploadStatus.SUCCESS.getCode());
+            });
+            when(fileMapper.selectById(1L)).thenReturn(parentFile);
+
+            // When & Then
+            GeneralException ex = assertThrows(GeneralException.class, () ->
+                    fileService.createNewVersion(USER_ID, 1L, "new.txt", 1024, "text/plain"));
+
+            assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED.getCode(), ex.getResultEnum().getCode());
+        }
+
+        @Test
+        @DisplayName("should throw VERSION_SOURCE_INVALID when parent not SUCCESS")
+        void shouldThrowWhenParentNotSuccess() {
+            // Given
+            File parentFile = FileTestBuilder.aFile(f -> {
+                f.setId(1L);
+                f.setUid(USER_ID);
+                f.setStatus(FileUploadStatus.PREPARE.getCode());
+            });
+            when(fileMapper.selectById(1L)).thenReturn(parentFile);
+
+            // When & Then
+            GeneralException ex = assertThrows(GeneralException.class, () ->
+                    fileService.createNewVersion(USER_ID, 1L, "new.txt", 1024, "text/plain"));
+
+            assertEquals(ResultEnum.VERSION_SOURCE_INVALID.getCode(), ex.getResultEnum().getCode());
+        }
+
+        @Test
+        @DisplayName("should throw VERSION_CONFLICT when lock not acquired")
+        void shouldThrowWhenLockNotAcquired() throws Exception {
+            // Given
+            File parentFile = FileTestBuilder.aFile(f -> {
+                f.setId(1L);
+                f.setUid(USER_ID);
+                f.setTenantId(TENANT_ID);
+                f.setVersion(1);
+                f.setVersionGroupId(1L);
+                f.setStatus(FileUploadStatus.SUCCESS.getCode());
+            });
+
+            when(fileMapper.selectById(1L)).thenReturn(parentFile);
+            when(redissonClient.getLock(anyString())).thenReturn(rLock);
+            when(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+            // When & Then
+            GeneralException ex = assertThrows(GeneralException.class, () ->
+                    fileService.createNewVersion(USER_ID, 1L, "new.txt", 1024, "text/plain"));
+
+            assertEquals(ResultEnum.VERSION_CONFLICT.getCode(), ex.getResultEnum().getCode());
+        }
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/test/builders/FileTestBuilder.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/test/builders/FileTestBuilder.java
@@ -16,13 +16,17 @@ public class FileTestBuilder {
     private static final AtomicLong idCounter = new AtomicLong(1L);
 
     public static File aFile() {
+        long id = idCounter.getAndIncrement();
         return new File()
-                .setId(idCounter.getAndIncrement())
+                .setId(id)
                 .setUid(100L)
                 .setFileName("test_file.txt")
                 .setFileHash("sha256_" + System.nanoTime())
                 .setFileParam("{\"fileSize\":1024,\"contentType\":\"text/plain\",\"initialKey\":\"dGVzdGtleQ==\"}")
                 .setStatus(FileUploadStatus.SUCCESS.getCode())
+                .setVersion(1)
+                .setIsLatest(1)
+                .setVersionGroupId(id)
                 .setCreateTime(new Date());
     }
 
@@ -50,6 +54,24 @@ public class FileTestBuilder {
 
     public static File aFileWithName(String name) {
         return aFile(f -> f.setFileName(name));
+    }
+
+    public static File aVersionedFile(Long versionGroupId, int version, int isLatest) {
+        return aFile(f -> f
+                .setVersionGroupId(versionGroupId)
+                .setVersion(version)
+                .setIsLatest(isLatest));
+    }
+
+    public static File aNewVersion(File parent) {
+        return aFile(f -> f
+                .setUid(parent.getUid())
+                .setTenantId(parent.getTenantId())
+                .setVersionGroupId(parent.getVersionGroupId())
+                .setVersion(parent.getVersion() + 1)
+                .setParentVersionId(parent.getId())
+                .setIsLatest(1)
+                .setStatus(FileUploadStatus.PREPARE.getCode()));
     }
 
     public static void resetIdCounter() {

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/FileController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/FileController.java
@@ -5,8 +5,10 @@ import cn.flying.common.constant.Result;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.dto.File;
+import cn.flying.dao.vo.file.CreateVersionVO;
 import cn.flying.dao.vo.file.FileProvenanceVO;
 import cn.flying.dao.vo.file.FileShareVO;
+import cn.flying.dao.vo.file.FileVersionVO;
 import cn.flying.dao.vo.file.ShareAccessLogVO;
 import cn.flying.dao.vo.file.ShareAccessStatsVO;
 import cn.flying.dao.vo.file.UserFileStatsVO;
@@ -20,17 +22,21 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * 文件操作相关接口。
@@ -208,5 +214,49 @@ public class FileController {
         Long fileId = IdUtils.fromExternalId(id);
         FileProvenanceVO provenance = shareAuditService.getFileProvenance(fileId);
         return Result.success(provenance);
+    }
+
+    /**
+     * 获取文件版本历史。
+     *
+     * @param userId 用户 ID
+     * @param id     文件外部 ID（版本链中任意一个文件）
+     * @return 版本历史列表
+     */
+    @GetMapping("/{id}/versions")
+    @Operation(summary = "获取文件版本历史")
+    @OperationLog(module = "文件操作", operationType = "查询", description = "获取文件版本历史")
+    public Result<List<FileVersionVO>> getFileVersionHistory(
+            @RequestAttribute(Const.ATTR_USER_ID) Long userId,
+            @Parameter(description = "文件ID") @PathVariable String id) {
+        Long fileId = IdUtils.fromExternalId(id);
+        List<FileVersionVO> versions = fileQueryService.getFileVersionHistory(userId, fileId);
+        return Result.success(versions);
+    }
+
+    /**
+     * 创建文件新版本。
+     * 返回 PREPARE 状态的新文件，客户端拿 fileId 走现有上传流程。
+     *
+     * @param userId 用户 ID
+     * @param id     父版本文件外部 ID
+     * @param vo     创建参数
+     * @return 新版本信息（fileId、version、versionGroupId 均为外部 ID）
+     */
+    @PostMapping("/{id}/versions")
+    @Operation(summary = "创建文件新版本")
+    @OperationLog(module = "文件操作", operationType = "新增", description = "创建文件新版本")
+    public Result<Map<String, Object>> createNewVersion(
+            @RequestAttribute(Const.ATTR_USER_ID) Long userId,
+            @Parameter(description = "父版本文件ID") @PathVariable String id,
+            @Valid @RequestBody CreateVersionVO vo) {
+        Long parentFileId = IdUtils.fromExternalId(id);
+        File newVersion = fileService.createNewVersion(userId, parentFileId, vo.fileName(), vo.fileSize(), vo.contentType());
+        Map<String, Object> result = Map.of(
+                "fileId", IdUtils.toExternalId(newVersion.getId()),
+                "version", newVersion.getVersion(),
+                "versionGroupId", IdUtils.toExternalId(newVersion.getVersionGroupId())
+        );
+        return Result.success(result);
     }
 }

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/UploadSessionController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/UploadSessionController.java
@@ -4,6 +4,7 @@ import cn.flying.common.annotation.OperationLog;
 import cn.flying.common.util.CommonUtils;
 import cn.flying.common.constant.Result;
 import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.vo.file.FileUploadStatusVO;
@@ -72,7 +73,13 @@ public class UploadSessionController {
             @Schema(description = "分片大小") @RequestParam(value = "chunkSize") @Min(1) @Max(83886080) int chunkSize,
             @Schema(description = "分片总数") @RequestParam(value = "totalChunks") @Min(1) @Max(10000) int totalChunks,
             @Schema(description = "目标文件ID（可选）") @RequestParam(value = "fileId", required = false) String fileId) {
-        Long targetFileId = CommonUtils.isNotEmpty(fileId) ? IdUtils.fromExternalId(fileId) : null;
+        Long targetFileId = null;
+        if (CommonUtils.isNotEmpty(fileId)) {
+            targetFileId = IdUtils.fromExternalId(fileId);
+            if (targetFileId == null) {
+                throw new GeneralException(ResultEnum.PARAM_ERROR, "fileId 无效");
+            }
+        }
         StartUploadVO uploadVO = fileUploadService.startUpload(
                 userId, fileName, fileSize, contentType, providedClientId, chunkSize, totalChunks, targetFileId
         );

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/UploadSessionController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/UploadSessionController.java
@@ -1,9 +1,11 @@
 package cn.flying.controller;
 
 import cn.flying.common.annotation.OperationLog;
+import cn.flying.common.util.CommonUtils;
 import cn.flying.common.constant.Result;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.util.Const;
+import cn.flying.common.util.IdUtils;
 import cn.flying.dao.vo.file.FileUploadStatusVO;
 import cn.flying.dao.vo.file.ProgressVO;
 import cn.flying.dao.vo.file.ResumeUploadVO;
@@ -52,6 +54,7 @@ public class UploadSessionController {
      * @param providedClientId 客户端会话 ID
      * @param chunkSize        分片大小
      * @param totalChunks      分片总数
+     * @param fileId           目标文件ID（版本上传场景可选）
      * @return 上传会话信息
      */
     @PostMapping("")
@@ -67,9 +70,11 @@ public class UploadSessionController {
             @Schema(description = "客户端ID") @RequestParam(value = "clientId", required = false)
             @Pattern(regexp = "^[A-Za-z0-9-]{1,64}$", message = "clientId 格式无效") String providedClientId,
             @Schema(description = "分片大小") @RequestParam(value = "chunkSize") @Min(1) @Max(83886080) int chunkSize,
-            @Schema(description = "分片总数") @RequestParam(value = "totalChunks") @Min(1) @Max(10000) int totalChunks) {
+            @Schema(description = "分片总数") @RequestParam(value = "totalChunks") @Min(1) @Max(10000) int totalChunks,
+            @Schema(description = "目标文件ID（可选）") @RequestParam(value = "fileId", required = false) String fileId) {
+        Long targetFileId = CommonUtils.isNotEmpty(fileId) ? IdUtils.fromExternalId(fileId) : null;
         StartUploadVO uploadVO = fileUploadService.startUpload(
-                userId, fileName, fileSize, contentType, providedClientId, chunkSize, totalChunks
+                userId, fileName, fileSize, contentType, providedClientId, chunkSize, totalChunks, targetFileId
         );
         return Result.success(uploadVO);
     }
@@ -185,4 +190,3 @@ public class UploadSessionController {
         return Result.success(fileUploadService.getUploadProgress(userId, clientId));
     }
 }
-

--- a/platform-backend/backend-web/src/main/java/cn/flying/listener/FileStorageEventListener.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/listener/FileStorageEventListener.java
@@ -67,6 +67,7 @@ public class FileStorageEventListener {
             try {
                 File storedFile = fileService.storeFile(
                         event.getUid(),
+                        event.getFileId(),
                         event.getFileName(),
                         event.getProcessedFiles(),
                         event.getFileHashes(),
@@ -103,12 +104,21 @@ public class FileStorageEventListener {
      * @param reason 失败原因
      */
     private void handleStorageFailure(FileStorageEvent event, String reason) {
-        fileService.changeFileStatusByName(event.getUid(), event.getFileName(), FileUploadStatus.FAIL.getCode());
+        if (event.getFileId() != null) {
+            fileService.changeFileStatusById(event.getUid(), event.getFileId(), FileUploadStatus.FAIL.getCode());
+        } else {
+            fileService.changeFileStatusByName(event.getUid(), event.getFileName(), FileUploadStatus.FAIL.getCode());
+        }
 
         // 存证失败时清理Redis上传状态
         try {
-            redisStateManager.removeSessionByFileName(event.getUid(), event.getFileName());
-            log.info("存证失败，已清理Redis状态: 用户={}, 文件名={}", event.getUid(), event.getFileName());
+            if (CommonUtils.isNotEmpty(event.getClientId()) && CommonUtils.isNotEmpty(event.getSessionId())) {
+                redisStateManager.removeSession(event.getClientId(), event.getSessionId());
+            } else {
+                redisStateManager.removeSessionByFileName(event.getUid(), event.getFileName());
+            }
+            log.info("存证失败，已清理Redis状态: 用户={}, 文件名={}, fileId={}",
+                    event.getUid(), event.getFileName(), event.getFileId());
         } catch (Exception cleanupEx) {
             log.warn("存证失败时清理Redis状态异常: 用户={}, 文件名={}",
                     event.getUid(), event.getFileName(), cleanupEx);

--- a/platform-backend/backend-web/src/main/java/cn/flying/listener/FileStorageEventListener.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/listener/FileStorageEventListener.java
@@ -105,7 +105,7 @@ public class FileStorageEventListener {
      */
     private void handleStorageFailure(FileStorageEvent event, String reason) {
         if (event.getFileId() != null) {
-            fileService.changeFileStatusById(event.getUid(), event.getFileId(), FileUploadStatus.FAIL.getCode());
+            fileService.markFileUploadFailed(event.getUid(), event.getFileId());
         } else {
             fileService.changeFileStatusByName(event.getUid(), event.getFileName(), FileUploadStatus.FAIL.getCode());
         }

--- a/platform-backend/backend-web/src/main/resources/db/migration/V1.4.0__file_version_chain.sql
+++ b/platform-backend/backend-web/src/main/resources/db/migration/V1.4.0__file_version_chain.sql
@@ -1,0 +1,23 @@
+-- 文件版本链支持
+-- 为 file 表新增版本链字段，支持同一业务文件的版本演进关系
+
+ALTER TABLE `file`
+  ADD COLUMN `version` INT NOT NULL DEFAULT 1 COMMENT '版本号，从 1 开始',
+  ADD COLUMN `parent_version_id` BIGINT NULL COMMENT '上一版本文件ID',
+  ADD COLUMN `is_latest` TINYINT(1) NOT NULL DEFAULT 1 COMMENT '是否最新版本：1=是，0=否',
+  ADD COLUMN `version_group_id` BIGINT NULL COMMENT '版本链分组ID';
+
+-- 回填历史数据：每条现有记录自成独立的 v1
+UPDATE `file` SET `version_group_id` = `id` WHERE `version_group_id` IS NULL;
+
+-- 版本链查询索引（按 tenant + group 查版本链，version DESC 取最新）
+ALTER TABLE `file`
+  ADD INDEX `idx_file_version_chain` (`tenant_id`, `version_group_id`, `version` DESC);
+
+-- 文件列表默认过滤 is_latest=1 的覆盖索引
+ALTER TABLE `file`
+  ADD INDEX `idx_file_latest_list` (`tenant_id`, `is_latest`, `deleted`, `create_time` DESC);
+
+-- parent_version_id 查询索引
+ALTER TABLE `file`
+  ADD INDEX `idx_file_parent_version` (`parent_version_id`);

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/ControllerCoverageBoostTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/ControllerCoverageBoostTest.java
@@ -95,6 +95,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -411,7 +412,7 @@ class ControllerCoverageBoostTest {
         assertEquals(7, ticketController.getUnreadCount(1L).getData().get("count"));
 
         StartUploadVO startUploadVO = new StartUploadVO("client-1", 1024, 4, false, List.of(1), List.of(1), false);
-        when(fileUploadService.startUpload(eq(1L), eq("file.txt"), eq(2048L), eq("text/plain"), eq("client-1"), eq(1024), eq(4)))
+        when(fileUploadService.startUpload(eq(1L), eq("file.txt"), eq(2048L), eq("text/plain"), eq("client-1"), eq(1024), eq(4), isNull()))
                 .thenReturn(startUploadVO);
         assertEquals(ResultEnum.SUCCESS.getCode(), uploadSessionController.createUploadSession(
                 1L,
@@ -420,7 +421,8 @@ class ControllerCoverageBoostTest {
                 "text/plain",
                 "client-1",
                 1024,
-                4
+                4,
+                null
         ).getCode());
 
         MockMultipartFile chunk = new MockMultipartFile("file", "chunk.bin", "application/octet-stream", "abc".getBytes());

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/UploadSessionControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/UploadSessionControllerTest.java
@@ -2,6 +2,9 @@ package cn.flying.controller;
 
 import cn.flying.common.constant.Result;
 import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.common.util.SecureIdCodec;
+import cn.flying.common.util.IdUtils;
 import cn.flying.dao.vo.file.FileUploadStatusVO;
 import cn.flying.dao.vo.file.ProgressVO;
 import cn.flying.dao.vo.file.ResumeUploadVO;
@@ -19,8 +22,10 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -99,5 +104,29 @@ class UploadSessionControllerTest {
         when(fileUploadService.cancelUpload(30L, "client-x")).thenReturn(false);
         Result<String> result = controller.cancelUpload(30L, "client-x");
         assertEquals(ResultEnum.RESULT_DATA_NONE.getCode(), result.getCode());
+    }
+
+    /**
+     * 验证提供非法 fileId 时会直接返回参数错误，而不是退化为普通上传。
+     */
+    @Test
+    void shouldRejectInvalidExternalFileId() {
+        SecureIdCodec codec = mock(SecureIdCodec.class);
+        ReflectionTestUtils.setField(IdUtils.class, "secureIdCodec", codec);
+        when(codec.fromExternalId("invalid_external_id")).thenReturn(null);
+
+        GeneralException ex = assertThrows(GeneralException.class, () ->
+                controller.createUploadSession(
+                        20L,
+                        "a.txt",
+                        100L,
+                        "text/plain",
+                        null,
+                        1024,
+                        2,
+                        "invalid_external_id"
+                ));
+
+        assertEquals(ResultEnum.PARAM_ERROR.getCode(), ex.getResultEnum().getCode());
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/UploadSessionControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/UploadSessionControllerTest.java
@@ -57,13 +57,13 @@ class UploadSessionControllerTest {
         FileUploadStatusVO statusVO = new FileUploadStatusVO("f", 100L, clientId, false, "UPLOADING", 50, List.of(1), 1, 2);
         ProgressVO progressVO = new ProgressVO(50, 50, 0, 1, 0, 2, clientId, "uploading");
 
-        when(fileUploadService.startUpload(userId, "a.txt", 100L, "text/plain", null, 1024, 2)).thenReturn(startUploadVO);
+        when(fileUploadService.startUpload(userId, "a.txt", 100L, "text/plain", null, 1024, 2, null)).thenReturn(startUploadVO);
         when(fileUploadService.resumeUpload(userId, clientId)).thenReturn(resumeUploadVO);
         when(fileUploadService.checkFileStatus(userId, clientId)).thenReturn(statusVO);
         when(fileUploadService.getUploadProgress(userId, clientId)).thenReturn(progressVO);
         when(fileUploadService.cancelUpload(userId, clientId)).thenReturn(true);
 
-        Result<StartUploadVO> startResult = controller.createUploadSession(userId, "a.txt", 100L, "text/plain", null, 1024, 2);
+        Result<StartUploadVO> startResult = controller.createUploadSession(userId, "a.txt", 100L, "text/plain", null, 1024, 2, null);
         Result<String> uploadResult = controller.uploadChunk(
                 userId,
                 clientId,

--- a/platform-backend/backend-web/src/test/java/cn/flying/listener/FileStorageEventListenerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/listener/FileStorageEventListenerTest.java
@@ -82,6 +82,7 @@ class FileStorageEventListenerTest {
         assertThat(eventCaptor.getValue().getType()).isEqualTo("file-record-success");
         verify(fileService, never()).changeFileStatusByName(anyLong(), anyString(), anyInt());
         verify(fileService, never()).changeFileStatusById(anyLong(), anyLong(), anyInt());
+        verify(fileService, never()).markFileUploadFailed(anyLong(), anyLong());
         verify(redisStateManager, never()).removeSession(anyString(), anyString());
         verify(redisStateManager, never()).removeSessionByFileName(anyLong(), anyString());
     }
@@ -94,11 +95,8 @@ class FileStorageEventListenerTest {
 
         listener.handleFileStorageEvent(buildEvent());
 
-        verify(fileService, times(1)).changeFileStatusById(
-                100L,
-                9527L,
-                FileUploadStatus.FAIL.getCode()
-        );
+        verify(fileService, times(1)).markFileUploadFailed(100L, 9527L);
+        verify(fileService, never()).changeFileStatusById(anyLong(), anyLong(), eq(FileUploadStatus.FAIL.getCode()));
         verify(redisStateManager, times(1)).removeSession("client-1", "session-1");
         verify(redisStateManager, never()).removeSessionByFileName(anyLong(), anyString());
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/listener/FileStorageEventListenerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/listener/FileStorageEventListenerTest.java
@@ -58,6 +58,7 @@ class FileStorageEventListenerTest {
                 this,
                 1L,
                 100L,
+                9527L,
                 "contract.pdf",
                 "session-1",
                 "client-1",
@@ -72,7 +73,7 @@ class FileStorageEventListenerTest {
     void successPathShouldSendFileRecordSuccessEvent() {
         File storedFile = new File();
         storedFile.setFileHash("hash-1");
-        when(fileService.storeFile(anyLong(), anyString(), anyList(), anyList(), anyString())).thenReturn(storedFile);
+        when(fileService.storeFile(anyLong(), any(Long.class), anyString(), anyList(), anyList(), anyString())).thenReturn(storedFile);
 
         listener.handleFileStorageEvent(buildEvent());
 
@@ -80,23 +81,26 @@ class FileStorageEventListenerTest {
         verify(sseEmitterManager, times(1)).sendToUser(eq(1L), eq(100L), eventCaptor.capture());
         assertThat(eventCaptor.getValue().getType()).isEqualTo("file-record-success");
         verify(fileService, never()).changeFileStatusByName(anyLong(), anyString(), anyInt());
+        verify(fileService, never()).changeFileStatusById(anyLong(), anyLong(), anyInt());
+        verify(redisStateManager, never()).removeSession(anyString(), anyString());
         verify(redisStateManager, never()).removeSessionByFileName(anyLong(), anyString());
     }
 
     @Test
     @DisplayName("failure path should send file-record-failed and keep cleanup behavior")
     void failurePathShouldSendFileRecordFailedAndKeepCleanupBehavior() {
-        when(fileService.storeFile(anyLong(), anyString(), anyList(), anyList(), anyString()))
+        when(fileService.storeFile(anyLong(), any(Long.class), anyString(), anyList(), anyList(), anyString()))
                 .thenThrow(new RuntimeException("chain write failed"));
 
         listener.handleFileStorageEvent(buildEvent());
 
-        verify(fileService, times(1)).changeFileStatusByName(
+        verify(fileService, times(1)).changeFileStatusById(
                 100L,
-                "contract.pdf",
+                9527L,
                 FileUploadStatus.FAIL.getCode()
         );
-        verify(redisStateManager, times(1)).removeSessionByFileName(100L, "contract.pdf");
+        verify(redisStateManager, times(1)).removeSession("client-1", "session-1");
+        verify(redisStateManager, never()).removeSessionByFileName(anyLong(), anyString());
 
         ArgumentCaptor<SseEvent> eventCaptor = ArgumentCaptor.forClass(SseEvent.class);
         verify(sseEmitterManager, times(1)).sendToUser(eq(1L), eq(100L), eventCaptor.capture());

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/controller/FileVersionIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/controller/FileVersionIntegrationTest.java
@@ -1,5 +1,6 @@
 package cn.flying.test.controller;
 
+import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.dto.File;
 import cn.flying.dao.mapper.FileMapper;
@@ -130,6 +131,8 @@ class FileVersionIntegrationTest extends BaseControllerIntegrationTest {
                     .andReturn();
 
             // Verify is_latest was flipped in DB
+            // MockMvc request clears TenantContext via TenantFilter; restore it for direct mapper calls
+            TenantContext.setTenantId(testTenantId);
             File reloadedV1 = fileMapper.selectById(v1.getId());
             org.junit.jupiter.api.Assertions.assertEquals(0, reloadedV1.getIsLatest());
         }

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/controller/FileVersionIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/controller/FileVersionIntegrationTest.java
@@ -117,7 +117,7 @@ class FileVersionIntegrationTest extends BaseControllerIntegrationTest {
                     {"fileName":"v2.txt","fileSize":2048,"contentType":"text/plain"}
                     """;
 
-            MvcResult result = mockMvc.perform(withAuth(
+            mockMvc.perform(withAuth(
                     org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                             .post(API_PREFIX + "/{id}/versions", externalId))
                     .contentType(MediaType.APPLICATION_JSON)

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/controller/FileVersionIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/controller/FileVersionIntegrationTest.java
@@ -1,0 +1,182 @@
+package cn.flying.test.controller;
+
+import cn.flying.common.util.IdUtils;
+import cn.flying.dao.dto.File;
+import cn.flying.dao.mapper.FileMapper;
+import cn.flying.test.support.BaseControllerIntegrationTest;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("File Version Integration Tests")
+@Transactional
+class FileVersionIntegrationTest extends BaseControllerIntegrationTest {
+
+    @Autowired
+    private FileMapper fileMapper;
+
+    private static final String API_PREFIX = "/api/v1/files";
+
+    private File createAndInsertFile(Long userId, Long tenantId, Long versionGroupId,
+                                      int version, int isLatest, Long parentVersionId) {
+        File file = new File();
+        file.setId(IdUtils.nextEntityId());
+        file.setUid(userId);
+        file.setTenantId(tenantId);
+        file.setFileName("version_" + version + "_" + UUID.randomUUID() + ".txt");
+        file.setFileHash("sha256-" + UUID.randomUUID().toString().replace("-", ""));
+        file.setFileParam("{\"fileSize\":1024,\"contentType\":\"text/plain\",\"initialKey\":\"dGVzdA==\"}");
+        file.setClassification("document");
+        file.setStatus(1); // SUCCESS
+        file.setDeleted(0);
+        file.setVersion(version);
+        file.setIsLatest(isLatest);
+        file.setVersionGroupId(versionGroupId);
+        file.setParentVersionId(parentVersionId);
+        file.setCreateTime(new Date());
+        fileMapper.insert(file);
+        return file;
+    }
+
+    @Nested
+    @DisplayName("GET /{id}/versions")
+    class GetVersionHistory {
+
+        @Test
+        @DisplayName("should return complete version chain with 3 versions")
+        void shouldReturnCompleteVersionChain() throws Exception {
+            Long versionGroupId = IdUtils.nextEntityId();
+
+            File v1 = createAndInsertFile(testUserId, testTenantId, versionGroupId, 1, 0, null);
+            File v2 = createAndInsertFile(testUserId, testTenantId, versionGroupId, 2, 0, v1.getId());
+            File v3 = createAndInsertFile(testUserId, testTenantId, versionGroupId, 3, 1, v2.getId());
+
+            String externalId = IdUtils.toExternalId(v3.getId());
+
+            expectOk(performGet(API_PREFIX + "/{id}/versions", externalId))
+                    .andExpect(jsonPath("$.data", hasSize(3)))
+                    .andExpect(jsonPath("$.data[0].version", is(3)))
+                    .andExpect(jsonPath("$.data[1].version", is(2)))
+                    .andExpect(jsonPath("$.data[2].version", is(1)));
+        }
+
+        @Test
+        @DisplayName("should return single entry for single-version file")
+        void shouldReturnSingleEntryForSingleVersionFile() throws Exception {
+            Long versionGroupId = IdUtils.nextEntityId();
+            File file = createAndInsertFile(testUserId, testTenantId, versionGroupId, 1, 1, null);
+
+            String externalId = IdUtils.toExternalId(file.getId());
+
+            expectOk(performGet(API_PREFIX + "/{id}/versions", externalId))
+                    .andExpect(jsonPath("$.data", hasSize(1)))
+                    .andExpect(jsonPath("$.data[0].version", is(1)))
+                    .andExpect(jsonPath("$.data[0].isLatest", is(1)));
+        }
+
+        @Test
+        @DisplayName("should reject access to other user's file versions")
+        void shouldRejectOtherUserFile() throws Exception {
+            Long otherUserId = 999L;
+            Long versionGroupId = IdUtils.nextEntityId();
+            File file = createAndInsertFile(otherUserId, testTenantId, versionGroupId, 1, 1, null);
+
+            String externalId = IdUtils.toExternalId(file.getId());
+
+            MvcResult result = performGet(API_PREFIX + "/{id}/versions", externalId)
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            int code = extractCode(result);
+            // Should be a permission error code (70001)
+            org.junit.jupiter.api.Assertions.assertNotEquals(200, code);
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /{id}/versions")
+    class CreateNewVersion {
+
+        @Test
+        @DisplayName("should create new version and flip is_latest correctly")
+        void shouldCreateNewVersionAndFlipIsLatest() throws Exception {
+            Long versionGroupId = IdUtils.nextEntityId();
+            File v1 = createAndInsertFile(testUserId, testTenantId, versionGroupId, 1, 1, null);
+            String externalId = IdUtils.toExternalId(v1.getId());
+
+            String body = """
+                    {"fileName":"v2.txt","fileSize":2048,"contentType":"text/plain"}
+                    """;
+
+            MvcResult result = mockMvc.perform(withAuth(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .post(API_PREFIX + "/{id}/versions", externalId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.data.version").value(2))
+                    .andExpect(jsonPath("$.data.fileId").isNotEmpty())
+                    .andExpect(jsonPath("$.data.versionGroupId").isNotEmpty())
+                    .andReturn();
+
+            // Verify is_latest was flipped in DB
+            File reloadedV1 = fileMapper.selectById(v1.getId());
+            org.junit.jupiter.api.Assertions.assertEquals(0, reloadedV1.getIsLatest());
+        }
+
+        @Test
+        @DisplayName("should reject when parent file not found")
+        void shouldRejectWhenParentNotFound() throws Exception {
+            String fakeExternalId = IdUtils.toExternalId(999999L);
+
+            String body = """
+                    {"fileName":"v2.txt","fileSize":2048,"contentType":"text/plain"}
+                    """;
+
+            MvcResult result = mockMvc.perform(withAuth(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .post(API_PREFIX + "/{id}/versions", fakeExternalId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            int code = extractCode(result);
+            org.junit.jupiter.api.Assertions.assertNotEquals(200, code);
+        }
+
+        @Test
+        @DisplayName("should reject non-owner creating version")
+        void shouldRejectNonOwner() throws Exception {
+            Long otherUserId = 999L;
+            Long versionGroupId = IdUtils.nextEntityId();
+            File file = createAndInsertFile(otherUserId, testTenantId, versionGroupId, 1, 1, null);
+            String externalId = IdUtils.toExternalId(file.getId());
+
+            String body = """
+                    {"fileName":"v2.txt","fileSize":2048,"contentType":"text/plain"}
+                    """;
+
+            MvcResult result = mockMvc.perform(withAuth(
+                    org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .post(API_PREFIX + "/{id}/versions", externalId))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            int code = extractCode(result);
+            org.junit.jupiter.api.Assertions.assertNotEquals(200, code);
+        }
+    }
+}

--- a/platform-frontend/src/lib/api/endpoints/upload.test.ts
+++ b/platform-frontend/src/lib/api/endpoints/upload.test.ts
@@ -63,6 +63,26 @@ describe("upload endpoints", () => {
     });
   });
 
+  it("startUpload 在提供 fileId 时应透传参数", async () => {
+    clientMocks.api.post.mockResolvedValue({
+      clientId: "c2",
+      processedChunks: [],
+    });
+
+    await uploadApi.startUpload({
+      fileName: "report-v2.pdf",
+      fileSize: 2048,
+      contentType: "application/pdf",
+      totalChunks: 4,
+      chunkSize: 512,
+      fileId: "ext_file_id",
+    });
+
+    const [, body] = clientMocks.api.post.mock.calls[0];
+    const payload = paramsToObject(body as URLSearchParams);
+    expect(payload.fileId).toBe("ext_file_id");
+  });
+
   it("uploadChunk 应构建 FormData 并调用 PUT 新路径", async () => {
     clientMocks.api.put.mockResolvedValue(undefined);
     const blob = new Blob(["abc"], { type: "text/plain" });

--- a/platform-frontend/src/lib/api/endpoints/upload.ts
+++ b/platform-frontend/src/lib/api/endpoints/upload.ts
@@ -24,6 +24,9 @@ export async function startUpload(
   params.append("contentType", data.contentType);
   params.append("totalChunks", String(data.totalChunks));
   params.append("chunkSize", String(data.chunkSize));
+  if (data.fileId) {
+    params.append("fileId", data.fileId);
+  }
 
   return api.post<StartUploadVO>(BASE, params);
 }

--- a/platform-frontend/src/lib/api/types/files.ts
+++ b/platform-frontend/src/lib/api/types/files.ts
@@ -172,6 +172,7 @@ export interface StartUploadRequest {
   contentType: string;
   chunkSize: number;
   totalChunks: number;
+  fileId?: string;
   fileHash?: string;
 }
 

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -913,6 +913,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/files/{id}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 获取文件版本历史 */
+        get: operations["getFileVersionHistory"];
+        put?: never;
+        /** 创建文件新版本 */
+        post: operations["createNewVersion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/friend-shares": {
         parameters: {
             query?: never;
@@ -2830,6 +2848,18 @@ export interface components {
              */
             unreadCount?: number;
         };
+        /** @description 创建新版本请求 */
+        CreateVersionVO: {
+            /** @description 文件类型 */
+            contentType: string;
+            /** @description 文件名称 */
+            fileName: string;
+            /**
+             * Format: int64
+             * @description 文件大小（字节）
+             */
+            fileSize: number;
+        };
         /** @description 用户注册表单信息 */
         EmailRegisterVO: {
             /** @description 验证码 */
@@ -3026,6 +3056,42 @@ export interface components {
              * @description 总分片数量
              */
             totalChunks?: number;
+        };
+        /** @description 文件版本信息 */
+        FileVersionVO: {
+            /** @description 文件类型 */
+            contentType?: string;
+            /**
+             * Format: date-time
+             * @description 创建时间
+             */
+            createTime?: string;
+            /** @description 文件哈希 */
+            fileHash?: string;
+            /** @description 文件ID（外部ID） */
+            fileId?: string;
+            /** @description 文件名称 */
+            fileName?: string;
+            /**
+             * Format: int64
+             * @description 文件大小（字节）
+             */
+            fileSize?: number;
+            /**
+             * Format: int32
+             * @description 是否最新版本
+             */
+            isLatest?: number;
+            /**
+             * Format: int32
+             * @description 文件状态
+             */
+            status?: number;
+            /**
+             * Format: int32
+             * @description 版本号
+             */
+            version?: number;
         };
         /** @description 好友文件分享详情 */
         FriendFileShareDetailVO: {
@@ -3963,6 +4029,18 @@ export interface components {
             code?: number;
             /** @description 结果数据 */
             data?: components["schemas"]["file"][];
+            /** @description 提示信息 */
+            message?: string;
+        };
+        /** @description 返回结果封装 */
+        ResultListFileVersionVO: {
+            /**
+             * Format: int32
+             * @description 操作代码
+             */
+            code?: number;
+            /** @description 结果数据 */
+            data?: components["schemas"]["FileVersionVO"][];
             /** @description 提示信息 */
             message?: string;
         };
@@ -4959,6 +5037,11 @@ export interface components {
              */
             id?: number;
             /**
+             * Format: int32
+             * @description 是否最新版本：1=是，0=否
+             */
+            isLatest?: number;
+            /**
              * Format: int64
              * @description 来源Id(标识分享文件原始来源用户Id)
              */
@@ -4967,6 +5050,11 @@ export interface components {
             originOwnerName?: string;
             /** @description 文件所有者用户名（分享场景） */
             ownerName?: string;
+            /**
+             * Format: int64
+             * @description 上一版本文件ID
+             */
+            parentVersionId?: number;
             /**
              * Format: int64
              * @description 直接分享者用户ID
@@ -4991,6 +5079,16 @@ export interface components {
              * @description 用户ID
              */
             uid?: number;
+            /**
+             * Format: int32
+             * @description 版本号，从 1 开始
+             */
+            version?: number;
+            /**
+             * Format: int64
+             * @description 版本链分组ID
+             */
+            versionGroupId?: number;
         };
         /** @description 系统操作日志实体类 */
         sys_operation_log: {
@@ -6267,6 +6365,56 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["ResultFileProvenanceVO"];
+                };
+            };
+        };
+    };
+    getFileVersionHistory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 文件ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResultListFileVersionVO"];
+                };
+            };
+        };
+    };
+    createNewVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 父版本文件ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateVersionVO"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResultMapStringObject"];
                 };
             };
         };
@@ -7926,6 +8074,8 @@ export interface operations {
                 clientId?: string;
                 /** @description 文件类型 */
                 contentType: string;
+                /** @description 目标文件ID（可选） */
+                fileId?: string;
                 /** @description 文件名 */
                 fileName: string;
                 /** @description 文件大小 */

--- a/platform-frontend/src/lib/stores/upload.svelte.test.ts
+++ b/platform-frontend/src/lib/stores/upload.svelte.test.ts
@@ -115,6 +115,20 @@ describe("upload store", () => {
     expect(upload.tasks.length).toBe(2);
   });
 
+  it("版本上传任务应将 targetFileId 透传到 startUpload", async () => {
+    const upload = await loadUploadStore();
+    await upload.addFile(createFile(1024), { targetFileId: "ext-version-id" });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.startUpload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileId: "ext-version-id",
+      }),
+    );
+  });
+
   it("startUpload 初始化失败时任务应进入 failed", async () => {
     mocks.startUpload.mockRejectedValue(new Error("start failed"));
 

--- a/platform-frontend/src/lib/stores/upload.svelte.ts
+++ b/platform-frontend/src/lib/stores/upload.svelte.ts
@@ -17,6 +17,7 @@ export type UploadStatus =
 export interface UploadTask {
   id: string;
   file: File;
+  targetFileId: string | null;
   clientId: string | null;
   status: UploadStatus;
   progress: number;
@@ -29,6 +30,14 @@ export interface UploadTask {
   error: string | null;
   startTime: number | null;
   endTime: number | null;
+}
+
+/**
+ * 新建上传任务的可选参数。
+ */
+export interface AddFileOptions {
+  targetFileId?: string;
+  autoStart?: boolean;
 }
 
 // ===== Configuration =====
@@ -335,14 +344,26 @@ async function uploadChunks(task: UploadTask): Promise<void> {
 
 // ===== Actions =====
 
-async function addFile(file: File): Promise<string> {
+/**
+ * 添加单个上传任务并按需自动启动。
+ *
+ * @param file 待上传文件。
+ * @param options 可选参数（目标版本 fileId、是否自动启动）。
+ * @returns 新建任务 ID。
+ */
+async function addFile(
+  file: File,
+  options: AddFileOptions = {},
+): Promise<string> {
   const id = generateId();
   const chunkSize = calculateOptimalChunkSize(file.size);
   const totalChunks = calculateChunks(file.size, chunkSize);
+  const shouldAutoStart = options.autoStart ?? true;
 
   const task: UploadTask = {
     id,
     file,
+    targetFileId: options.targetFileId ?? null,
     clientId: null,
     status: "pending",
     progress: 0,
@@ -360,15 +381,25 @@ async function addFile(file: File): Promise<string> {
   tasks = [...tasks, task];
 
   // Auto start if below concurrent limit
-  if (activeTasks.length < MAX_CONCURRENT_UPLOADS) {
+  if (shouldAutoStart && activeTasks.length < MAX_CONCURRENT_UPLOADS) {
     startUpload(id);
   }
 
   return id;
 }
 
-async function addFiles(files: File[]): Promise<string[]> {
-  return Promise.all(files.map((f) => addFile(f)));
+/**
+ * 批量添加上传任务。
+ *
+ * @param files 待上传文件列表。
+ * @param options 任务可选参数，会应用到每个任务。
+ * @returns 任务 ID 列表。
+ */
+async function addFiles(
+  files: File[],
+  options?: AddFileOptions,
+): Promise<string[]> {
+  return Promise.all(files.map((f) => addFile(f, options)));
 }
 
 async function startUpload(id: string): Promise<void> {
@@ -391,6 +422,7 @@ async function startUpload(id: string): Promise<void> {
       contentType: task.file.type || "application/octet-stream",
       chunkSize: task.chunkSize,
       totalChunks: task.totalChunks,
+      fileId: task.targetFileId ?? undefined,
     });
 
     const initialProgress = Math.round(


### PR DESCRIPTION
## Summary

- Add file version chain infrastructure: 4 new columns (`version`, `parent_version_id`, `is_latest`, `version_group_id`) on `file` table with Flyway migration V1.4.0
- Implement `createNewVersion` (distributed lock + clearLatestInChain + insert PREPARE version) and `getFileVersionHistory` (owner/admin permission check)
- Default file list queries now filter by `is_latest=1`; add REST endpoints `GET/POST /{id}/versions`

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| Migration | `V1.4.0__file_version_chain.sql` | ALTER TABLE + backfill + 3 indexes |
| Entity | `File.java` | 4 new persistent fields |
| Enums | `ResultEnum.java` | VERSION_CHAIN_NOT_FOUND, VERSION_CONFLICT, VERSION_SOURCE_INVALID |
| VO | `FileVersionVO.java`, `CreateVersionVO.java` | Request/response records |
| Mapper | `FileMapper.java` | clearLatestInChain, selectVersionChain, countVersionsInChain |
| Service (Write) | `FileService.java`, `FileServiceImpl.java` | createNewVersion with Redisson distributed lock |
| Service (Read) | `FileQueryService.java`, `FileQueryServiceImpl.java` | getFileVersionHistory + isLatest filter |
| Service (Admin) | `FileAdminServiceImpl.java` | isLatest filter on getAllFiles |
| Controller | `FileController.java` | GET/POST `/{id}/versions` endpoints |
| Test Builder | `FileTestBuilder.java` | Default version fields + aVersionedFile/aNewVersion helpers |
| Unit Tests | `FileVersionServiceTest.java`, `FileQueryServiceTest.java` | 10 new version-related tests |
| Integration Tests | `FileVersionIntegrationTest.java` | 6 end-to-end tests |

## Design decisions

- **Quota does not filter by is_latest** — each version independently consumes storage
- **Distributed lock granularity** — lock per `version_group_id` (chain-level), not global
- **No unique constraint on is_latest** — multiple `is_latest=0` rows allowed; enforced by lock + application logic
- **Version creation returns PREPARE file** — client reuses existing upload flow with new fileId
- **Legacy backfill** — historical files get `version_group_id=id`, treated as standalone v1

## Test plan

- [x] Unit tests pass (532 tests, 0 failures)
- [ ] Integration tests with Docker (FileVersionIntegrationTest covers GET/POST version endpoints)
- [ ] CI pipeline (backend-test, frontend-test, contract-consistency, build-check)
- [ ] Manual: create version → upload → verify is_latest flip in DB
- [ ] Manual: GET /{id}/versions returns correct chain order