### PR TITLE
fix(deps): upgrade Spring Boot 3.5.13 and Tomcat 10.1.54 for CVE fixes

### DIFF
--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.12</version>
+        <version>3.5.13</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
@@ -16,6 +16,7 @@
     <description>存证平台后端服务</description>
     <properties>
         <java.version>21</java.version>
+        <tomcat.version>10.1.54</tomcat.version>
         <jackson-bom.version>2.21.1</jackson-bom.version>
         <hutool.version>5.8.44</hutool.version>
         <mybatis-plus-bom.version>3.5.16</mybatis-plus-bom.version>

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.12</version>
+        <version>3.5.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>cn.flying</groupId>

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.12</version>
+        <version>3.5.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>cn.flying</groupId>


### PR DESCRIPTION
## Summary
- Upgrade Spring Boot 3.5.12 → 3.5.13 across all modules (platform-backend, platform-fisco, platform-storage)
- Override `tomcat.version` to 10.1.54 in platform-backend to resolve remaining Tomcat CVEs
- Dismiss Dependabot #59 (vite path traversal) — project uses vite 7.3.2, outside vulnerable range

## Security Alerts Resolved

### Tomcat embed-core 10.1.52 → 10.1.54 (8 Dependabot + 24 Code Scanning alerts)

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-29145 | CRITICAL | CLIENT_CERT authentication bypass |
| CVE-2026-29129 | HIGH | Cipher preference order not preserved |
| CVE-2026-29146 | HIGH | Padding Oracle in EncryptInterceptor |
| CVE-2026-34483 | HIGH | Improper encoding in JsonAccessLogValve |
| CVE-2026-34487 | HIGH | Sensitive info in log file |
| CVE-2026-25854 | MEDIUM | Open Redirect |
| CVE-2026-32990 | MEDIUM | Improper input validation |
| CVE-2026-34500 | MEDIUM | CLIENT_CERT authentication failure |

### Vite #59 (dismissed as inaccurate)
- CVE-2026-39365: path traversal in `.map` handling (affects <= 6.4.1)
- Project uses vite 7.3.2 (patched version for 7.x range)

## Risk Assessment
- **Low risk**: patch-level Spring Boot upgrade (3.5.12 → 3.5.13) + Tomcat minor version bump
- All backend unit tests pass locally
- No API or behavior changes

## Test Plan
- [x] `mvn clean package -DskipTests` — all modules compile
- [x] `mvn test` — backend unit tests pass
- [x] `mvn dependency:tree` — confirms tomcat-embed-core 10.1.54
- [ ] CI pipeline passes