### PR TITLE
chore: add root aggregator POM for unified IDE import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ package-lock.json
 /.claude/
 /.codex/
 /.trellis/
+/.sdkmanrc

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>cn.flying</groupId>
+    <artifactId>record-platform</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>RecordPlatform</name>
+    <description>Enterprise file attestation platform</description>
+
+    <!-- Reactor module order: shared API first, then providers, then consumer -->
+    <modules>
+        <module>platform-api</module>
+        <module>platform-fisco</module>
+        <module>platform-storage</module>
+        <module>platform-backend</module>
+    </modules>
+</project>


### PR DESCRIPTION
## Summary
- Add root `pom.xml` as a pure aggregator POM that lists all four Maven modules (`platform-api`, `platform-fisco`, `platform-storage`, `platform-backend`)
- Enables IntelliJ to import the entire project as a single Maven project, resolving "Maven 项目配置不可用" errors
- Add `.sdkmanrc` to `.gitignore`

## Notes
- **Zero invasive**: no existing module's parent, dependencies, or build behavior is changed
- Existing CI commands (`mvn -f xxx/pom.xml`) are unaffected
- Reactor order is resolved by dependency topology: api → providers → backend

## Test plan
- [x] `mvn validate` passes with all 10 modules resolved
- [ ] IntelliJ reimport from root POM — all modules recognized, no resource compiler errors