### PR TITLE
refactor: migrate image S3 client from MinIO SDK to AWS SDK v2

### DIFF
--- a/platform-backend/backend-common/pom.xml
+++ b/platform-backend/backend-common/pom.xml
@@ -16,7 +16,6 @@
         <knife4j.version>4.5.0</knife4j.version>
         <springdoc.version>2.8.16</springdoc.version>
         <java-jwt.version>4.5.1</java-jwt.version>
-        <minio.sdk.version>8.6.0</minio.sdk.version>
         <redisson.version>4.3.0</redisson.version>
     </properties>
 
@@ -59,11 +58,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
-        <!-- S3 兼容对象存储 (使用 MinIO SDK) -->
+        <!-- S3 兼容对象存储 (AWS SDK v2) -->
         <dependency>
-            <groupId>io.minio</groupId>
-            <artifactId>minio</artifactId>
-            <version>${minio.sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
         </dependency>
         <!--    Redis交互模块    -->
         <dependency>

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/ImageServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/ImageServiceImpl.java
@@ -9,13 +9,18 @@ import cn.flying.dao.mapper.ImageStoreMapper;
 import cn.flying.service.ImageService;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
-import io.minio.*;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -35,7 +40,7 @@ public class ImageServiceImpl extends ServiceImpl<ImageStoreMapper, ImageStore> 
     @Value("${s3.bucket-name}")
     String bucketName;
     @Resource
-    MinioClient s3Client;
+    S3Client s3Client;
     @Resource
     AccountMapper accountMapper;
     @Resource
@@ -44,13 +49,13 @@ public class ImageServiceImpl extends ServiceImpl<ImageStoreMapper, ImageStore> 
     @Override
     public String uploadAvatar(MultipartFile file, Long userId) throws IOException {
         String imageName= "/avatar/"+UUID.randomUUID().toString().replace("-","");
-        PutObjectArgs objectArgs= PutObjectArgs.builder()
+        PutObjectRequest putRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
-                .stream(file.getInputStream(),file.getSize(),-1)
-                .object(imageName)
+                .key(imageName)
+                .contentType(file.getContentType())
                 .build();
         try {
-            s3Client.putObject(objectArgs);
+            s3Client.putObject(putRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
             String avatar =accountMapper.selectById(userId).getAvatar();
             this.deleteOldImage(avatar);
             if(accountMapper.update(null, Wrappers.<Account>update()
@@ -73,13 +78,13 @@ public class ImageServiceImpl extends ServiceImpl<ImageStoreMapper, ImageStore> 
         String imageName= UUID.randomUUID().toString().replace("-","");
         Date data=new Date();
         imageName="/cache"+format.format(data)+"/"+imageName;
-        PutObjectArgs objectArgs= PutObjectArgs.builder()
+        PutObjectRequest putRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
-                .stream(file.getInputStream(),file.getSize(),-1)
-                .object(imageName)
+                .key(imageName)
+                .contentType(file.getContentType())
                 .build();
         try {
-            s3Client.putObject(objectArgs);
+            s3Client.putObject(putRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
             String imageUid = UUID.randomUUID().toString().replace("-", "");
             if (this.save(new ImageStore(imageUid, imageName, data)))
                 return imageName;
@@ -95,22 +100,23 @@ public class ImageServiceImpl extends ServiceImpl<ImageStoreMapper, ImageStore> 
 
     @Override
     public void fetchImage(OutputStream outputStream, String imagePath) throws Exception {
-        GetObjectArgs args= GetObjectArgs.builder()
+        GetObjectRequest getRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
-                .object(imagePath)
+                .key(imagePath)
                 .build();
-        GetObjectResponse object = s3Client.getObject(args);
-        IOUtils.copy(object,outputStream);
+        try (ResponseInputStream<GetObjectResponse> object = s3Client.getObject(getRequest)) {
+            object.transferTo(outputStream);
+        }
     }
     private void deleteOldImage(String avatar){
         if (avatar==null||avatar.isEmpty())
             return ;
-        RemoveObjectArgs args= RemoveObjectArgs.builder()
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                 .bucket(bucketName)
-                .object(avatar)
+                .key(avatar)
                 .build();
         try {
-            s3Client.removeObject(args);
+            s3Client.deleteObject(deleteRequest);
         }catch (Exception e){
             log.error("图片删除失败:{}", e.getMessage(), e);
         }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/ImageServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/ImageServiceImplTest.java
@@ -6,11 +6,6 @@ import cn.flying.dao.dto.Account;
 import cn.flying.dao.dto.ImageStore;
 import cn.flying.dao.mapper.AccountMapper;
 import cn.flying.dao.mapper.ImageStoreMapper;
-import io.minio.GetObjectArgs;
-import io.minio.GetObjectResponse;
-import io.minio.MinioClient;
-import io.minio.PutObjectArgs;
-import io.minio.RemoveObjectArgs;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -23,11 +18,17 @@ import org.mockito.quality.Strictness;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -48,7 +49,7 @@ import static org.mockito.Mockito.*;
 class ImageServiceImplTest {
 
     @Mock
-    private MinioClient s3Client;
+    private S3Client s3Client;
 
     @Mock
     private AccountMapper accountMapper;
@@ -83,12 +84,14 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             String result = imageService.uploadAvatar(file, USER_ID);
 
             assertThat(result).isNotNull();
             assertThat(result).startsWith("/avatar/");
-            verify(s3Client).putObject(any(PutObjectArgs.class));
+            verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
             verify(accountMapper).update(isNull(), any());
         }
 
@@ -100,12 +103,14 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             imageService.uploadAvatar(file, USER_ID);
 
-            ArgumentCaptor<RemoveObjectArgs> captor = ArgumentCaptor.forClass(RemoveObjectArgs.class);
-            verify(s3Client).removeObject(captor.capture());
-            assertThat(captor.getValue().object()).isEqualTo("/avatar/old-avatar");
+            ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+            verify(s3Client).deleteObject(captor.capture());
+            assertThat(captor.getValue().key()).isEqualTo("/avatar/old-avatar");
         }
 
         @Test
@@ -116,10 +121,12 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             imageService.uploadAvatar(file, USER_ID);
 
-            verify(s3Client, never()).removeObject(any(RemoveObjectArgs.class));
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
         }
 
         @Test
@@ -130,10 +137,12 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             imageService.uploadAvatar(file, USER_ID);
 
-            verify(s3Client, never()).removeObject(any(RemoveObjectArgs.class));
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
         }
 
         @Test
@@ -144,6 +153,8 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(0);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             String result = imageService.uploadAvatar(file, USER_ID);
 
@@ -155,7 +166,8 @@ class ImageServiceImplTest {
         void uploadAvatar_returnNullWhenS3Fails() throws Exception {
             MultipartFile file = createMockFile("avatar.png", "image/png");
 
-            doThrow(new RuntimeException("S3 error")).when(s3Client).putObject(any(PutObjectArgs.class));
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenThrow(new RuntimeException("S3 error"));
 
             String result = imageService.uploadAvatar(file, USER_ID);
 
@@ -171,6 +183,8 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             String result1 = imageService.uploadAvatar(file, USER_ID);
             String result2 = imageService.uploadAvatar(file, USER_ID);
@@ -190,13 +204,15 @@ class ImageServiceImplTest {
             String rateKey = Const.IMAGE_COUNTER + USER_ID;
 
             when(flowUtils.limitPeriodCountCheck(rateKey, 20, 3600)).thenReturn(true);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
             doReturn(true).when(imageService).save(any(ImageStore.class));
 
             String result = imageService.uploadImage(file, USER_ID);
 
             assertThat(result).isNotNull();
             assertThat(result).startsWith("/cache");
-            verify(s3Client).putObject(any(PutObjectArgs.class));
+            verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
             verify(imageService).save(any(ImageStore.class));
         }
 
@@ -211,7 +227,7 @@ class ImageServiceImplTest {
             String result = imageService.uploadImage(file, USER_ID);
 
             assertThat(result).isNull();
-            verify(s3Client, never()).putObject(any(PutObjectArgs.class));
+            verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         }
 
         @Test
@@ -221,12 +237,14 @@ class ImageServiceImplTest {
             String rateKey = Const.IMAGE_COUNTER + USER_ID;
 
             when(flowUtils.limitPeriodCountCheck(rateKey, 20, 3600)).thenReturn(true);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
             doReturn(false).when(imageService).save(any(ImageStore.class));
 
             String result = imageService.uploadImage(file, USER_ID);
 
             assertThat(result).isNull();
-            verify(s3Client).removeObject(any(RemoveObjectArgs.class));
+            verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
         }
 
         @Test
@@ -236,7 +254,8 @@ class ImageServiceImplTest {
             String rateKey = Const.IMAGE_COUNTER + USER_ID;
 
             when(flowUtils.limitPeriodCountCheck(rateKey, 20, 3600)).thenReturn(true);
-            doThrow(new RuntimeException("S3 error")).when(s3Client).putObject(any(PutObjectArgs.class));
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenThrow(new RuntimeException("S3 error"));
 
             String result = imageService.uploadImage(file, USER_ID);
 
@@ -250,6 +269,8 @@ class ImageServiceImplTest {
             String rateKey = Const.IMAGE_COUNTER + USER_ID;
 
             when(flowUtils.limitPeriodCountCheck(rateKey, 20, 3600)).thenReturn(true);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
             doReturn(true).when(imageService).save(any(ImageStore.class));
 
             String result = imageService.uploadImage(file, USER_ID);
@@ -262,6 +283,7 @@ class ImageServiceImplTest {
     @DisplayName("fetchImage Tests")
     class FetchImageTests {
 
+        @SuppressWarnings("unchecked")
         @Test
         @DisplayName("should fetch image and write to output stream")
         void fetchImage_success() throws Exception {
@@ -269,39 +291,32 @@ class ImageServiceImplTest {
             byte[] imageData = "fake image data".getBytes();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-            GetObjectResponse mockResponse = mock(GetObjectResponse.class);
-            when(mockResponse.read(any(byte[].class))).thenAnswer(invocation -> {
-                byte[] buffer = invocation.getArgument(0);
-                System.arraycopy(imageData, 0, buffer, 0, Math.min(imageData.length, buffer.length));
-                return imageData.length;
-            }).thenReturn(-1);
-            when(mockResponse.read(any(byte[].class), anyInt(), anyInt())).thenAnswer(invocation -> {
-                byte[] buffer = invocation.getArgument(0);
-                int offset = invocation.getArgument(1);
-                int length = invocation.getArgument(2);
-                int toCopy = Math.min(imageData.length, length);
-                System.arraycopy(imageData, 0, buffer, offset, toCopy);
-                return toCopy;
-            }).thenReturn(-1);
+            ResponseInputStream<GetObjectResponse> mockStream = mock(ResponseInputStream.class);
+            when(mockStream.transferTo(any())).thenAnswer(invocation -> {
+                java.io.OutputStream os = invocation.getArgument(0);
+                os.write(imageData);
+                return (long) imageData.length;
+            });
 
-            when(s3Client.getObject(any(GetObjectArgs.class))).thenReturn(mockResponse);
+            when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(mockStream);
 
             imageService.fetchImage(outputStream, imagePath);
 
-            ArgumentCaptor<GetObjectArgs> captor = ArgumentCaptor.forClass(GetObjectArgs.class);
+            ArgumentCaptor<GetObjectRequest> captor = ArgumentCaptor.forClass(GetObjectRequest.class);
             verify(s3Client).getObject(captor.capture());
-            assertThat(captor.getValue().object()).isEqualTo(imagePath);
+            assertThat(captor.getValue().key()).isEqualTo(imagePath);
             assertThat(captor.getValue().bucket()).isEqualTo(BUCKET_NAME);
+            assertThat(outputStream.toByteArray()).isEqualTo(imageData);
         }
 
         @Test
         @DisplayName("should throw exception when S3 object not found")
-        void fetchImage_throwsWhenNotFound() throws Exception {
+        void fetchImage_throwsWhenNotFound() {
             String imagePath = "/avatar/nonexistent";
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-            doThrow(new RuntimeException("Object not found"))
-                    .when(s3Client).getObject(any(GetObjectArgs.class));
+            when(s3Client.getObject(any(GetObjectRequest.class)))
+                    .thenThrow(new RuntimeException("Object not found"));
 
             Assertions.assertThrows(Exception.class, () ->
                     imageService.fetchImage(outputStream, imagePath));
@@ -354,11 +369,13 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
 
             String result = imageService.uploadAvatar(file, USER_ID);
 
             // Should still attempt upload
-            verify(s3Client).putObject(any(PutObjectArgs.class));
+            verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         }
 
         @Test
@@ -369,7 +386,10 @@ class ImageServiceImplTest {
 
             when(accountMapper.selectById(USER_ID)).thenReturn(existingAccount);
             when(accountMapper.update(isNull(), any())).thenReturn(1);
-            doThrow(new RuntimeException("Delete error")).when(s3Client).removeObject(any(RemoveObjectArgs.class));
+            when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                    .thenReturn(PutObjectResponse.builder().build());
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+                    .thenThrow(new RuntimeException("Delete error"));
 
             // Should not throw, deletion error is logged but not propagated
             String result = imageService.uploadAvatar(file, USER_ID);

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/S3ClientConfiguration.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/S3ClientConfiguration.java
@@ -1,10 +1,16 @@
 package cn.flying.config;
 
-import io.minio.MinioClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
 
 /**
  * S3 兼容对象存储客户端配置类
@@ -15,7 +21,7 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 @Configuration
 public class S3ClientConfiguration {
-    // S3 兼容存储地址
+
     @Value("${s3.endpoint}")
     private String endpoint;
 
@@ -25,12 +31,20 @@ public class S3ClientConfiguration {
     @Value("${s3.secret-key}")
     private String secretKey;
 
+    @Value("${s3.region:us-east-1}")
+    private String region;
+
     @Bean
-    public MinioClient s3Client() {
+    public S3Client s3Client() {
         log.info("Init S3 Compatible Storage Client...");
-        return MinioClient.builder()
-                .endpoint(endpoint)
-                .credentials(accessKey, secretKey)
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .region(Region.of(region))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
                 .build();
     }
 }

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/ImageController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/ImageController.java
@@ -8,7 +8,7 @@ import cn.flying.common.exception.GeneralException;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.ErrorPayloadFactory;
 import cn.flying.service.ImageService;
-import io.minio.errors.ErrorResponseException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -136,13 +136,11 @@ public class ImageController {
             }
             imageService.fetchImage(outputStream, imagePath);
             response.setHeader("Cache-Control", "max-age=2592000");
-        } catch (ErrorResponseException e) {
-            if (e.response() != null && e.response().code() == 404) {
-                throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
-            } else {
-                log.error("从 S3 存储读取图片出现异常：{}", e.getMessage(), e);
-                throw new GeneralException(ResultEnum.FAIL);
-            }
+        } catch (NoSuchKeyException e) {
+            throw new GeneralException(ResultEnum.FILE_NOT_EXIST);
+        } catch (Exception e) {
+            log.error("从 S3 存储读取图片出现异常：{}", e.getMessage(), e);
+            throw new GeneralException(ResultEnum.FAIL);
         }
     }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/BaseIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/BaseIntegrationTest.java
@@ -5,9 +5,10 @@ import cn.flying.platformapi.external.DistributedStorageService;
 import cn.flying.platformapi.constant.Result;
 import cn.flying.service.remote.FileRemoteClient;
 import cn.flying.test.config.MockDubboServicesConfig;
-import io.minio.BucketExistsArgs;
-import io.minio.MakeBucketArgs;
-import io.minio.MinioClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +72,7 @@ public abstract class BaseIntegrationTest {
     protected DistributedStorageService distributedStorageService;
 
     @Autowired
-    private MinioClient s3Client;
+    private S3Client s3Client;
 
     @Value("${s3.bucket-name}")
     private String s3BucketName;
@@ -212,18 +213,13 @@ public abstract class BaseIntegrationTest {
     }
 
     /**
-     * 确保测试环境下 MinIO 的 S3 bucket 已创建，避免图片上传等集成测试因 NoSuchBucket 失败。
+     * 确保测试环境下 S3 bucket 已创建，避免图片上传等集成测试因 NoSuchBucket 失败。
      */
     private void ensureS3BucketExists() {
         try {
-            boolean exists = s3Client.bucketExists(
-                    BucketExistsArgs.builder().bucket(s3BucketName).build()
-            );
-            if (!exists) {
-                s3Client.makeBucket(MakeBucketArgs.builder().bucket(s3BucketName).build());
-            }
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to ensure S3 bucket exists: " + s3BucketName, e);
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(s3BucketName).build());
+        } catch (NoSuchBucketException e) {
+            s3Client.createBucket(CreateBucketRequest.builder().bucket(s3BucketName).build());
         }
     }
 }

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -40,11 +40,7 @@
          -->
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <netty.version>4.2.10.Final</netty.version>
-        <!--
-            OkHttp 5.x is a Kotlin Multiplatform artifact (empty JVM jar).
-            MinIO SDK 8.6.0 requires OkHttp 4.x Java classes (okhttp3.HttpUrl, etc.).
-         -->
-        <okhttp.version>4.12.0</okhttp.version>
+        <aws.sdk.version>2.42.18</aws.sdk.version>
         <!--
             Mockito inline mock maker relies on Byte Buddy instrumentation.
             On some macOS/JDK builds, runtime self-attach is not available; pre-attaching the agent fixes it.
@@ -92,11 +88,16 @@
                 <artifactId>backend-web</artifactId>
                 <version>0.0.1-SNAPSHOT</version>
             </dependency>
-            <!-- Pin OkHttp to 4.x for MinIO SDK compatibility -->
+            <!-- AWS SDK v2 for S3-compatible storage -->
             <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>s3</artifactId>
+                <version>${aws.sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>apache-client</artifactId>
+                <version>${aws.sdk.version}</version>
             </dependency>
             <!--     共享库     -->
             <dependency>

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -4004,7 +4004,7 @@ export interface components {
              */
             code?: number;
             /** @description 结果数据 */
-            data?: string[];
+            data?: string[][];
             /** @description 提示信息 */
             message?: string;
         };


### PR DESCRIPTION
## Summary

- Replace `io.minio:minio` 8.6.0 with `software.amazon.awssdk:s3` 2.42.18 in platform-backend
- Align backend image operations (avatar/cache upload/download) with platform-storage which already uses AWS SDK v2
- Remove OkHttp 4.x version pin that was only needed for MinIO SDK compatibility

## Changes

| File | Change |
|------|--------|
| `backend-common/pom.xml` | `io.minio:minio` → `software.amazon.awssdk:s3` + `apache-client` |
| `platform-backend/pom.xml` | Remove `okhttp.version` pin, add `aws.sdk.version` to dependencyManagement |
| `S3ClientConfiguration.java` | `MinioClient` → `S3Client` with path-style access |
| `ImageServiceImpl.java` | `putObject`/`getObject`/`removeObject` → AWS SDK v2 API |
| `ImageController.java` | `ErrorResponseException` → `NoSuchKeyException` |
| `ImageServiceImplTest.java` | Mock types updated to AWS SDK v2 |
| `BaseIntegrationTest.java` | Bucket creation logic updated to AWS SDK v2 |

## Motivation

- MinIO SDK 8.6.0 → 9.0.0 is a full rewrite with widespread breaking changes (blocked by Dependabot PR #142)
- AWS SDK v2 is already used by platform-storage and is the standard S3 client
- Eliminates the OkHttp 4.x transitive dependency pinning issue
- Unifies the S3 client across the entire project

## Test plan

- [x] All 256 backend unit tests pass (0 failures)
- [ ] CI backend tests (includes integration tests with Testcontainers MinIO)
- [ ] Verify avatar upload/download in local environment