### PR TITLE
chore(deps): batch backend dependency updates

### DIFF
--- a/.github/workflows/security-poc.yml
+++ b/.github/workflows/security-poc.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run Trivy SCA (SARIF)
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -106,7 +106,7 @@ jobs:
 
       - name: Run Trivy SCA (JSON)
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -171,7 +171,7 @@ jobs:
 
       - name: Generate CycloneDX SBOM
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -214,7 +214,7 @@ jobs:
           exit-code: '0'
 
       - name: Run Trivy SARIF output
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: fs
           scan-ref: .

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -20,9 +20,9 @@
         <protobuf.version>4.34.0</protobuf.version>
         <dubbo-api-docs.version>2.7.8.1</dubbo-api-docs.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <netty.version>4.1.129.Final</netty.version>
-        <logback.version>1.5.25</logback.version>
-        <jackson-bom.version>2.18.6</jackson-bom.version>
+        <netty.version>4.2.10.Final</netty.version>
+        <logback.version>1.5.32</logback.version>
+        <jackson-bom.version>2.21.1</jackson-bom.version>
     </properties>
 
     <dependencies>

--- a/platform-backend/backend-web/pom.xml
+++ b/platform-backend/backend-web/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <java.version>21</java.version>
         <!-- Keep Flyway aligned with Spring Boot managed API surface to avoid NoSuchMethodError -->
-        <flyway.version>9.22.3</flyway.version>
+        <flyway.version>12.1.0</flyway.version>
         <poi.version>5.5.1</poi.version>
         <logstash.encoder.version>9.0</logstash.encoder.version>
         <tools.jackson.version>3.1.0</tools.jackson.version>

--- a/platform-backend/backend-web/pom.xml
+++ b/platform-backend/backend-web/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <java.version>21</java.version>
         <!-- Keep Flyway aligned with Spring Boot managed API surface to avoid NoSuchMethodError -->
-        <flyway.version>12.1.0</flyway.version>
+        <flyway.version>9.22.3</flyway.version>
         <poi.version>5.5.1</poi.version>
         <logstash.encoder.version>9.0</logstash.encoder.version>
         <tools.jackson.version>3.1.0</tools.jackson.version>

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -42,7 +42,7 @@
         <netty.version>4.2.10.Final</netty.version>
         <logback.version>1.5.32</logback.version>
         <jackson-bom.version>2.21.1</jackson-bom.version>
-        <tomcat.embed.version>11.0.18</tomcat.embed.version>
+        <tomcat.embed.version>10.1.49</tomcat.embed.version>
         <!--
             Mockito inline mock maker relies on Byte Buddy instrumentation.
             On some macOS/JDK builds, runtime self-attach is not available; pre-attaching the agent fixes it.

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -39,9 +39,9 @@
             Testcontainers (docker-java) may require SystemProperties.getUserName(String) (>= 3.17.0).
          -->
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <netty.version>4.1.129.Final</netty.version>
-        <logback.version>1.5.25</logback.version>
-        <jackson-bom.version>2.18.6</jackson-bom.version>
+        <netty.version>4.2.10.Final</netty.version>
+        <logback.version>1.5.32</logback.version>
+        <jackson-bom.version>2.21.1</jackson-bom.version>
         <tomcat.embed.version>10.1.49</tomcat.embed.version>
         <!--
             Mockito inline mock maker relies on Byte Buddy instrumentation.

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -42,7 +42,7 @@
         <netty.version>4.1.129.Final</netty.version>
         <logback.version>1.5.25</logback.version>
         <jackson-bom.version>2.18.6</jackson-bom.version>
-        <tomcat.embed.version>10.1.49</tomcat.embed.version>
+        <tomcat.embed.version>11.0.18</tomcat.embed.version>
         <!--
             Mockito inline mock maker relies on Byte Buddy instrumentation.
             On some macOS/JDK builds, runtime self-attach is not available; pre-attaching the agent fixes it.

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -25,12 +25,12 @@
         <protobuf.version>4.34.0</protobuf.version>
         <logstash.logback.version>7.4</logstash.logback.version>
         <skywalking.toolkit.version>9.6.0</skywalking.toolkit.version>
-        <netty.version>4.1.129.Final</netty.version>
-        <logback.version>1.5.25</logback.version>
-        <jackson-bom.version>2.18.6</jackson-bom.version>
-        <commons-io.version>2.14.0</commons-io.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
-        <bcprov.version>1.78</bcprov.version>
+        <netty.version>4.2.10.Final</netty.version>
+        <logback.version>1.5.32</logback.version>
+        <jackson-bom.version>2.21.1</jackson-bom.version>
+        <commons-io.version>2.21.0</commons-io.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <bcprov.version>1.83</bcprov.version>
     </properties>
     <dependencies>
         <dependency>

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.1-jre</version>
+            <version>33.5.0-jre</version>
         </dependency>
 
         <!-- api -->

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -19,15 +19,15 @@
         <protobuf.version>4.34.0</protobuf.version>
         <spring-cloud-bootstrap.version>4.1.3</spring-cloud-bootstrap.version>
         <prometheus.version>0.16.0</prometheus.version>
-        <aws.sdk.version>2.42.4</aws.sdk.version>
+        <aws.sdk.version>2.42.8</aws.sdk.version>
         <hutool.version>5.8.43</hutool.version>
         <redisson.version>4.3.0</redisson.version>
         <spring-cloud-alibaba-dependencies.version>2023.0.3.2</spring-cloud-alibaba-dependencies.version>
         <logstash.logback.version>7.4</logstash.logback.version>
         <skywalking.toolkit.version>9.6.0</skywalking.toolkit.version>
-        <netty.version>4.1.129.Final</netty.version>
-        <logback.version>1.5.25</logback.version>
-        <jackson-bom.version>2.18.6</jackson-bom.version>
+        <netty.version>4.2.10.Final</netty.version>
+        <logback.version>1.5.32</logback.version>
+        <jackson-bom.version>2.21.1</jackson-bom.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary
- Bump the minor-and-patch group in /platform-api with 4 updates (#96)
- Bump the minor-and-patch group in /platform-fisco with 7 updates (#97)
- Bump the minor-and-patch group in /platform-storage with 6 updates (#98)
- Bump com.google.guava:guava from 32.0.1-jre to 33.5.0-jre in /platform-storage (#99)
- Bump the minor-and-patch group in /platform-backend with 4 updates (#100)
- Bump aquasecurity/trivy-action from 0.28.0 to 0.35.0 (#95)

### Excluded (incompatible with Spring Boot 3.2.x)
- ~~tomcat-embed-core 10.1.49 → 11.0.18~~ (#101, requires Servlet 6.1 / Spring Boot 4.x)
- ~~flyway-mysql 9.22.3 → 12.1.0~~ (#102, removed cleanOnValidationError API)

### Dependency changes

**Shared across modules:**
| Package | From | To |
|---------|------|----|
| netty | 4.1.129.Final | 4.2.10.Final |
| logback | 1.5.25 | 1.5.32 |
| jackson-bom | 2.18.6 | 2.21.1 |

**platform-api:** netty, logback, jackson-bom (+ dubbo group)

**platform-fisco:** netty, logback, jackson-bom, commons-io 2.14.0→2.21.0, commons-lang3 3.18.0→3.20.0, bcprov 1.78→1.83

**platform-storage:** aws-sdk 2.42.4→2.42.8, guava 32.0.1-jre→33.5.0-jre, netty, logback, jackson-bom

**platform-backend:** netty, logback, jackson-bom

**GitHub Actions:** trivy-action 0.28.0→0.35.0

Supersedes #95, #96, #97, #98, #99, #100