### PR TITLE
docs: sync documentation with actual codebase state

### DIFF
--- a/docs/en/api/error-codes.md
+++ b/docs/en/api/error-codes.md
@@ -102,6 +102,9 @@ The following error codes are defined in `platform-api` (the Dubbo provider inte
 | 50011 | SHARE_CANCELLED | Share link has been cancelled |
 | 50012 | SHARE_EXPIRED | Share has expired |
 | 50013 | QUOTA_EXCEEDED | Storage quota exceeded |
+| 50014 | VERSION_CHAIN_NOT_FOUND | Version chain not found |
+| 50015 | VERSION_CONFLICT | Version creation conflict, please retry |
+| 50016 | VERSION_SOURCE_INVALID | Source file state does not allow creating new version |
 
 ## Messaging Errors (60000-69999)
 

--- a/docs/en/deployment/docker-compose.md
+++ b/docs/en/deployment/docker-compose.md
@@ -13,8 +13,6 @@ Deploy RecordPlatform using Docker Compose.
 Create `docker-compose.infra.yml`:
 
 ```yaml
-version: '3.8'
-
 services:
   nacos:
     image: nacos/nacos-server:v2.3.0
@@ -28,6 +26,12 @@ services:
       - NACOS_AUTH_TOKEN=your-secret-token
     volumes:
       - nacos_data:/home/nacos/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8848/nacos/v1/console/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   mysql:
@@ -41,6 +45,12 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   redis:
@@ -51,6 +61,12 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     restart: unless-stopped
 
   rabbitmq:
@@ -64,10 +80,16 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   minio-a:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     container_name: minio-a
     ports:
       - "9000:9000"
@@ -78,10 +100,16 @@ services:
     command: server /data --console-address ":9001"
     volumes:
       - minio_a_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   minio-b:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     container_name: minio-b
     ports:
       - "9010:9000"
@@ -92,6 +120,12 @@ services:
     command: server /data --console-address ":9001"
     volumes:
       - minio_b_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
 volumes:
@@ -112,8 +146,6 @@ In Docker environments, Dubbo provider services (storage, fisco) must register w
 :::
 
 ```yaml
-version: '3.8'
-
 services:
   storage:
     build:

--- a/docs/en/getting-started/frontend.md
+++ b/docs/en/getting-started/frontend.md
@@ -18,7 +18,7 @@ This guide covers development setup for the RecordPlatform frontend application.
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - pnpm 10+
 
 ### Development Setup
@@ -55,7 +55,7 @@ Create `.env` file in `platform-frontend/`:
 |----------|-------------|---------|
 | `PUBLIC_API_BASE_URL` | Backend API URL | `http://localhost:8000/record-platform` |
 | `PUBLIC_ENV` | Environment name | `development` |
-| `PUBLIC_TENANT_ID` | Default tenant ID | `1` |
+| `PUBLIC_TENANT_ID` | Default tenant ID | `0` |
 
 ## Project Structure
 

--- a/docs/en/getting-started/prerequisites.md
+++ b/docs/en/getting-started/prerequisites.md
@@ -37,7 +37,7 @@ mvn -version
 
 ### Node.js (for frontend)
 
-- **Required**: Node.js 18+ and pnpm
+- **Required**: Node.js 20+ and pnpm
 
 ```bash
 # Verify Node.js
@@ -53,7 +53,6 @@ For development, you can start all infrastructure services using Docker Compose:
 
 ```yaml
 # docker-compose.yml (infrastructure only)
-version: '3.8'
 services:
   nacos:
     image: nacos/nacos-server:v2.3.0
@@ -81,11 +80,21 @@ services:
       - "5672:5672"
       - "15672:15672"
 
-  minio:
-    image: minio/minio:latest
+  minio-a:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     ports:
       - "9000:9000"
       - "9001:9001"
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+
+  minio-b:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    ports:
+      - "9010:9000"
+      - "9011:9001"
     command: server /data --console-address ":9001"
     environment:
       - MINIO_ROOT_USER=minioadmin

--- a/docs/zh/api/error-codes.md
+++ b/docs/zh/api/error-codes.md
@@ -102,6 +102,9 @@
 | 50011 | SHARE_CANCELLED | 分享链接已被取消 |
 | 50012 | SHARE_EXPIRED | 分享已过期 |
 | 50013 | QUOTA_EXCEEDED | 配额超限 |
+| 50014 | VERSION_CHAIN_NOT_FOUND | 版本链不存在 |
+| 50015 | VERSION_CONFLICT | 版本创建冲突，请重试 |
+| 50016 | VERSION_SOURCE_INVALID | 源文件状态不允许创建新版本 |
 
 ## 消息服务错误（60000-69999）
 

--- a/docs/zh/deployment/docker-compose.md
+++ b/docs/zh/deployment/docker-compose.md
@@ -13,8 +13,6 @@
 创建 `docker-compose.infra.yml`：
 
 ```yaml
-version: '3.8'
-
 services:
   nacos:
     image: nacos/nacos-server:v2.3.0
@@ -28,6 +26,12 @@ services:
       - NACOS_AUTH_TOKEN=your-secret-token
     volumes:
       - nacos_data:/home/nacos/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8848/nacos/v1/console/health/readiness"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   mysql:
@@ -41,6 +45,12 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-p${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
 
   redis:
@@ -51,6 +61,12 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     restart: unless-stopped
 
   rabbitmq:
@@ -64,10 +80,16 @@ services:
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   minio-a:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     container_name: minio-a
     ports:
       - "9000:9000"
@@ -78,10 +100,16 @@ services:
     command: server /data --console-address ":9001"
     volumes:
       - minio_a_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   minio-b:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     container_name: minio-b
     ports:
       - "9010:9000"
@@ -92,6 +120,12 @@ services:
     command: server /data --console-address ":9001"
     volumes:
       - minio_b_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
 volumes:
@@ -112,8 +146,6 @@ volumes:
 :::
 
 ```yaml
-version: '3.8'
-
 services:
   storage:
     build:

--- a/docs/zh/getting-started/frontend.md
+++ b/docs/zh/getting-started/frontend.md
@@ -18,7 +18,7 @@
 
 ### 前置条件
 
-- Node.js 18+
+- Node.js 20+
 - pnpm 10+
 
 ### 开发环境设置
@@ -55,7 +55,7 @@ pnpm dev
 |------|------|------|
 | `PUBLIC_API_BASE_URL` | 后端 API 地址 | `http://localhost:8000/record-platform` |
 | `PUBLIC_ENV` | 环境名称 | `development` |
-| `PUBLIC_TENANT_ID` | 默认租户 ID | `1` |
+| `PUBLIC_TENANT_ID` | 默认租户 ID | `0` |
 
 ## 项目结构
 

--- a/docs/zh/getting-started/prerequisites.md
+++ b/docs/zh/getting-started/prerequisites.md
@@ -37,7 +37,7 @@ mvn -version
 
 ### Node.js（前端开发）
 
-- **要求**: Node.js 18+ 和 pnpm
+- **要求**: Node.js 20+ 和 pnpm
 
 ```bash
 # 验证 Node.js
@@ -53,7 +53,6 @@ npm install -g pnpm
 
 ```yaml
 # docker-compose.yml（仅基础设施）
-version: '3.8'
 services:
   nacos:
     image: nacos/nacos-server:v2.3.0
@@ -81,11 +80,21 @@ services:
       - "5672:5672"
       - "15672:15672"
 
-  minio:
-    image: minio/minio:latest
+  minio-a:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
     ports:
       - "9000:9000"
       - "9001:9001"
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+
+  minio-b:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    ports:
+      - "9010:9000"
+      - "9011:9001"
     command: server /data --console-address ":9001"
     environment:
       - MINIO_ROOT_USER=minioadmin


### PR DESCRIPTION
## Summary

- Fix Node.js version requirement from 18+ to 20+ across prerequisites and frontend docs (EN/ZH)
- Fix `PUBLIC_TENANT_ID` example value from `1` to `0` to match `.env.example`
- Remove deprecated `version: '3.8'` from all Docker Compose YAML blocks
- Pin MinIO image to `RELEASE.2024-11-07T00-52-20Z` instead of `latest`
- Show dual MinIO instances (minio-a/minio-b) in prerequisites quick-start example
- Add healthcheck configs for all 6 infrastructure services in deployment docs
- Add version chain error codes (50014-50016) to error-codes reference

## Test plan

- [x] `pnpm docs:build` passes with no errors
- [x] EN/ZH docs are consistent with each other
- [x] Docker Compose YAML matches actual `docker-compose.infra.yml`
- [x] Error codes match `ResultEnum.java`