### PR TITLE
feat: upload SARIF results to GitHub Code Scanning

### DIFF
--- a/.github/workflows/security-poc.yml
+++ b/.github/workflows/security-poc.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   semgrep-sast:
@@ -58,6 +59,13 @@ jobs:
             "durationSeconds": ${DURATION_SECONDS}
           }
           EOF
+
+      - name: Upload Semgrep SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: security-artifacts/semgrep/semgrep.sarif
+          category: semgrep
 
       - name: Upload Semgrep Artifacts
         uses: actions/upload-artifact@v4
@@ -129,6 +137,13 @@ jobs:
             "durationSeconds": ${DURATION_SECONDS}
           }
           EOF
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: security-artifacts/trivy/trivy.sarif
+          category: trivy-sca
 
       - name: Upload Trivy Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,6 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scan
@@ -211,6 +212,25 @@ jobs:
           ignore-unfixed: true
           vuln-type: os,library
           exit-code: '0'
+
+      - name: Run Trivy SARIF output
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-pr.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          vuln-type: os,library
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-pr.sarif
+          category: trivy-pr
 
   build-check:
     name: Build Verification


### PR DESCRIPTION
## Summary

- Add `upload-sarif` steps to `security-poc.yml` for Semgrep (category: `semgrep`) and Trivy (category: `trivy-sca`) scan results
- Add SARIF output + upload to `test.yml` security-scan job (category: `trivy-pr`) while keeping existing table output for CI logs
- Add `security-events: write` permission where needed

Enables vulnerability lifecycle tracking (open → dismissed/fixed) in GitHub Security → Code scanning alerts.

## Test plan

- [ ] Trigger `security-poc.yml` via workflow_dispatch, verify Semgrep + Trivy SARIF uploads succeed
- [ ] Create a PR to trigger `test.yml`, verify `trivy-pr` SARIF upload succeeds
- [ ] Check GitHub → Security → Code scanning alerts shows 3 categories: `semgrep`, `trivy-sca`, `trivy-pr`