### PR TITLE
feat: add environment bootstrap and validation (P1-4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,20 @@ NACOS_USERNAME=nacos
 NACOS_PASSWORD=nacos
 
 # ==============================================================================
+# 基础设施服务凭据 (docker-compose.infra.yml)
+# ==============================================================================
+DB_PASSWORD=recordplatform
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=redis123
+RABBITMQ_HOST=localhost
+RABBITMQ_PORT=5672
+RABBITMQ_MANAGEMENT_PORT=15672
+RABBITMQ_USERNAME=rabbitmq
+RABBITMQ_PASSWORD=rabbitmq
+NACOS_AUTH_TOKEN=c2VjcmV0VG9rZW5Gb3JSZWNvcmRQbGF0Zm9ybQ==
+
+# ==============================================================================
 # Knife4j API 文档配置 (开发环境)
 # ==============================================================================
 KNIFE4J_USERNAME=admin

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,450 @@
+# RecordPlatform 演进路线图
+
+> 最后更新：2026-03-02
+> 定位：个人维护的开源项目，以自动化流程替代人工管理
+
+## 1. 文档目标
+
+本路线图记录项目的自动化基线与演进优先级。每个条目必须回答：**增加了什么自动化** 或 **消除了什么手动步骤**。
+
+原则：
+
+- **自动化优先**：能由 CI/CD 和工具完成的，不靠人工判断。
+- **证据驱动**：所有门禁条目必须可在仓库中找到实现证据。
+- **最小人工干预**：减少流程开销，专注于代码和自动化建设。
+- **环境同构**：本地开发与生产使用相同基础设施栈（含区块链节点和智能合约），不存在仅本地运行的轻量模式。
+
+---
+
+## 1.5 市场与技术背景
+
+> **声明**：本节提供决策参考，非承诺路线图。数据来源于公开市场报告和技术标准文档。
+
+| 领域 | 趋势 | 与本项目的关联 |
+|------|------|----------------|
+| 区块链存证市场 | 全球市场 CAGR 36.7%，FISCO BCOS 生态 600+ 产业案例，WeBASE 中间件已成熟 | 验证技术选型方向正确；WeBASE 可辅助合约生命周期管理（→ P1-5） |
+| 分布式存储 | 趋向混合架构（热数据 S3 + 冷数据 IPFS/Filecoin），内容寻址和可验证存储成为行业标准 | 当前 S3 架构可作为热存储层；冷数据层为远期演进方向（→ P3-1） |
+| 隐私增强技术 | ZKP 市场 $1.5B → $7.6B，zk-STARKs 具备后量子安全特性，无需可信设置 | "证明文件存在但不泄露内容"场景价值高（→ P3-2） |
+| 后量子密码学 | NIST 已发布 FIPS 203/204/205，HQC 2025 年入选第五算法，迁移时间线 2030-2035 | 当前对称加密量子安全，密钥交换需评估（→ P2-3） |
+| 可观测性 | OTel Java Agent 自动注入已成为微服务可观测性标准方案 | 三个 Dubbo 服务可零代码改动接入（→ P2-2） |
+| 智能合约安全 | 业界采用 Slither 静态分析 + Echidna/Foundry 模糊测试作为 CI 标配 | 合约逻辑复杂度增加时应引入（→ P2-4） |
+| 国内存证行业生态 | 至信链对接 31 省 300+ 法院、蚁链 TEE+MPC 隐私计算、长安链 10 万+ TPS 高性能共识 [置信度: Medium] | 验证联盟链选型方向；司法互认通道为远期跨链参考（→ P3-3） |
+| 开源存证参考项目 | OpenTimestamps（比特币锚定）、OpenAttestation（Merkle Root 批量存证）、evidenceSample（FISCO 存证工厂）、WeIdentity（DID 全栈） [置信度: High] | P2-5 Merkle 聚合、P2-8 多方签名、P3-4 DID/VC 参考实现 |
+| 可验证存储 | Filecoin PDP 周期性存储证明、Storacha IPFS 热层 + UCAN 授权网关 [置信度: Medium] | 存储完整性校验参考（→ P2-7）；冷热混合架构演进（→ P3-1） |
+| 数字身份标准 | W3C VC 2.0 已发布正式推荐标准、WeIdentity 提供 FISCO 上 DID 全栈实现 [置信度: High] | 存证结果封装为可验证凭证（→ P3-4） |
+
+---
+
+## 2. 自动化基线
+
+### 表 1：PR 合并阻断门禁（已就位）
+
+| 门禁 | 证据路径 |
+|------|----------|
+| 后端单元 + 集成测试 | `.github/workflows/test.yml` |
+| 后端覆盖率 (web ≥ 40%, service ≥ 45%, common ≥ 40%) | `platform-backend/pom.xml` JaCoCo |
+| 前端 lint + type check + 测试 | `.github/workflows/test.yml` |
+| 前端覆盖率 (utils ≥ 70%, endpoints/stores/services ≥ 90%) | `platform-frontend/vitest.config.ts` |
+| 契约一致性 (OpenAPI ↔ generated.ts) | `.github/workflows/test.yml` contract-consistency job |
+| 构建验证 | `.github/workflows/test.yml` build-check job |
+| 安全扫描 (Trivy HIGH/CRITICAL 阻断) | `.github/workflows/test.yml` security-scan job |
+| Dependabot 自动依赖更新 | `.github/dependabot.yml` |
+| Codecov patch 覆盖率 ≥ 80% | `.codecov.yml` |
+
+### 表 2：信息级 / 手动（尚未阻断）
+
+| 项目 | 现状 | 证据 |
+|------|------|------|
+| SAST (Semgrep) | 每周定时，信息级；自动观测汇总链路已就位，待首轮数据校准阈值 | `.github/workflows/security-poc.yml`, `tools/security/scripts/render-security-poc-observation.mjs` |
+| SCA (Trivy) 全量扫描 | 每周深度扫描（信息级）；PR 级 HIGH/CRITICAL 已升级为阻断 | `.github/workflows/security-poc.yml`, `.github/workflows/test.yml` |
+| SBOM (CycloneDX) | 每周定时，信息级 | `.github/workflows/security-poc.yml` |
+| 性能 smoke (k6) | 手动触发；k6 脚本已现代化，渲染管线就绪，待在线实测回填 | `.github/workflows/perf-smoke.yml`, `tools/k6/file-query.js`, `tools/k6/scripts/render-query-baseline.mjs` |
+
+### 表 3：尚未实现
+
+| 缺失项 | 影响 |
+|--------|------|
+| 容器镜像构建 | Dockerfile 尚未创建；基础设施 compose 已就位（`docker-compose.infra.yml`），应用服务 compose 模板存在于文档中 |
+| 自动化发布 / Changelog | 每次发布需手动操作 |
+| ~~GitHub 分支保护 required checks~~ | ~~已完成：required checks 已启用（Backend Tests, Frontend Tests, Contract Consistency, Build Verification）~~ |
+| 智能合约部署自动化 | 合约编译和部署完全手动；ABI 文件作为静态资源签入，无工具链保障 ABI 与链上合约一致 |
+
+> 门禁策略详见 `plan/gate-policy.md`
+
+---
+
+## 3. 优先级清单
+
+### P0：自动化质量门禁（防止回退）
+
+**P0-1：配置 GitHub 分支保护 required checks** ✅
+
+- **What**：将 `backend-test`、`frontend-test`、`contract-consistency`、`build-check` 设为 `main` 的 required status checks
+- **自动化收益**：从平台层阻断未通过 CI 的 PR 合并，消除人工判断
+- **完成标准**：`gh api` 确认 required checks 已启用；故意破坏测试的 PR 无法合并
+- **涉及文件**：GitHub 仓库设置（非仓库内文件）
+- **当前状态**：已完成。`main` 分支保护已启用，required checks: `Backend Tests`, `Frontend Tests`, `Contract Consistency`, `Build Verification`；`strict: true`（要求分支与 base 同步）；`enforce_admins: true`
+
+**P0-2：启用 Dependabot 自动依赖更新** ✅
+
+- **What**：新建 `.github/dependabot.yml`，覆盖 maven（4 模块）、npm（frontend + docs）、github-actions
+- **自动化收益**：消除手动依赖监控；安全补丁自动提 PR，CI 自动验证
+- **完成标准**：`.github/dependabot.yml` 存在；一周内出现 Dependabot PR
+- **涉及文件**：新建 `.github/dependabot.yml`
+
+**P0-3：安全扫描升级为 PR 阻断** ✅
+
+- **What**：在 `test.yml` 新增 `security-scan` job（PR 触发），Trivy `exit-code: 1` 仅对 HIGH/CRITICAL 阻断；保留 `security-poc.yml` 作为每周全量深度扫描
+- **当前状态**：观测汇总链路已就位（`tools/security/scripts/render-security-poc-observation.mjs`），下一步是校准阈值后升级为阻断
+- **自动化收益**：高危漏洞在 PR 阶段自动拦截，无需人工定期检查
+- **完成标准**：引入已知 CVE 依赖的 PR 被 CI 阻断
+- **涉及文件**：`.github/workflows/test.yml`、`.github/workflows/security-poc.yml`
+
+**P0-4：覆盖率阈值逐步提升** ✅
+
+- **What**：后端 JaCoCo 从 35%/35%/30% → 40%/45%/40%（第一阶段），后续按模块覆盖率基线逐步上调；配置 `.codecov.yml` 对新代码要求 patch coverage ≥ 80%
+- **自动化收益**：自动防止覆盖率下降；新代码自动被更高标准约束
+- **完成标准**：`pom.xml` 阈值更新后 CI 通过；Codecov patch check 出现在 PR 上
+- **涉及文件**：`platform-backend/pom.xml`、新建 `.codecov.yml`
+
+### P1：可靠性增强（自动检测问题）
+
+**P1-1：SARIF 上传至 GitHub Security 面板** ✅
+
+- **What**：在 `security-poc.yml` 和 `test.yml` 中用 `github/codeql-action/upload-sarif` 上传 Semgrep/Trivy SARIF
+- **自动化收益**：漏洞具有生命周期跟踪（open/dismissed/fixed），不再是一次性 CI 输出
+- **涉及文件**：`.github/workflows/test.yml`、`.github/workflows/security-poc.yml`
+- **当前状态**：已完成（PR #73, commit `3afe670`）。三个 category 上传：`semgrep`（Semgrep SAST）、`trivy-sca`（Trivy 全量扫描）、`trivy-pr`（Trivy PR 级扫描），结果可在 GitHub Security → Code scanning alerts 面板查看
+
+**P1-2：故障注入集成测试**
+
+- **What**：新增 `*IT.java` 测试：(a) S3 节点故障（Testcontainers MinIO 中断）、(b) 区块链节点不可达（mock）、(c) RabbitMQ 断连期间的 Outbox 处理
+- **自动化收益**：Resilience4j 断路器、重试、Saga 补偿的行为在 CI 中持续验证
+- **涉及文件**：`platform-backend/backend-service/src/test/` 新增测试类
+
+**P1-3：自动化发布流程**
+
+- **What**：新建 `.github/workflows/release.yml`，tag push 触发：自动生成 Release Notes + 构建 SBOM 附件 + 构建容器镜像推送 ghcr.io
+- **自动化收益**：消除手动编写 Changelog、手动构建部署包、手动生成 SBOM
+- **涉及文件**：新建 `.github/workflows/release.yml`、新建各模块 `Dockerfile`
+- **前置依赖**：需先创建各模块 Dockerfile（当前仓库中尚不存在）
+
+**P1-4：服务器环境引导与验证** ✅
+
+- **What**：创建环境验证脚本和完善部署文档，覆盖完整的服务器端基础设施栈
+- **背景**：FISCO BCOS 节点初始化需要创世块生成、CA 证书签发、节点组网等多步骤服务器操作，
+  无法简单 docker-compose 解决。`SdkBeanConfig` 在 Bean 创建时调用 `getBlockNumber()`，
+  节点不可达则服务无法启动
+- **交付物**：
+  1. `scripts/env-check.sh` — 环境预检脚本，验证所有前置条件：
+     - Nacos (8848) 可达且命名空间存在
+     - MySQL (3306) 可访问，数据库已创建
+     - Redis (6379) ping 成功
+     - RabbitMQ (5672) 连接 + 管理 API (15672) 可达
+     - FISCO BCOS 节点 (20200) 可达
+     - S3/MinIO 端点可访问，bucket 已创建
+     - TLS 证书存在于 `platform-fisco/src/main/resources/conf/`
+     - 合约地址已配置于 `.env` 或 Nacos
+  2. `docker-compose.infra.yml` — 仓库根目录实体文件（从文档中提取），
+     包含**可容器化的服务**：Nacos、MySQL、Redis、RabbitMQ、MinIO
+  3. 更新 `docs/` 部署文档，新增「服务器环境搭建」页面：
+     - FISCO BCOS 节点安装、创世块创建、证书生成（链接官方文档）
+     - 合约编译与部署步骤
+     - Nacos 命名空间创建与配置导入
+- **不包含**：不尝试容器化 FISCO BCOS 节点或自动化智能合约部署（归入 P1-5）
+- **自动化收益**：消除试错式环境搭建；`env-check.sh` 即时反馈缺失项
+- **完成标准**：`env-check.sh` 全项通过后，按文档操作可在全新服务器上启动全部服务
+- **涉及文件**：新建 `scripts/env-check.sh`、新建 `docker-compose.infra.yml`、
+  更新 `docs/zh/deployment/`、更新 `docs/en/deployment/`
+- **当前状态**：已完成。交付物：
+  - `docker-compose.infra.yml`：根目录可执行 compose 文件，含 6 个服务（Nacos/MySQL/Redis/RabbitMQ/MinIO x2），全部配置 healthcheck + env 默认值
+  - `scripts/env-check.sh`：8 项环境预检脚本，支持 `--fix` 自动修复和 `--service` 单项检查
+  - `docs/zh/deployment/environment-setup.md` + `docs/en/deployment/environment-setup.md`：中英文环境搭建指南
+  - `.env.example`：补充基础设施凭据变量（DB_PASSWORD, REDIS_*, RABBITMQ_*, NACOS_AUTH_TOKEN）
+
+**P1-5：智能合约生命周期工具**
+
+- **What**：创建 `scripts/contract-deploy.sh`，封装 FISCO BCOS 控制台命令：
+  1. 检查 FISCO BCOS 控制台已安装且节点可达
+  2. 编译 Storage.sol 和 Sharing.sol
+  3. 部署合约并捕获部署地址
+  4. 自动更新 `.env` 中的合约地址
+  5. 验证部署（调用合约只读方法）
+- **背景**：当前合约部署完全手动且仓库内无文档。`platform-fisco/src/main/resources/abi/` 中的
+  ABI 文件为静态签入，合约变更后无自动化路径从 `.sol` 到链上部署地址
+- **自动化收益**：将多步手动操作收敛为单脚本调用；消除 ABI/合约不匹配风险
+- **完成标准**：在已初始化的 FISCO BCOS 节点上运行脚本可完成双合约部署，输出地址可直接使用
+- **涉及文件**：新建 `scripts/contract-deploy.sh`、`platform-fisco/contract/Storage.sol`、
+  `platform-fisco/contract/Sharing.sol`
+- **可选增强**：
+  - **WeBASE 集成**：评估 WeBASE-Front 可视化合约 IDE，用于合约调试和管理界面
+  - **安全增强**：部署前可选运行 Slither 静态分析（需 Python 环境）；部署日志包含字节码哈希便于审计追溯
+  - **ABI 校验**：部署前对比 `.sol` 编译产物与 `abi/` 签入文件的 SHA-256，不一致时中断并提示
+
+### P2：未来能力（条件触发）
+
+**P2-1：文件版本治理 MVP** ✅
+
+- **What**：实现 `plan/w4-file-versioning-rfc.md` 设计的版本链 schema
+- **前置条件**：P0 门禁全部就位后再实施
+- **涉及文件**：`plan/w4-file-versioning-rfc.md`、`plan/w4-file-versioning-migration-draft.sql`
+- **当前状态**：已完成（PR #68, commit `9fa95a8`）。实现证据：
+  - DB 迁移：`V1.4.0__file_version_chain.sql`（正式 Flyway 迁移，取代草案脚本）
+  - 并发控制：Redisson `RLock` 分布式锁防止同一版本链并发写入
+  - REST API：`GET /api/v1/files/{id}/versions`（版本历史）、`POST /api/v1/files/{id}/versions`（派生新版本）
+  - 前端：上传流支持 `targetFileId` 参数触发版本续写
+  - 测试覆盖：`FileVersionServiceTest`（单元）、`FileVersionIntegrationTest`（集成）
+
+**P2-2：OpenTelemetry 统一追踪**
+
+- **What**：三个 Java 服务接入 OTel Java Agent，替换可选的 SkyWalking
+- **实施方案**：
+  - **接入方式**：`-javaagent:opentelemetry-javaagent.jar` 自动注入，无需代码改动即可采集 HTTP/gRPC/JDBC/Redis span
+  - **传播协议**：W3C Trace Context（`traceparent`, `tracestate` 头），Dubbo Triple 协议原生支持
+  - **采样策略**：`ParentBased` + `TraceIdRatio`（初始 10%），错误请求始终采样（`alwaysOn` for error spans）
+  - **语义约定**：Span 命名遵循 `{verb} {object}` 格式（如 `POST /files`, `SELECT file_record`）
+  - **业务上下文**：自定义属性 `tenant.id`, `user.id`, `file.hash` 注入 span，便于业务关联查询
+  - **信号关联**：trace/span ID 注入 log MDC（Logback `%X{trace_id}`），metrics 和 logs 可通过 trace ID 关联
+  - **导出链路**：OTLP gRPC → Jaeger / Grafana Tempo（可视化） + Prometheus（metrics）
+- **触发条件**：跨服务问题排查成本明显增加时
+- **自动化收益**：零代码改动获得全链路追踪；故障定位从"翻日志"变为"看 trace"
+- **涉及文件**：各服务 `Dockerfile` 或启动脚本（添加 `-javaagent`）、Nacos 配置（采样率）
+
+**P2-3：后量子密码学准备**
+
+- **What**：评估 PQC 算法对文件哈希和加密层的影响
+- **NIST 标准现状**（截至 2025）：
+  - **FIPS 203 (ML-KEM)**：基于格的密钥封装机制，已发布最终标准
+  - **FIPS 204 (ML-DSA)**：基于格的数字签名，已发布最终标准
+  - **FIPS 205 (SLH-DSA)**：基于哈希的数字签名（无状态），已发布最终标准
+  - **HQC**：2025 年 3 月入选第五算法（基于码的 KEM，作为 ML-KEM 的备选方案）
+- **影响评估**：
+  - **对称加密（AES-256）**：量子安全，无需迁移
+  - **文件哈希（SHA-256）**：Grover 算法降低安全性至 128-bit，仍在安全范围内
+  - **密钥交换（RSA/ECDH）**：需评估迁移至 ML-KEM 的路径
+  - **国密 SM2/SM3**：SM3 量子安全性同 SHA-256；SM2（椭圆曲线）需跟踪国家 PQC 标准进展
+- **迁移时间线**：参考 NIST 建议 2030-2035 完成迁移；当前阶段为调研和算法评估
+- **触发条件**：监管要求出现，或 Java 生态 PQC 库（如 Bouncy Castle PQC）达到生产就绪时
+
+**P2-4：智能合约安全测试增强**
+
+- **What**：在 CI 中集成 Slither 静态分析 + Echidna/Foundry 模糊测试，覆盖 `.sol` 合约变更
+- **实施方案**：
+  - `.sol` 文件变更时触发安全扫描 workflow
+  - Slither 静态分析：检测重入攻击、整数溢出、未检查返回值等常见漏洞模式
+  - Echidna/Foundry 模糊测试：针对合约不变式（invariant）进行自动化属性测试
+  - 初期信息级不阻断 PR，积累基线数据后评估升级为阻断
+- **触发条件**：合约逻辑复杂度增加时（如新增合约或修改核心存证/分享逻辑）
+- **自动化收益**：合约安全检查从人工审计变为 CI 自动执行
+- **涉及文件**：新建 `.github/workflows/contract-security.yml`、`platform-fisco/contract/`
+
+**P2-5：文件完整性批量验证（Merkle Tree）**
+
+- **What**：批量文件哈希聚合为 Merkle Root 上链，减少链上交易数；审计时提供 Merkle Proof 验证单文件归属
+- **实施方案**：
+  - 批量上传场景：收集 N 个文件哈希 → 构建 Merkle Tree → 仅 Root 上链（1 笔交易替代 N 笔）
+  - 单文件验证：提供 Merkle Proof（O(log N) 个中间哈希），链下可独立验证文件归属
+  - 参考方案：
+    - OpenTimestamps Calendar Server 聚合模式：将多个时间戳请求批量锚定到比特币区块，日均处理数万请求仅消耗 1 笔链上交易 [置信度: High]
+    - OpenAttestation Merkle Root 批量存证 SDK：新加坡政府使用，支持文档批量哈希聚合与独立验证 [置信度: High]
+    - Merkle Mountain Ranges（MMR）：支持流式追加场景（无需预知叶节点总数），适用于持续写入的存证流水 [置信度: Medium]
+- **触发条件**：批量上传场景增多，或链上交易成本/频率成为瓶颈时
+- **自动化收益**：链上交易数从 O(N) 降至 O(1)；审计验证保持 O(log N) 效率
+- **涉及文件**：`platform-fisco/` 新增 Merkle Tree 工具类、`platform-backend/backend-service/` 批量存证逻辑
+
+**P2-6：可观测性驱动 SLO/SLI 体系**
+
+- **What**：基于 OTel 指标定义 SLI/SLO，建立燃尽率告警机制
+- **实施方案**：
+  - **SLI 定义**：上传成功率、存证 P99 延迟、存储可用性、API 错误率
+  - **SLO 目标**：上传成功率 ≥ 99.5%、存证 P99 ≤ 5s、存储可用性 ≥ 99.9%
+  - **告警策略**：燃尽率告警（Burn Rate Alert），基于滑动窗口检测 SLO 预算消耗速率
+  - **仪表盘**：Grafana 展示 SLO 达成率、错误预算剩余、趋势预测
+- **触发条件**：生产环境稳定运行且 P2-2 OTel 追踪就位后
+- **前置依赖**：P2-2（OpenTelemetry 统一追踪）
+- **自动化收益**：从"感觉系统不稳"变为"SLO 预算还剩 X%"的量化决策
+- **涉及文件**：告警规则配置、Grafana 仪表盘 JSON、OTel Collector 配置
+
+**P2-7：存储完整性周期校验**
+
+- **What**：后台定时任务对 S3 存储文件进行 re-hash 校验，比对链上哈希，检测静默数据损坏（bit rot）或篡改
+- **实施方案**：
+  - 参考 Filecoin Provable Data Possession（PDP）模式，首期采样校验 1%/天，覆盖全量约需 100 天 [置信度: Medium]
+  - 校验流程：`DistributedStorageService.download()` → 计算 SHA-256 → `BlockChainService.getFile()` 比对链上哈希
+  - 不一致记录写入告警表，触发管理员通知（复用现有 SSE 通知通道）
+  - 支持手动触发全量校验（合规审计场景）
+- **触发条件**：存储节点故障恢复后需验证数据完整性，或合规审计要求提供存储证明时
+- **自动化收益**：从"出问题才发现数据损坏"变为"持续自动检测"；合规审计可一键出报告
+- **涉及文件**：`platform-backend/backend-service/` 新增定时任务与校验服务、`platform-backend/backend-dao/` 告警记录表
+
+**P2-8：多方签名存证**
+
+- **What**：支持多方协作存证，采用 M/N 阈值签署确认模式（如 2/3），适用于机构间协作场景
+- **实施方案**：
+  - 参考 FISCO BCOS evidenceSample 工厂合约模式：发起方创建存证提案 → 参与方逐一签署 → 达到阈值后上链确认 [置信度: High]
+  - 新增 `MultiPartyStorage.sol` 合约，包含提案创建、签署、阈值判定、最终确认逻辑
+  - 后端新增提案管理服务：提案生命周期（草稿→待签→已确认/已过期）、签署通知
+  - 前端新增协作签署工作流 UI
+- **触发条件**：机构间协作存证需求出现，或需要多方见证的高价值文件存证场景
+- **自动化收益**：从线下多方签字确认变为链上自动阈值判定；签署过程全程可审计
+- **涉及文件**：`platform-fisco/contract/` 新增 `MultiPartyStorage.sol`、`platform-backend/backend-service/` 提案管理服务、`platform-frontend/` 协作 UI
+
+### P3：远期探索（方向性评估）
+
+> P3 条目为远期技术方向探索，不承诺实施时间。每个条目标注触发条件，满足时升级为 P2 并细化方案。
+
+**P3-1：内容寻址存储层（IPFS/Filecoin）**
+
+- **What**：引入混合存储架构，热数据保持 S3，冷数据/归档迁移至 IPFS pinning + Filecoin 存储证明
+- **技术要点**：
+  - 热数据（近期访问）：保持当前 S3 兼容存储，低延迟读写
+  - 冷数据（归档/合规保留）：IPFS pinning 服务 + Filecoin 存储交易，成本显著降低
+  - 内容寻址（CID）：基于文件内容生成唯一标识，天然支持跨租户去重和完整性验证
+  - 可验证存储：Filecoin 的 Proof-of-Spacetime 提供链上存储证明
+  - **Storacha**（原 web3.storage）：基于 UCAN 授权的 IPFS 热存储网关，提供 S3 兼容 API + IPFS CID 双寻址，可作为 S3→IPFS 过渡方案 [置信度: Medium]
+  - **Filecoin PDP**（Provable Data Possession）：周期性存储证明，验证存储提供者确实持有数据 [置信度: High]
+  - **Filecoin F3**（Fast Finality）：将最终确认时间从 ~30 分钟降至 ~5 秒，大幅改善存储交易体验 [置信度: Medium]
+- **触发条件**：存储成本优化需求明确，或可验证存储成为合规要求时
+- **涉及文件**：`platform-storage/` 存储抽象层、新增 IPFS/Filecoin 适配器
+
+**P3-2：零知识证明隐私存证**
+
+- **What**：实现"证明文件存在但不泄露内容"的隐私保护存证能力
+- **技术要点**：
+  - **zk-SNARKs**：证明体积小（~200B）、验证快（~毫秒级），但需可信设置（trusted setup）
+  - **zk-STARKs**：无需可信设置、具备后量子安全特性，但证明体积较大（~100KB）
+  - 应用场景：文件存在性证明、选择性属性披露（证明文件属于某类别但不暴露内容）
+  - 链上验证：在 FISCO BCOS 上部署 ZKP 验证合约
+  - **学术参考**：ZKBAR-V（基于 ZKP 的区块链审计报告验证框架）、VeriNet（可验证神经网络推理）提供了 ZKP 在数据验证场景的可行性验证 [置信度: Low]
+  - **FISCO BCOS 3.x 隐私计算**：内置隐私计算模块（同态加密、群环签名），可作为 ZKP 全方案的阶段性替代 [置信度: Medium]
+- **触发条件**：隐私合规需求（如 GDPR 数据最小化原则）或高价值客户明确需求时
+- **涉及文件**：新增 ZKP 电路、`platform-fisco/` ZKP 验证合约、`platform-backend/` 证明生成服务
+
+**P3-3：跨链互操作性**
+
+- **What**：扩展当前双链适配架构，探索跨链存证互认能力
+- **现状**：已有 FISCO BCOS + Besu 双链适配（互斥配置，通过 `blockchain.type` 切换）
+- **潜在方向**：
+  - 双链同步写入：同一存证同时锚定到两条链，提升可信度
+  - 跨链存证验证：A 链存证可在 B 链验证，实现跨组织互认
+  - 中继/桥接方案：评估轻节点验证或第三方跨链桥
+  - **至信链司法互认通道**：已对接 31 省 300+ 法院，存证数据可直接作为电子证据采信；评估通过跨链桥接实现存证结果向司法链的锚定 [置信度: Medium]
+  - **长安链 SPV 轻节点跨链**：基于简单支付验证的轻量跨链方案，无需完整节点同步即可验证对方链上存证 [置信度: Low]
+  - **标准化方向**：IEEE P3205（区块链互操作性）、信通院跨链互操作规范，为跨链方案选型提供合规框架 [置信度: Medium]
+- **触发条件**：多链部署需求明确，或跨组织存证互认成为业务需求时
+- **涉及文件**：`platform-fisco/` 多链适配层、新增跨链桥接模块
+
+**P3-4：分布式身份与可验证凭证（DID/VC）**
+
+- **What**：基于 W3C DID + Verifiable Credentials 2.0 标准，将存证结果封装为可验证凭证，支持跨平台独立验证
+- **技术要点**：
+  - **W3C VC 2.0**：已发布正式推荐标准，定义凭证数据模型和验证协议 [置信度: High]
+  - **WeIdentity**：微众银行开源的 FISCO BCOS DID 全栈实现，可复用现有 FISCO 基础设施 [置信度: High]
+  - 存证结果封装为 VC：包含文件哈希、时间戳、签发者 DID、链上交易 ID
+  - 验证方无需接入本平台即可独立验证 VC 签名和链上锚定
+  - 用户身份从平台内部 ID 演进为 DID，支持自主身份管理
+- **触发条件**：跨组织验证需求出现，或凭证标准化成为行业要求时
+- **涉及文件**：`platform-fisco/` DID 注册合约、`platform-backend/` VC 签发与验证服务、`platform-frontend/` 凭证展示 UI
+
+---
+
+## 4. 技术演进策略
+
+### 4.1 依赖管理策略
+
+| 策略 | 说明 |
+|------|------|
+| 安全补丁 | Dependabot PR 自动创建，及时合并 |
+| LTS 版本 | 评估并在发布后一个月内采纳 |
+| EOL 依赖 | 在 EOL 前规划迁移 |
+| 中间版本 | 不追非 LTS 中间版本 |
+
+### 4.2 区块链演进策略
+
+| 策略 | 说明 |
+|------|------|
+| FISCO BCOS 版本 | 跟踪 FISCO BCOS 3.x 发布；升级前必须验证合约 ABI 向后兼容 |
+| 智能合约变更 | 任何 `.sol` 修改需重新生成 ABI、重新部署合约并更新地址配置 |
+| WeBASE 评估 | 跟踪 WeBASE 中间件发布，评估合约管理可视化的集成价值（→ P1-5） |
+| 合约升级模式 | 当前为全量重部署；合约逻辑稳定后评估代理合约（Proxy Pattern）升级模式 |
+
+### 4.3 密码学演进策略
+
+| 策略 | 说明 |
+|------|------|
+| 对称加密（AES-256） | 量子安全，当前无需迁移 |
+| 哈希算法（SHA-256） | 量子安全性充足（128-bit），持续监控 |
+| 密钥交换（RSA/ECDH） | 跟踪 NIST PQC 标准（FIPS 203 ML-KEM），2030 前完成评估 |
+| 国密算法（SM2/SM3/SM4） | SM3/SM4 量子安全；SM2 需跟踪国家 PQC 标准进展 |
+
+### 4.4 存储演进策略
+
+| 策略 | 说明 |
+|------|------|
+| S3 兼容层 | 保持 S3 API 作为统一存储接口，后端实现可替换 |
+| 内容寻址 | 评估 IPFS CID 作为文件标识的可行性（→ P3-1） |
+| 冷热分层 | 评估热数据 S3 + 冷数据 IPFS/Filecoin 的混合架构成本模型（→ P3-1） |
+
+### 4.5 当前技术栈
+
+| 组件 | 当前版本 | 下一目标版本 | 备注 |
+|------|----------|-------------|------|
+| Java | 21 (LTS) | 25 (LTS, 2025-09) | 评估 Virtual Threads 深度采用 |
+| Spring Boot | 3.2.11 | 3.4.x | 跟踪 3.4 LTS |
+| Dubbo | 3.3.6 (Triple) | 3.3.x | 保持 Triple 协议 |
+| Svelte | 5.53.3 | 5.x | Runes API 已稳定 |
+| SvelteKit | 2.52.2 | 2.x | — |
+| MySQL | 8.0 | 8.0 / 9.x | 评估 9.x 新特性 |
+| Redis | 7 | 7.x | — |
+| RabbitMQ | 3 | 3.x / 4.x | 跟踪 4.0 发布 |
+| MinIO (S3) | — | — | 保持 S3 兼容 API |
+| FISCO BCOS | 3.8.0 | 3.x | 跟踪社区发布 |
+
+---
+
+## 附录
+
+### 附录 A：RFC 索引
+
+| RFC 文件 | 状态 | 关联优先级 | 说明 |
+|----------|------|-----------|------|
+| `plan/gate-policy.md` | 活跃 | P0 全量 | 门禁分层策略，定义 PR 阻断 / 发布阻断 / 人工检查分级 |
+| `plan/w4-file-versioning-rfc.md` | 已实现 | P2-1 ✅ | 文件版本治理 MVP 设计（版本链 schema），PR #68 实现 |
+| `plan/w4-file-versioning-migration-draft.sql` | 已废弃 | P2-1 ✅ | 迁移草案，已被正式迁移 `V1.4.0__file_version_chain.sql` 取代 |
+
+### 附录 B：术语表
+
+| 术语 | 全称 | 说明 |
+|------|------|------|
+| PQC | Post-Quantum Cryptography | 后量子密码学，抵御量子计算机攻击的密码算法 |
+| ZKP | Zero-Knowledge Proof | 零知识证明，证明者向验证者证明某个陈述为真而不泄露任何额外信息 |
+| zk-SNARKs | Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge | 简洁非交互式零知识证明，证明小、验证快 |
+| zk-STARKs | Zero-Knowledge Scalable Transparent Arguments of Knowledge | 透明零知识证明，无需可信设置，后量子安全 |
+| OTel | OpenTelemetry | 开源可观测性框架，统一 traces/metrics/logs 采集 |
+| SLO | Service Level Objective | 服务级别目标，如"可用性 ≥ 99.9%" |
+| SLI | Service Level Indicator | 服务级别指标，SLO 的度量数据源 |
+| WeBASE | Web3 App & Blockchain Engine | FISCO BCOS 中间件平台，提供合约管理、交易审计等功能 |
+| Merkle Tree | — | 哈希树，叶节点为数据哈希，父节点为子节点哈希的聚合 |
+| CID | Content Identifier | IPFS 内容标识符，基于文件内容哈希生成的唯一地址 |
+| ML-KEM | Module-Lattice-Based Key-Encapsulation Mechanism | NIST FIPS 203，基于格的密钥封装机制 |
+| ML-DSA | Module-Lattice-Based Digital Signature Algorithm | NIST FIPS 204，基于格的数字签名算法 |
+| OTLP | OpenTelemetry Protocol | OTel 数据传输协议，支持 gRPC 和 HTTP |
+| PDP | Provable Data Possession | 可证数据持有，存储提供者定期证明仍持有完整数据 |
+| MMR | Merkle Mountain Range | 默克尔山脉，支持流式追加的 Merkle 变体结构 |
+| DID | Decentralized Identifier | 分布式标识符，W3C 标准，用户自主控制的去中心化身份 |
+| VC | Verifiable Credential | 可验证凭证，W3C 标准，可独立验证的数字凭证格式 |
+| UCAN | User Controlled Authorization Networks | 用户控制授权网络，基于 JWT 的去中心化授权协议 |
+| F3 | Fast Finality | Filecoin 快速最终性，将确认时间从 ~30 分钟降至 ~5 秒 |
+
+### 附录 C：外部参考项目
+
+| 项目 | 简介 | 关联方向 | 参考价值 |
+|------|------|---------|---------|
+| [OpenTimestamps](https://opentimestamps.org/) | 比特币区块链时间戳锚定，Calendar Server 批量聚合 | P2-5 | Merkle 聚合模式、日均处理量参考 |
+| [OpenAttestation](https://www.openattestation.com/) | 新加坡政府使用的文档存证框架，Merkle Root 批量存证 | P2-5 | 批量存证 SDK 设计、政府级部署案例 |
+| [evidenceSample](https://github.com/FISCO-BCOS/evidenceSample) | FISCO BCOS 官方存证合约示例，工厂模式创建存证 | P2-8 | 多方签名合约模式、FISCO 合约最佳实践 |
+| [WeBASE](https://github.com/WeBankBlockchain/WeBASE) | 微众银行区块链中间件平台，合约管理 + 交易审计 | P1-5 | 合约生命周期管理、可视化运维 |
+| [WeIdentity](https://github.com/WeBankBlockchain/WeIdentity) | FISCO BCOS 上的 DID + VC 全栈实现 | P3-4 | DID 注册、VC 签发验证、可复用 FISCO 基础设施 |
+| [Storacha](https://storacha.network/) | 原 web3.storage，UCAN 授权 + IPFS 热存储网关 | P3-1 | S3 兼容 API → IPFS CID 过渡方案 |
+| 至信链 | 腾讯联合多家法院建设的司法联盟链，31 省 300+ 法院互认 | P3-3 | 司法互认通道、电子证据采信标准 |
+| 长安链 | 国家级区块链基础设施，10 万+ TPS，SPV 轻节点跨链 | P3-3 | 高性能共识参考、跨链验证方案 |

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -1,0 +1,138 @@
+# ==============================================================================
+# RecordPlatform Infrastructure Services
+# ==============================================================================
+#
+# Usage:
+#   cp .env.example .env   # edit credentials as needed
+#   docker compose -f docker-compose.infra.yml up -d
+#   docker compose -f docker-compose.infra.yml up -d --wait  # wait for healthy
+#
+# Included: Nacos, MySQL, Redis, RabbitMQ, MinIO (x2)
+# NOT included: FISCO BCOS (requires native node setup, see docs)
+#
+# ==============================================================================
+
+services:
+  nacos:
+    image: nacos/nacos-server:v2.3.0
+    container_name: nacos
+    ports:
+      - "8848:8848"
+      - "9848:9848"
+    environment:
+      - MODE=standalone
+      - NACOS_AUTH_ENABLE=true
+      - NACOS_AUTH_TOKEN=${NACOS_AUTH_TOKEN:-c2VjcmV0VG9rZW5Gb3JSZWNvcmRQbGF0Zm9ybQ==}
+      - NACOS_AUTH_IDENTITY_KEY=serverIdentity
+      - NACOS_AUTH_IDENTITY_VALUE=security
+    volumes:
+      - nacos_data:/home/nacos/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8848/nacos/v1/console/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD:-recordplatform}
+      - MYSQL_DATABASE=RecordPlatform
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${DB_PASSWORD:-recordplatform}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: redis-server --requirepass ${REDIS_PASSWORD:-redis123}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis123}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "${RABBITMQ_PORT:-5672}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT:-15672}:15672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_USERNAME:-rabbitmq}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD:-rabbitmq}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  minio-a:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    container_name: minio-a
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=${S3_ACCESS_KEY:-minioadmin}
+      - MINIO_ROOT_PASSWORD=${S3_SECRET_KEY:-minioadmin}
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_a_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  minio-b:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    container_name: minio-b
+    ports:
+      - "9010:9000"
+      - "9011:9001"
+    environment:
+      - MINIO_ROOT_USER=${S3_ACCESS_KEY:-minioadmin}
+      - MINIO_ROOT_PASSWORD=${S3_SECRET_KEY:-minioadmin}
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_b_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  nacos_data:
+  mysql_data:
+  redis_data:
+  rabbitmq_data:
+  minio_a_data:
+  minio_b_data:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -91,6 +91,10 @@ export default withMermaid(
                 items: [
                   { text: "Overview", link: "/en/deployment/" },
                   {
+                    text: "Environment Setup",
+                    link: "/en/deployment/environment-setup",
+                  },
+                  {
                     text: "Docker Compose",
                     link: "/en/deployment/docker-compose",
                   },
@@ -204,6 +208,10 @@ export default withMermaid(
                 collapsed: false,
                 items: [
                   { text: "概述", link: "/zh/deployment/" },
+                  {
+                    text: "环境搭建",
+                    link: "/zh/deployment/environment-setup",
+                  },
                   {
                     text: "Docker Compose",
                     link: "/zh/deployment/docker-compose",

--- a/docs/en/deployment/environment-setup.md
+++ b/docs/en/deployment/environment-setup.md
@@ -1,0 +1,230 @@
+# Environment Setup
+
+Complete environment setup guide for RecordPlatform from scratch.
+
+## Prerequisites
+
+### Host Requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU | 4 cores | 8 cores |
+| Memory | 8 GB | 16 GB |
+| Disk | 40 GB | 100 GB SSD |
+| OS | Ubuntu 20.04+ / CentOS 8+ / macOS 12+ | Ubuntu 22.04 LTS |
+
+### Software Requirements
+
+| Software | Version | Purpose |
+|----------|---------|---------|
+| Docker | 20.10+ | Infrastructure containerization |
+| Docker Compose | 2.0+ | Container orchestration |
+| Java | 21 (LTS) | Backend services |
+| Maven | 3.8+ | Java build |
+| Node.js | 20+ | Frontend build |
+| pnpm | 10+ | Frontend package manager |
+| Git | 2.30+ | Version control |
+
+## Step 1: Configure Environment Variables
+
+```bash
+# Clone the repository
+git clone https://github.com/SoarCollab/RecordPlatform.git
+cd RecordPlatform
+
+# Copy the environment template
+cp .env.example .env
+```
+
+Edit `.env` and update key settings:
+
+```bash
+# Must change
+JWT_KEY=<random-string-at-least-32-chars>
+DB_PASSWORD=<database-password>
+REDIS_PASSWORD=<redis-password>
+S3_ACCESS_KEY=<minio-access-key>
+S3_SECRET_KEY=<minio-secret-key>
+
+# Optional: adjust for your environment
+SPRING_PROFILES_ACTIVE=local   # local / dev / prod
+```
+
+::: tip
+For development, the default values in `.env.example` work out of the box.
+:::
+
+## Step 2: Start Infrastructure
+
+Use `docker-compose.infra.yml` to start all containerizable infrastructure:
+
+```bash
+# Start all infrastructure services
+docker compose -f docker-compose.infra.yml up -d
+
+# Wait until all services are healthy
+docker compose -f docker-compose.infra.yml up -d --wait
+```
+
+Included services:
+
+| Service | Port | Management UI |
+|---------|------|---------------|
+| Nacos | 8848 | http://localhost:8848/nacos |
+| MySQL | 3306 | — |
+| Redis | 6379 | — |
+| RabbitMQ | 5672 | http://localhost:15672 |
+| MinIO-A | 9000 | http://localhost:9001 |
+| MinIO-B | 9010 | http://localhost:9011 |
+
+Verify status:
+
+```bash
+docker compose -f docker-compose.infra.yml ps
+```
+
+## Step 3: Configure Nacos
+
+Nacos serves as the configuration center. Application configs must be imported.
+
+1. Open Nacos console: http://localhost:8848/nacos (default: nacos/nacos)
+2. Create configurations:
+
+| Data ID | Group | Description |
+|---------|-------|-------------|
+| `backend-web.yaml` | DEFAULT_GROUP | Backend main config (DB, Redis, RabbitMQ connections) |
+| `platform-storage.yaml` | DEFAULT_GROUP | Storage service config (S3 node list, encryption params) |
+
+::: warning Important
+Sensitive credentials (DB password, Redis password, etc.) are stored in Nacos configurations, not in `.env`. The infrastructure credentials in `.env` are only used by docker-compose. `platform-fisco` reads blockchain node and contract settings from `.env` (`FISCO_*`), not from a Nacos Data ID.
+:::
+
+## Step 4: FISCO BCOS Node
+
+The FISCO BCOS blockchain node **cannot be started via docker-compose** and requires manual deployment on the server.
+
+### Quick Setup (Single Group, 4 Nodes)
+
+```bash
+# Download build_chain script
+curl -#LO https://github.com/FISCO-BCOS/FISCO-BCOS/releases/download/v3.8.0/build_chain.sh
+chmod +x build_chain.sh
+
+# Generate 4-node chain (Air version)
+bash build_chain.sh -l 127.0.0.1:4 -p 30300,20200
+
+# Start all nodes
+bash nodes/127.0.0.1/start_all.sh
+```
+
+### Copy SDK Certificates
+
+```bash
+# Copy certificates to the FISCO service resource directory
+cp nodes/127.0.0.1/sdk/* platform-fisco/src/main/resources/conf/
+```
+
+### Deploy Smart Contracts
+
+Deploy `Storage.sol` and `Sharing.sol` using the FISCO BCOS console:
+
+```bash
+# Download and start the console
+# See: https://fisco-bcos-doc.readthedocs.io/zh-cn/latest/docs/quick_start/air_installation.html
+
+# After deployment, update contract addresses in .env
+FISCO_STORAGE_CONTRACT=0x<deployed-address>
+FISCO_SHARING_CONTRACT=0x<deployed-address>
+```
+
+::: info
+For detailed node setup and contract deployment, see the [FISCO BCOS Documentation](https://fisco-bcos-doc.readthedocs.io/zh-cn/latest/).
+:::
+
+## Step 5: Verify Environment
+
+Run the environment pre-check script to validate all infrastructure at once:
+
+```bash
+./scripts/env-check.sh
+```
+
+The script checks 8 items:
+
+| # | Check | Validates |
+|---|-------|-----------|
+| 1 | Nacos | Connectivity + config existence |
+| 2 | MySQL | Connection + database existence |
+| 3 | Redis | Authentication + PING |
+| 4 | RabbitMQ | AMQP port + management API |
+| 5 | FISCO BCOS | Node port connectivity |
+| 6 | S3/MinIO | Health check + bucket existence |
+| 7 | TLS Certificates | File existence + expiry |
+| 8 | Contract Addresses | Format validation |
+
+Auto-fix mode (creates database, buckets, etc.):
+
+```bash
+./scripts/env-check.sh --fix
+```
+
+Check a single service:
+
+```bash
+./scripts/env-check.sh --service mysql
+```
+
+## Step 6: Build and Start
+
+### Build
+
+```bash
+# 1. Install shared interfaces (first time or when dependencies change)
+mvn -f platform-api/pom.xml clean install
+
+# 2. Build backend
+mvn -f platform-backend/pom.xml clean package -DskipTests
+
+# 3. Build FISCO service
+mvn -f platform-fisco/pom.xml clean package -DskipTests
+
+# 4. Build storage service
+mvn -f platform-storage/pom.xml clean package -DskipTests
+
+# 5. Frontend
+cd platform-frontend && pnpm install && pnpm build
+```
+
+### Start
+
+```bash
+# Start all services with the management script
+./scripts/start.sh start all
+
+# Check service status
+./scripts/start.sh status
+```
+
+Startup order: `platform-storage` → `platform-fisco` → `platform-backend` → frontend
+
+### Verify
+
+```bash
+# Backend health check
+curl http://localhost:8000/record-platform/actuator/health
+
+# Frontend dev server
+cd platform-frontend && pnpm dev
+```
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Nacos fails to start | Insufficient memory | Ensure Docker has ≥ 4GB memory allocated |
+| MySQL connection refused | Container not ready | `docker compose -f docker-compose.infra.yml up -d --wait` |
+| Redis AUTH failed | Password mismatch | Check `REDIS_PASSWORD` in `.env` matches Nacos config |
+| FISCO service hangs on startup | Node unreachable | `SdkBeanConfig` connects on init — ensure node is running |
+| MinIO inaccessible | Port conflict | Check if ports 9000/9001 are already in use |
+| Dubbo service discovery fails | Wrong DUBBO_HOST | Set `DUBBO_HOST` to host IP in Docker environments |
+| env-check.sh deep checks skipped | CLI tools missing | Install `mysql-client`, `redis-cli`, `aws`, etc. |

--- a/docs/en/deployment/index.md
+++ b/docs/en/deployment/index.md
@@ -4,6 +4,7 @@ Deployment and operations guide for RecordPlatform.
 
 ## Contents
 
+- [Environment Setup](environment-setup) - Complete environment setup from scratch
 - [Docker Compose](docker-compose) - Container-based deployment
 - [Production](production.md) - Production environment setup
 - [Monitoring](monitoring) - Metrics, alerts, and health checks

--- a/docs/zh/deployment/environment-setup.md
+++ b/docs/zh/deployment/environment-setup.md
@@ -1,0 +1,230 @@
+# 环境搭建
+
+从零搭建 RecordPlatform 完整运行环境。
+
+## 前置条件
+
+### 主机要求
+
+| 资源 | 最低配置 | 推荐配置 |
+|------|----------|----------|
+| CPU | 4 核 | 8 核 |
+| 内存 | 8 GB | 16 GB |
+| 磁盘 | 40 GB | 100 GB SSD |
+| 操作系统 | Ubuntu 20.04+ / CentOS 8+ / macOS 12+ | Ubuntu 22.04 LTS |
+
+### 软件要求
+
+| 软件 | 版本 | 用途 |
+|------|------|------|
+| Docker | 20.10+ | 基础设施容器化 |
+| Docker Compose | 2.0+ | 容器编排 |
+| Java | 21 (LTS) | 后端服务 |
+| Maven | 3.8+ | Java 构建 |
+| Node.js | 20+ | 前端构建 |
+| pnpm | 10+ | 前端包管理 |
+| Git | 2.30+ | 版本控制 |
+
+## 步骤 1：配置环境变量
+
+```bash
+# 克隆仓库
+git clone https://github.com/SoarCollab/RecordPlatform.git
+cd RecordPlatform
+
+# 复制环境变量模板
+cp .env.example .env
+```
+
+编辑 `.env`，修改关键配置：
+
+```bash
+# 必须修改的配置
+JWT_KEY=<生成32字符以上随机字符串>
+DB_PASSWORD=<数据库密码>
+REDIS_PASSWORD=<Redis密码>
+S3_ACCESS_KEY=<MinIO访问密钥>
+S3_SECRET_KEY=<MinIO密钥>
+
+# 可选：根据部署环境调整
+SPRING_PROFILES_ACTIVE=local   # local / dev / prod
+```
+
+::: tip
+开发环境可直接使用 `.env.example` 中的默认值快速启动。
+:::
+
+## 步骤 2：启动基础设施
+
+使用 `docker-compose.infra.yml` 一键启动可容器化的基础服务：
+
+```bash
+# 启动所有基础设施
+docker compose -f docker-compose.infra.yml up -d
+
+# 等待所有服务健康就绪（需要 healthcheck 支持）
+docker compose -f docker-compose.infra.yml up -d --wait
+```
+
+包含的服务：
+
+| 服务 | 端口 | 管理界面 |
+|------|------|----------|
+| Nacos | 8848 | http://localhost:8848/nacos |
+| MySQL | 3306 | — |
+| Redis | 6379 | — |
+| RabbitMQ | 5672 | http://localhost:15672 |
+| MinIO-A | 9000 | http://localhost:9001 |
+| MinIO-B | 9010 | http://localhost:9011 |
+
+验证启动状态：
+
+```bash
+docker compose -f docker-compose.infra.yml ps
+```
+
+## 步骤 3：配置 Nacos
+
+Nacos 作为配置中心，需要导入应用配置。
+
+1. 登录 Nacos 控制台：http://localhost:8848/nacos（默认 nacos/nacos）
+2. 创建配置：
+
+| Data ID | Group | 说明 |
+|---------|-------|------|
+| `backend-web.yaml` | DEFAULT_GROUP | 后端主配置（数据库、Redis、RabbitMQ 连接信息） |
+| `platform-storage.yaml` | DEFAULT_GROUP | 存储服务配置（S3 节点列表、加密参数） |
+
+::: warning 重要
+数据库密码、Redis 密码等敏感信息存储在 Nacos 配置中，而非 `.env` 文件。`.env` 中的基础设施凭据仅供 docker-compose 使用。`platform-fisco` 的区块链节点与合约地址配置来自 `.env` 中的 `FISCO_*` 变量，而不是 Nacos Data ID。
+:::
+
+## 步骤 4：FISCO BCOS 节点
+
+FISCO BCOS 区块链节点**无法通过 docker-compose 启动**，需要在服务器上手动部署。
+
+### 快速搭建（单群组 4 节点）
+
+```bash
+# 下载 build_chain 脚本
+curl -#LO https://github.com/FISCO-BCOS/FISCO-BCOS/releases/download/v3.8.0/build_chain.sh
+chmod +x build_chain.sh
+
+# 生成 4 节点链（Air 版）
+bash build_chain.sh -l 127.0.0.1:4 -p 30300,20200
+
+# 启动所有节点
+bash nodes/127.0.0.1/start_all.sh
+```
+
+### 复制 SDK 证书
+
+```bash
+# 将证书复制到 FISCO 服务的资源目录
+cp nodes/127.0.0.1/sdk/* platform-fisco/src/main/resources/conf/
+```
+
+### 部署智能合约
+
+使用 FISCO BCOS 控制台部署 `Storage.sol` 和 `Sharing.sol`：
+
+```bash
+# 下载并启动控制台
+# 参考：https://fisco-bcos-doc.readthedocs.io/zh-cn/latest/docs/quick_start/air_installation.html
+
+# 部署合约后，将合约地址更新到 .env
+FISCO_STORAGE_CONTRACT=0x<部署后的地址>
+FISCO_SHARING_CONTRACT=0x<部署后的地址>
+```
+
+::: info
+详细的节点搭建和合约部署流程请参考 [FISCO BCOS 官方文档](https://fisco-bcos-doc.readthedocs.io/zh-cn/latest/)。
+:::
+
+## 步骤 5：环境验证
+
+运行环境预检脚本，一次性验证所有基础设施：
+
+```bash
+./scripts/env-check.sh
+```
+
+脚本检查 8 项内容：
+
+| # | 检查项 | 验证内容 |
+|---|--------|----------|
+| 1 | Nacos | 连通性 + 配置存在性 |
+| 2 | MySQL | 连接 + 数据库存在 |
+| 3 | Redis | 认证 + PING |
+| 4 | RabbitMQ | AMQP 端口 + 管理 API |
+| 5 | FISCO BCOS | 节点端口连通 |
+| 6 | S3/MinIO | 健康检查 + Bucket 存在 |
+| 7 | TLS 证书 | 文件存在 + 有效期 |
+| 8 | 合约地址 | 格式校验 |
+
+自动修复模式（创建数据库、Bucket 等）：
+
+```bash
+./scripts/env-check.sh --fix
+```
+
+检查单个服务：
+
+```bash
+./scripts/env-check.sh --service mysql
+```
+
+## 步骤 6：构建与启动
+
+### 构建
+
+```bash
+# 1. 安装共享接口（首次或依赖变更时）
+mvn -f platform-api/pom.xml clean install
+
+# 2. 构建后端
+mvn -f platform-backend/pom.xml clean package -DskipTests
+
+# 3. 构建 FISCO 服务
+mvn -f platform-fisco/pom.xml clean package -DskipTests
+
+# 4. 构建存储服务
+mvn -f platform-storage/pom.xml clean package -DskipTests
+
+# 5. 前端
+cd platform-frontend && pnpm install && pnpm build
+```
+
+### 启动
+
+```bash
+# 使用管理脚本一键启动所有服务
+./scripts/start.sh start all
+
+# 查看服务状态
+./scripts/start.sh status
+```
+
+启动顺序：`platform-storage` → `platform-fisco` → `platform-backend` → 前端
+
+### 验证
+
+```bash
+# 后端健康检查
+curl http://localhost:8000/record-platform/actuator/health
+
+# 前端开发服务器
+cd platform-frontend && pnpm dev
+```
+
+## 故障排查
+
+| 问题 | 原因 | 解决方案 |
+|------|------|----------|
+| Nacos 启动失败 | 内存不足 | 确保 Docker 分配 ≥ 4GB 内存 |
+| MySQL 连接拒绝 | 容器未就绪 | `docker compose -f docker-compose.infra.yml up -d --wait` |
+| Redis AUTH 失败 | 密码不匹配 | 检查 `.env` 中 `REDIS_PASSWORD` 与 Nacos 配置一致 |
+| FISCO 服务启动卡住 | 节点不可达 | `SdkBeanConfig` 初始化时连接节点，确保节点已启动 |
+| MinIO 无法访问 | 端口冲突 | 检查 9000/9001 端口是否被占用 |
+| Dubbo 服务发现失败 | DUBBO_HOST 配置错误 | Docker 环境需设置 `DUBBO_HOST` 为宿主机 IP |
+| env-check.sh 深度检查跳过 | CLI 工具未安装 | 安装 `mysql-client`、`redis-cli`、`aws` 等工具 |

--- a/docs/zh/deployment/index.md
+++ b/docs/zh/deployment/index.md
@@ -4,6 +4,7 @@ RecordPlatform 部署和运维指南。
 
 ## 目录
 
+- [环境搭建](environment-setup) - 从零搭建完整运行环境
 - [Docker Compose](docker-compose) - 容器化部署
 - [生产环境](production) - 生产环境配置
 - [监控告警](monitoring) - 指标、告警和健康检查

--- a/scripts/env-check.sh
+++ b/scripts/env-check.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# RecordPlatform Environment Pre-Check Script
+# ==============================================================================
+#
+# Usage:
+#   ./scripts/env-check.sh              # check all services
+#   ./scripts/env-check.sh --fix        # auto-fix where possible
+#   ./scripts/env-check.sh --service mysql  # check single service
+#
+# Exit codes:
+#   0 = all checks passed
+#   1 = one or more checks failed
+#
+# ==============================================================================
+
+set -uo pipefail
+
+# Load environment.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Load environment variables from .env without executing shell expressions.
+load_env_file() {
+    local env_file="$1"
+    [ -f "$env_file" ] || return 0
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+
+        # Skip empty lines and full-line comments.
+        [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+        if [[ "$line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z_0-9]*)=(.*)$ ]]; then
+            local key="${BASH_REMATCH[1]}"
+            local value="${BASH_REMATCH[2]}"
+
+            # Trim leading whitespace in value.
+            value="${value#"${value%%[![:space:]]*}"}"
+
+            # Parse quoted values first, allowing optional trailing inline comments.
+            if [[ "$value" =~ ^\"(.*)\"[[:space:]]*(#.*)?$ ]]; then
+                value="${BASH_REMATCH[1]}"
+            elif [[ "$value" =~ ^\'(.*)\'[[:space:]]*(#.*)?$ ]]; then
+                value="${BASH_REMATCH[1]}"
+            else
+                # Drop trailing inline comments for unquoted values.
+                value="${value%%[[:space:]]#*}"
+                # Trim trailing whitespace in value.
+                value="${value%"${value##*[![:space:]]}"}"
+            fi
+
+            export "${key}=${value}"
+        fi
+    done < "$env_file"
+}
+
+# Load .env safely (treat content as data, never execute).
+load_env_file "$PROJECT_ROOT/.env"
+
+# Enable errexit after environment loading
+set -e
+
+# ==============================================================================
+# Color & formatting
+# ==============================================================================
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ] && command -v tput &>/dev/null; then
+    GREEN=$(tput setaf 2)
+    RED=$(tput setaf 1)
+    YELLOW=$(tput setaf 3)
+    CYAN=$(tput setaf 6)
+    BOLD=$(tput bold)
+    RESET=$(tput sgr0)
+else
+    GREEN="" RED="" YELLOW="" CYAN="" BOLD="" RESET=""
+fi
+
+ok()   { echo "  ${GREEN}[OK]${RESET}   $1"; }
+fail() { echo "  ${RED}[FAIL]${RESET} $1"; FAILURES=$((FAILURES + 1)); }
+warn() { echo "  ${YELLOW}[WARN]${RESET} $1"; WARNINGS=$((WARNINGS + 1)); }
+info() { echo "  ${CYAN}[INFO]${RESET} $1"; }
+section() { echo; echo "${BOLD}[$1/$TOTAL_CHECKS] $2${RESET}"; }
+
+FAILURES=0
+WARNINGS=0
+TOTAL_CHECKS=8
+
+# ==============================================================================
+# Parse arguments
+# ==============================================================================
+FIX_MODE=false
+TARGET_SERVICE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fix) FIX_MODE=true; shift ;;
+        --service)
+            if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo "Option --service requires a service name"
+                echo "Services: nacos, mysql, redis, rabbitmq, fisco, s3, certs, contracts"
+                exit 1
+            fi
+            TARGET_SERVICE="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--fix] [--service NAME]"
+            echo ""
+            echo "Services: nacos, mysql, redis, rabbitmq, fisco, s3, certs, contracts"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ==============================================================================
+# Connectivity helpers
+# ==============================================================================
+
+# TCP port check with fallback: bash /dev/tcp -> nc -z
+tcp_check() {
+    local host="$1" port="$2" timeout="${3:-3}"
+    if (echo >/dev/tcp/"$host"/"$port") 2>/dev/null; then
+        return 0
+    elif command -v nc &>/dev/null; then
+        nc -z -w "$timeout" "$host" "$port" 2>/dev/null
+        return $?
+    else
+        return 1
+    fi
+}
+
+# Check if a CLI tool is available
+has_cmd() { command -v "$1" &>/dev/null; }
+
+# ==============================================================================
+# 1. Nacos
+# ==============================================================================
+check_nacos() {
+    local host="${NACOS_HOST:-localhost}"
+    local port="${NACOS_PORT:-8848}"
+
+    section 1 "Nacos ($host:$port)"
+
+    # Connectivity
+    if curl -sf --max-time 5 "http://$host:$port/nacos/v1/console/health/readiness" &>/dev/null; then
+        ok "Nacos is reachable and ready"
+    elif tcp_check "$host" "$port"; then
+        warn "Nacos port open but readiness endpoint failed"
+    else
+        fail "Cannot connect to Nacos at $host:$port"
+        info "Start with: docker compose -f docker-compose.infra.yml up -d nacos"
+        return
+    fi
+
+    # Deep check: login API
+    local user="${NACOS_USERNAME:-nacos}"
+    local pass="${NACOS_PASSWORD:-nacos}"
+    local token
+    token=$(curl -sf --max-time 5 -X POST \
+        "http://$host:$port/nacos/v1/auth/login" \
+        --data-urlencode "username=$user" \
+        --data-urlencode "password=$pass" 2>/dev/null | grep -o '"accessToken":"[^"]*"' | cut -d'"' -f4 || true)
+
+    if [ -n "$token" ]; then
+        ok "Nacos login successful (user: $user)"
+
+        # Check key config Data IDs
+        for data_id in "backend-web.yaml" "platform-storage.yaml"; do
+            local resp
+            # Keep pre-check running even if a single Nacos query fails.
+            resp=$(curl -sf --max-time 5 \
+                "http://$host:$port/nacos/v1/cs/configs?dataId=$data_id&group=DEFAULT_GROUP&accessToken=$token" 2>/dev/null || true)
+            if [ -n "$resp" ] && [ "$resp" != "config data not exist" ]; then
+                ok "Config found: $data_id"
+            else
+                warn "Config not found: $data_id"
+                info "Import Nacos configs from nacos-config-template.yaml"
+            fi
+        done
+    else
+        warn "Nacos login failed (user: $user) - auth may be disabled or credentials wrong"
+    fi
+}
+
+# ==============================================================================
+# 2. MySQL
+# ==============================================================================
+check_mysql() {
+    local host="${MYSQL_HOST:-127.0.0.1}"
+    local port="${MYSQL_PORT:-3306}"
+    local password="${DB_PASSWORD:-recordplatform}"
+
+    section 2 "MySQL ($host:$port)"
+
+    if has_cmd mysql; then
+        if mysql -h "$host" -P "$port" -uroot -p"$password" -e "SELECT 1" &>/dev/null; then
+            ok "MySQL connection successful"
+
+            # Check database exists
+            if mysql -h "$host" -P "$port" -uroot -p"$password" -e "USE RecordPlatform" &>/dev/null; then
+                ok "Database 'RecordPlatform' exists"
+            else
+                fail "Database 'RecordPlatform' does not exist"
+                if [ "$FIX_MODE" = true ]; then
+                    info "Creating database..."
+                    if mysql -h "$host" -P "$port" -uroot -p"$password" \
+                        -e "CREATE DATABASE IF NOT EXISTS RecordPlatform CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" &>/dev/null; then
+                        ok "Database 'RecordPlatform' created"
+                        FAILURES=$((FAILURES - 1))
+                    else
+                        fail "Failed to create database"
+                    fi
+                else
+                    info "Run with --fix to auto-create, or manually:"
+                    info "  CREATE DATABASE RecordPlatform CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+                fi
+            fi
+        else
+            fail "MySQL authentication failed"
+            info "Check DB_PASSWORD in .env (current: ****)"
+        fi
+    elif tcp_check "$host" "$port"; then
+        ok "MySQL port is open"
+        warn "mysql CLI not installed - deep check skipped"
+        info "Install: brew install mysql-client (macOS) / apt install mysql-client (Linux)"
+    else
+        fail "Cannot connect to MySQL at $host:$port"
+        info "Start with: docker compose -f docker-compose.infra.yml up -d mysql"
+    fi
+}
+
+# ==============================================================================
+# 3. Redis
+# ==============================================================================
+check_redis() {
+    local host="${REDIS_HOST:-localhost}"
+    local port="${REDIS_PORT:-6379}"
+    local password="${REDIS_PASSWORD:-redis123}"
+
+    section 3 "Redis ($host:$port)"
+
+    if has_cmd redis-cli; then
+        local pong
+        local redis_exit_code=0
+        pong=$(redis-cli -h "$host" -p "$port" -a "$password" --no-auth-warning PING 2>/dev/null) || redis_exit_code=$?
+        if [ "$redis_exit_code" -eq 0 ] && [ "$pong" = "PONG" ]; then
+            ok "Redis PING -> PONG (authenticated)"
+        else
+            fail "Redis PING failed (got: ${pong:-empty})"
+            info "Check REDIS_PASSWORD in .env"
+        fi
+    elif tcp_check "$host" "$port"; then
+        ok "Redis port is open"
+        warn "redis-cli not installed - deep check skipped"
+        info "Install: brew install redis (macOS) / apt install redis-tools (Linux)"
+    else
+        fail "Cannot connect to Redis at $host:$port"
+        info "Start with: docker compose -f docker-compose.infra.yml up -d redis"
+    fi
+}
+
+# ==============================================================================
+# 4. RabbitMQ
+# ==============================================================================
+check_rabbitmq() {
+    local host="${RABBITMQ_HOST:-localhost}"
+    local port="${RABBITMQ_PORT:-5672}"
+    local mgmt_port="${RABBITMQ_MANAGEMENT_PORT:-15672}"
+    local user="${RABBITMQ_USERNAME:-rabbitmq}"
+    local pass="${RABBITMQ_PASSWORD:-rabbitmq}"
+
+    section 4 "RabbitMQ ($host:$port)"
+
+    # AMQP port
+    if tcp_check "$host" "$port"; then
+        ok "RabbitMQ AMQP port is open"
+    else
+        fail "Cannot connect to RabbitMQ at $host:$port"
+        info "Start with: docker compose -f docker-compose.infra.yml up -d rabbitmq"
+        return
+    fi
+
+    # Management API
+    local resp
+    resp=$(curl -sf --max-time 5 -u "$user:$pass" "http://$host:$mgmt_port/api/overview" 2>/dev/null || true)
+    if [ -n "$resp" ]; then
+        local version
+        version=$(echo "$resp" | grep -o '"rabbitmq_version":"[^"]*"' | cut -d'"' -f4)
+        ok "Management API accessible (version: ${version:-unknown})"
+    else
+        warn "Management API not accessible at :$mgmt_port (AMQP is fine)"
+        info "Management plugin may not be enabled, or credentials are wrong"
+    fi
+}
+
+# ==============================================================================
+# 5. FISCO BCOS
+# ==============================================================================
+check_fisco() {
+    local peer="${FISCO_PEER_ADDRESS:-127.0.0.1:20200}"
+    local host="${peer%%:*}"
+    local port="${peer##*:}"
+
+    section 5 "FISCO BCOS ($host:$port)"
+
+    if tcp_check "$host" "$port"; then
+        ok "FISCO BCOS node is reachable"
+    else
+        fail "Cannot connect to FISCO BCOS at $host:$port"
+        info "FISCO BCOS cannot be started via docker-compose."
+        info "Follow the official setup guide:"
+        info "  https://fisco-bcos-doc.readthedocs.io/zh-cn/latest/docs/quick_start/air_installation.html"
+        info "Key steps: build_chain.sh -> start nodes -> copy SDK certs"
+    fi
+}
+
+# ==============================================================================
+# 6. S3 / MinIO
+# ==============================================================================
+check_s3() {
+    local endpoint="${S3_ENDPOINT:-http://localhost:9000}"
+    local access_key="${S3_ACCESS_KEY:-minioadmin}"
+    local secret_key="${S3_SECRET_KEY:-minioadmin}"
+    local bucket="${S3_BUCKET_NAME:-forum}"
+
+    section 6 "S3/MinIO ($endpoint)"
+
+    # Health check
+    if curl -sf --max-time 5 "$endpoint/minio/health/live" &>/dev/null; then
+        ok "MinIO health endpoint is live"
+    else
+        local endpoint_status="000"
+        # Root path on S3-compatible services often returns 403/405 when reachable.
+        endpoint_status=$(curl -sS -o /dev/null --max-time 5 -w "%{http_code}" "$endpoint" || true)
+        if [ "$endpoint_status" != "000" ]; then
+            ok "S3 endpoint is reachable (HTTP $endpoint_status)"
+        else
+            fail "Cannot reach S3 endpoint at $endpoint"
+            info "Start with: docker compose -f docker-compose.infra.yml up -d minio-a minio-b"
+            return
+        fi
+    fi
+
+    # Check bucket
+    local bucket_found=false
+    local mc_alias="envcheck_${$}"
+    if has_cmd aws; then
+        if AWS_ACCESS_KEY_ID="$access_key" AWS_SECRET_ACCESS_KEY="$secret_key" \
+            aws --endpoint-url "$endpoint" s3 ls "s3://$bucket" &>/dev/null; then
+            bucket_found=true
+        fi
+    elif has_cmd mc; then
+        if mc alias set "$mc_alias" "$endpoint" "$access_key" "$secret_key" &>/dev/null; then
+            if mc ls "$mc_alias/$bucket" &>/dev/null; then
+                bucket_found=true
+            fi
+        else
+            warn "Failed to configure mc alias for endpoint"
+        fi
+        mc alias rm "$mc_alias" &>/dev/null 2>&1 || true
+    else
+        warn "Neither aws CLI nor mc installed - bucket check skipped"
+        info "Install: brew install awscli (macOS) / pip install awscli"
+        return
+    fi
+
+    if [ "$bucket_found" = true ]; then
+        ok "Bucket '$bucket' exists"
+    else
+        fail "Bucket '$bucket' not found"
+        if [ "$FIX_MODE" = true ]; then
+            info "Creating bucket '$bucket'..."
+            local created=false
+            if has_cmd aws; then
+                if AWS_ACCESS_KEY_ID="$access_key" AWS_SECRET_ACCESS_KEY="$secret_key" \
+                    aws --endpoint-url "$endpoint" s3 mb "s3://$bucket" &>/dev/null; then
+                    created=true
+                fi
+            elif has_cmd mc; then
+                if mc alias set "$mc_alias" "$endpoint" "$access_key" "$secret_key" &>/dev/null; then
+                    if mc mb "$mc_alias/$bucket" &>/dev/null; then
+                        created=true
+                    fi
+                else
+                    warn "Failed to configure mc alias for endpoint"
+                fi
+                mc alias rm "$mc_alias" &>/dev/null 2>&1 || true
+            fi
+            if [ "$created" = true ]; then
+                ok "Bucket '$bucket' created"
+                FAILURES=$((FAILURES - 1))
+            else
+                fail "Failed to create bucket"
+            fi
+        else
+            info "Run with --fix to auto-create, or manually:"
+            info "  aws --endpoint-url $endpoint s3 mb s3://$bucket"
+        fi
+    fi
+}
+
+# ==============================================================================
+# 7. FISCO TLS Certificates
+# ==============================================================================
+check_certs() {
+    local cert_path="${FISCO_CERT_PATH:-conf}"
+    # Resolve relative path from project root
+    if [[ "$cert_path" != /* ]]; then
+        cert_path="$PROJECT_ROOT/platform-fisco/src/main/resources/$cert_path"
+    fi
+
+    section 7 "FISCO TLS Certificates ($cert_path)"
+
+    local all_found=true
+    for cert_file in ca.crt sdk.crt sdk.key; do
+        if [ -f "$cert_path/$cert_file" ]; then
+            ok "Found: $cert_file"
+            # Check expiry for .crt files
+            if [[ "$cert_file" == *.crt ]] && has_cmd openssl; then
+                if openssl x509 -checkend 2592000 -noout -in "$cert_path/$cert_file" &>/dev/null; then
+                    ok "  $cert_file valid for > 30 days"
+                else
+                    warn "$cert_file expires within 30 days or is already expired"
+                fi
+            fi
+        else
+            fail "Missing: $cert_path/$cert_file"
+            all_found=false
+        fi
+    done
+
+    if [ "$all_found" = false ]; then
+        info "Copy SDK certificates from FISCO BCOS node:"
+        info "  cp nodes/127.0.0.1/sdk/* $cert_path/"
+    fi
+}
+
+# ==============================================================================
+# 8. Contract Addresses
+# ==============================================================================
+check_contracts() {
+    section 8 "Smart Contract Addresses"
+
+    local storage_addr="${FISCO_STORAGE_CONTRACT:-}"
+    local sharing_addr="${FISCO_SHARING_CONTRACT:-}"
+
+    for name_addr in "Storage:$storage_addr" "Sharing:$sharing_addr"; do
+        local name="${name_addr%%:*}"
+        local addr="${name_addr##*:}"
+
+        if [ -z "$addr" ]; then
+            local env_key
+            env_key=$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]')
+            fail "$name contract address is empty (FISCO_${env_key}_CONTRACT)"
+            info "Deploy contracts first, then set address in .env"
+        elif [[ "$addr" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+            ok "$name contract: ${addr:0:10}...${addr: -4}"
+        else
+            fail "$name contract address invalid: $addr (expected 0x + 40 hex chars)"
+        fi
+    done
+}
+
+# ==============================================================================
+# Main
+# ==============================================================================
+
+echo "${BOLD}RecordPlatform Environment Check${RESET}"
+echo "Project root: $PROJECT_ROOT"
+echo "Fix mode: $FIX_MODE"
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    ok ".env file found"
+else
+    warn ".env file not found - using defaults"
+    info "Run: cp .env.example .env"
+fi
+
+if [ -n "$TARGET_SERVICE" ]; then
+    TOTAL_CHECKS=1
+    case "$TARGET_SERVICE" in
+        nacos)     check_nacos ;;
+        mysql)     check_mysql ;;
+        redis)     check_redis ;;
+        rabbitmq)  check_rabbitmq ;;
+        fisco)     check_fisco ;;
+        s3|minio)  check_s3 ;;
+        certs)     check_certs ;;
+        contracts) check_contracts ;;
+        *) echo "Unknown service: $TARGET_SERVICE"; exit 1 ;;
+    esac
+else
+    check_nacos
+    check_mysql
+    check_redis
+    check_rabbitmq
+    check_fisco
+    check_s3
+    check_certs
+    check_contracts
+fi
+
+# ==============================================================================
+# Summary
+# ==============================================================================
+echo
+echo "${BOLD}========================================${RESET}"
+if [ $FAILURES -eq 0 ] && [ $WARNINGS -eq 0 ]; then
+    echo "${GREEN}${BOLD}All checks passed!${RESET}"
+elif [ $FAILURES -eq 0 ]; then
+    echo "${YELLOW}${BOLD}Passed with $WARNINGS warning(s)${RESET}"
+else
+    echo "${RED}${BOLD}$FAILURES check(s) failed${RESET}, $WARNINGS warning(s)"
+fi
+echo "${BOLD}========================================${RESET}"
+
+if [ $FAILURES -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **`docker-compose.infra.yml`**: Root-level compose file for 6 infrastructure services (Nacos, MySQL, Redis, RabbitMQ, MinIO x2). All services include healthcheck definitions and `${VAR:-default}` env fallbacks for zero-config startup
- **`scripts/env-check.sh`**: 8-item environment pre-check script supporting `--fix` (auto-create database/bucket) and `--service NAME` (single-item check). Tool degradation: gracefully falls back from CLI deep-checks to TCP port checks when tools are unavailable
- **Deployment docs**: Chinese and English environment setup guides (`docs/{zh,en}/deployment/environment-setup.md`) with VitePress sidebar and index entries
- **`.env.example`**: Added infrastructure credentials section (DB_PASSWORD, REDIS_*, RABBITMQ_*, NACOS_AUTH_TOKEN)
- **`ROADMAP.md`**: P1-4 marked as completed with evidence

## Test plan

- [x] YAML syntax validation: `python3 -c "import yaml; yaml.safe_load(open('docker-compose.infra.yml'))"`
- [x] Shell syntax validation: `bash -n scripts/env-check.sh`
- [x] VitePress build: `cd docs && pnpm docs:build` — passes with no dead links
- [x] env-check.sh without infrastructure: 6 FAIL (expected) + clear error messages with fix guidance
- [x] env-check.sh cert/contract checks: PASS on existing project files
- [ ] `docker compose -f docker-compose.infra.yml config` (requires Docker)
- [ ] `docker compose -f docker-compose.infra.yml up -d --wait` (full integration)