### PR TITLE
feat: automated release pipeline with Dockerfiles and release workflow (P1-3)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+docs/
+*.md
+!platform-frontend/package.json
+!platform-frontend/pnpm-lock.yaml
+
+# Plans and scripts
+plan/
+scripts/
+tools/
+
+# IDE and OS
+.idea/
+.vscode/
+*.iml
+.DS_Store
+Thumbs.db
+
+# Environment files (secrets must not enter image)
+.env
+.env.*
+!.env.example
+
+# Logs and runtime
+log/
+logs/
+run/
+*.log
+
+# Node
+node_modules/
+platform-frontend/node_modules/
+
+# Maven build outputs
+**/target/
+!platform-api/**/target/
+!platform-backend/**/target/
+!platform-fisco/target/
+!platform-storage/target/
+
+# Frontend build output (only needed for runtime stage)
+# kept so multi-stage COPY can work
+# platform-frontend/dist/  <-- intentionally NOT ignored
+
+# Test artifacts
+**/src/test/
+**/*.test.ts
+**/*.spec.ts
+**/coverage/
+
+# GitHub Actions (not needed in image)
+.github/
+
+# Security artifacts
+security-artifacts/
+
+# Misc
+processed/
+jars/
+agent/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,172 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write   # create GitHub Release
+  packages: write   # push to ghcr.io
+
+jobs:
+  release:
+    name: Build & Publish Release
+    runs-on: ubuntu-latest
+    # Single job: avoids rebuilding platform-api across multiple matrix jobs
+    # and shares the Maven local repository cache across all modules.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history for accurate release notes
+
+      # ── Java build ────────────────────────────────────────────────────────
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build all Java modules
+        run: |
+          mvn -f platform-api/pom.xml clean install -DskipTests -q
+          mvn -f platform-backend/pom.xml clean package -DskipTests -q
+          mvn -f platform-fisco/pom.xml clean package -DskipTests -q
+          mvn -f platform-storage/pom.xml clean package -DskipTests -q
+
+      # ── Frontend build ─────────────────────────────────────────────────────
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: platform-frontend/pnpm-lock.yaml
+
+      - name: Build frontend
+        working-directory: platform-frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      # ── SBOM ───────────────────────────────────────────────────────────────
+      - name: Generate CycloneDX SBOM
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+          exit-code: '0'
+
+      # ── Docker ─────────────────────────────────────────────────────────────
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # backend
+      - name: Docker metadata -- backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/recordplatform-backend
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push -- backend
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: platform-backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      # fisco
+      - name: Docker metadata -- fisco
+        id: meta-fisco
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/recordplatform-fisco
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push -- fisco
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: platform-fisco/Dockerfile
+          push: true
+          tags: ${{ steps.meta-fisco.outputs.tags }}
+          labels: ${{ steps.meta-fisco.outputs.labels }}
+          cache-from: type=gha,scope=fisco
+          cache-to: type=gha,mode=max,scope=fisco
+
+      # storage
+      - name: Docker metadata -- storage
+        id: meta-storage
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/recordplatform-storage
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push -- storage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: platform-storage/Dockerfile
+          push: true
+          tags: ${{ steps.meta-storage.outputs.tags }}
+          labels: ${{ steps.meta-storage.outputs.labels }}
+          cache-from: type=gha,scope=storage
+          cache-to: type=gha,mode=max,scope=storage
+
+      # frontend
+      - name: Docker metadata -- frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/recordplatform-frontend
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push -- frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: platform-frontend
+          file: platform-frontend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          labels: ${{ steps.meta-frontend.outputs.labels }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
+      # ── GitHub Release ─────────────────────────────────────────────────────
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: sbom.cdx.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,8 +64,8 @@
 
 | 缺失项 | 影响 |
 |--------|------|
-| 容器镜像构建 | Dockerfile 尚未创建；基础设施 compose 已就位（`docker-compose.infra.yml`），应用服务 compose 模板存在于文档中 |
-| 自动化发布 / Changelog | 每次发布需手动操作 |
+| ~~容器镜像构建~~ | ~~已完成（P1-3）：4 个多阶段 Dockerfile（`platform-backend/Dockerfile`、`platform-fisco/Dockerfile`、`platform-storage/Dockerfile`、`platform-frontend/Dockerfile`）~~ |
+| ~~自动化发布 / Changelog~~ | ~~已完成（P1-3）：`.github/workflows/release.yml`，tag push 触发，自动生成 Release Notes + SBOM 附件 + 四镜像推送 ghcr.io~~ |
 | ~~GitHub 分支保护 required checks~~ | ~~已完成：required checks 已启用（Backend Tests, Frontend Tests, Contract Consistency, Build Verification）~~ |
 | 智能合约部署自动化 | 合约编译和部署完全手动；ABI 文件作为静态资源签入，无工具链保障 ABI 与链上合约一致 |
 
@@ -123,12 +123,19 @@
 - **涉及文件**：`platform-backend/backend-web/src/test/java/cn/flying/test/fault/` 新增 4 个测试类
 - **当前状态**：已完成。新增 `FaultInjectionBaseIT`（抽象基类）、`SagaCompensationIT`（5 个场景：S3/链上失败补偿、重试持久化、死信事件、REQUIRES_NEW 独立提交语义）、`OutboxPublisherIT`（5 个场景：发布成功、RabbitMQ 不可达退避、指数退避上限、多租户隔离）、`ResilienceConfigIT`（5 个配置校验）。共 15 个集成测试，无 Docker 时优雅跳过
 
-**P1-3：自动化发布流程**
+**P1-3：自动化发布流程** ✅
 
 - **What**：新建 `.github/workflows/release.yml`，tag push 触发：自动生成 Release Notes + 构建 SBOM 附件 + 构建容器镜像推送 ghcr.io
 - **自动化收益**：消除手动编写 Changelog、手动构建部署包、手动生成 SBOM
 - **涉及文件**：新建 `.github/workflows/release.yml`、新建各模块 `Dockerfile`
-- **前置依赖**：需先创建各模块 Dockerfile（当前仓库中尚不存在）
+- **当前状态**：已完成。交付物：
+  - `.dockerignore`：排除 git、docs、target 等非必要文件，缩小构建上下文
+  - `platform-backend/Dockerfile`：maven:3.9-eclipse-temurin-21 多阶段构建，runtime `eclipse-temurin:21-jre-noble`，非 root 用户，EXPOSE 8000
+  - `platform-fisco/Dockerfile`：同上，额外创建 `/app/conf/` 挂载点（TLS 证书），用户 home 可写（FISCO SDK 解压 native libs），EXPOSE 8091
+  - `platform-storage/Dockerfile`：同上，EXPOSE 8092
+  - `platform-frontend/Dockerfile`：node:20-alpine + pnpm 10 构建，nginx:1.27-alpine runtime，EXPOSE 80
+  - `platform-frontend/nginx.conf`：gzip_static、SPA 路由回退、`/_app/` 不可变长缓存、`index.html` no-cache、安全头
+  - `.github/workflows/release.yml`：tag push 触发，单 job（共享 Maven 缓存），Trivy CycloneDX SBOM，四镜像 ghcr.io 推送（semver + major.minor + sha tags），`softprops/action-gh-release@v2` 自动 Release Notes
 
 **P1-4：服务器环境引导与验证** ✅
 

--- a/platform-backend/Dockerfile
+++ b/platform-backend/Dockerfile
@@ -1,0 +1,37 @@
+# Build context: repository root (platform-api is a cross-module dependency)
+# Usage: docker build -f platform-backend/Dockerfile -t recordplatform-backend .
+
+# ── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+WORKDIR /workspace
+
+# Install platform-api (shared interface definitions required by backend)
+COPY platform-api/ platform-api/
+RUN mvn -f platform-api/pom.xml clean install -DskipTests -q
+
+# Build backend-web and its module dependencies
+COPY platform-backend/ platform-backend/
+RUN mvn -f platform-backend/pom.xml clean package \
+      -pl backend-web -am \
+      -DskipTests -q
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-noble AS runtime
+
+# Non-root user for security
+RUN groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin app
+WORKDIR /app
+
+COPY --from=build /workspace/platform-backend/backend-web/target/backend-web-0.0.1-SNAPSHOT.jar app.jar
+
+RUN chown -R app:app /app
+USER app
+
+EXPOSE 8000
+
+ENV SPRING_PROFILES_ACTIVE=prod
+
+ENTRYPOINT ["java", \
+  "-Xms512m", "-Xmx1024m", "-XX:+UseG1GC", \
+  "-jar", "app.jar"]

--- a/platform-fisco/Dockerfile
+++ b/platform-fisco/Dockerfile
@@ -1,0 +1,40 @@
+# Build context: repository root (platform-api is a cross-module dependency)
+# Usage: docker build -f platform-fisco/Dockerfile -t recordplatform-fisco .
+#
+# TLS certs (ca.crt, sdk.crt, sdk.key, etc.) are NOT bundled into the image.
+# Mount them at runtime: -v /host/certs:/app/conf:ro
+
+# ── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+WORKDIR /workspace
+
+# Install shared interfaces
+COPY platform-api/ platform-api/
+RUN mvn -f platform-api/pom.xml clean install -DskipTests -q
+
+# Build FISCO blockchain service
+COPY platform-fisco/ platform-fisco/
+RUN mvn -f platform-fisco/pom.xml clean package -DskipTests -q
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-noble AS runtime
+
+# FISCO Java SDK unpacks native JNI libs to ${user.home}/.fisco on startup.
+# -d /app ensures user home is /app so the SDK can write there.
+RUN groupadd -r app && useradd -r -g app -d /app -m -s /sbin/nologin app
+WORKDIR /app
+
+COPY --from=build /workspace/platform-fisco/target/platform-fisco-0.0.1-SNAPSHOT.jar app.jar
+
+# Directory for TLS certificate files (mount at runtime)
+RUN mkdir -p /app/conf && chown -R app:app /app
+USER app
+
+EXPOSE 8091
+
+ENV SPRING_PROFILES_ACTIVE=prod
+
+ENTRYPOINT ["java", \
+  "-Xms512m", "-Xmx1024m", "-XX:+UseG1GC", \
+  "-jar", "app.jar"]

--- a/platform-frontend/Dockerfile
+++ b/platform-frontend/Dockerfile
@@ -1,0 +1,32 @@
+# Build context: platform-frontend/
+# Usage: docker build -f platform-frontend/Dockerfile -t recordplatform-frontend platform-frontend/
+
+# ── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM node:20-alpine AS build
+
+# Enable pnpm via corepack (matches CI toolchain)
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+WORKDIR /app
+
+# Install dependencies first (layer caching: only re-runs on lockfile change)
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build SPA
+COPY . .
+RUN pnpm build
+# Output: dist/ with precompressed .gz/.br assets (precompress: true in svelte.config.js)
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM nginx:1.27-alpine AS runtime
+
+# Remove default nginx config
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/platform-frontend/nginx.conf
+++ b/platform-frontend/nginx.conf
@@ -1,0 +1,61 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    keepalive_timeout 65;
+
+    # Pre-compressed assets (SvelteKit precompress: true generates .gz/.br)
+    gzip_static on;
+
+    server {
+        listen 80;
+        server_name _;
+        root /usr/share/nginx/html;
+
+        # Security headers
+        add_header X-Frame-Options DENY always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header X-XSS-Protection "1; mode=block" always;
+
+        # Immutable assets — SvelteKit content-hashed filenames under /_app/
+        location /_app/ {
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+            # Repeat security headers (add_header inheritance resets inside nested blocks)
+            add_header X-Frame-Options DENY always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy strict-origin-when-cross-origin always;
+            try_files $uri =404;
+        }
+
+        # SPA entry point — must not be cached so updates are picked up immediately
+        location = /index.html {
+            add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+            add_header Pragma no-cache always;
+            add_header X-Frame-Options DENY always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy strict-origin-when-cross-origin always;
+        }
+
+        # SPA fallback routing — unknown paths serve index.html
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/platform-storage/Dockerfile
+++ b/platform-storage/Dockerfile
@@ -1,0 +1,34 @@
+# Build context: repository root (platform-api is a cross-module dependency)
+# Usage: docker build -f platform-storage/Dockerfile -t recordplatform-storage .
+
+# ── Stage 1: Build ──────────────────────────────────────────────────────────
+FROM maven:3.9-eclipse-temurin-21 AS build
+
+WORKDIR /workspace
+
+# Install shared interfaces
+COPY platform-api/ platform-api/
+RUN mvn -f platform-api/pom.xml clean install -DskipTests -q
+
+# Build S3-compatible storage service
+COPY platform-storage/ platform-storage/
+RUN mvn -f platform-storage/pom.xml clean package -DskipTests -q
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-noble AS runtime
+
+RUN groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin app
+WORKDIR /app
+
+COPY --from=build /workspace/platform-storage/target/platform-storage-0.0.1-SNAPSHOT.jar app.jar
+
+RUN chown -R app:app /app
+USER app
+
+EXPOSE 8092
+
+ENV SPRING_PROFILES_ACTIVE=prod
+
+ENTRYPOINT ["java", \
+  "-Xms512m", "-Xmx1024m", "-XX:+UseG1GC", \
+  "-jar", "app.jar"]


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfiles for all 4 services (backend, fisco, storage, frontend)
- Add `platform-frontend/nginx.conf` with SPA routing, gzip_static, immutable asset caching, and security headers
- Add `.github/workflows/release.yml`: triggered on `v*.*.*` tag push, builds all JARs + frontend, generates CycloneDX SBOM, pushes 4 Docker images to ghcr.io, creates GitHub Release with auto-generated notes
- Add `.dockerignore` to reduce build context size
- Update ROADMAP.md: mark P1-3 complete, strike through table-3 missing items

## Risk Assessment

- Dockerfiles are **not run in CI on PRs** (only on tag push) — no infrastructure required to merge
- `release.yml` uses only `GITHUB_TOKEN` (no external secrets needed)
- Java images use non-root `app` user; frontend uses nginx:1.27-alpine
- FISCO Dockerfile creates `/app/conf` mount point for TLS certs (never bundled into image)

## Test Plan

- [ ] CI gates (backend-test, frontend-test, contract-consistency, build-check) pass
- [ ] Local Docker build: `docker build -f platform-frontend/Dockerfile platform-frontend/`
- [ ] Workflow syntax: review `release.yml` for YAML correctness
- [ ] After merge: push a test tag `v0.1.0-rc1` to verify end-to-end release flow

## Contract Consistency

No backend API changes — no `generated.ts` update required.