### PR TITLE
chore: prepare 0.0.2 release

### DIFF
--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>cn.flying</groupId>
     <artifactId>platform-api</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>platform-api</name>
     <description>platform-api</description>
 

--- a/platform-backend/Dockerfile
+++ b/platform-backend/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.26.1/opentelemetry-javaagent.jar /opt/otel/opentelemetry-javaagent.jar
 RUN chmod 644 /opt/otel/opentelemetry-javaagent.jar
 
-COPY --from=build /workspace/platform-backend/backend-web/target/backend-web-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /workspace/platform-backend/backend-web/target/backend-web-0.0.2-SNAPSHOT.jar app.jar
 
 RUN chown -R app:app /app
 USER app

--- a/platform-backend/backend-api/pom.xml
+++ b/platform-backend/backend-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cn.flying</groupId>
         <artifactId>platform-backend</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>backend-api</artifactId>
     <name>backend-api</name>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>cn.flying</groupId>
             <artifactId>platform-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.2-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/platform-backend/backend-common/pom.xml
+++ b/platform-backend/backend-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cn.flying</groupId>
         <artifactId>platform-backend</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>backend-common</artifactId>
     <name>backend-common</name>

--- a/platform-backend/backend-dao/pom.xml
+++ b/platform-backend/backend-dao/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cn.flying</groupId>
         <artifactId>platform-backend</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>backend-dao</artifactId>
     <name>backend-dao</name>

--- a/platform-backend/backend-service/pom.xml
+++ b/platform-backend/backend-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cn.flying</groupId>
         <artifactId>platform-backend</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>backend-service</artifactId>
     <name>backend-service</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>cn.flying</groupId>
             <artifactId>platform-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>cn.flying</groupId>

--- a/platform-backend/backend-web/pom.xml
+++ b/platform-backend/backend-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>cn.flying</groupId>
         <artifactId>platform-backend</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>backend-web</artifactId>
     <name>backend-web</name>

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>cn.flying</groupId>
     <artifactId>platform-backend</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>RecordPlatform-backend</name>
     <description>存证平台后端服务</description>
     <properties>
@@ -68,27 +68,27 @@
             <dependency>
                 <groupId>cn.flying</groupId>
                 <artifactId>backend-dao</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>0.0.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>cn.flying</groupId>
                 <artifactId>backend-api</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>0.0.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>cn.flying</groupId>
                 <artifactId>backend-common</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>0.0.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>cn.flying</groupId>
                 <artifactId>backend-service</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>0.0.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>cn.flying</groupId>
                 <artifactId>backend-web</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>0.0.2-SNAPSHOT</version>
             </dependency>
             <!-- AWS SDK v2 for S3-compatible storage -->
             <dependency>

--- a/platform-fisco/Dockerfile
+++ b/platform-fisco/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /app
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.26.1/opentelemetry-javaagent.jar /opt/otel/opentelemetry-javaagent.jar
 RUN chmod 644 /opt/otel/opentelemetry-javaagent.jar
 
-COPY --from=build /workspace/platform-fisco/target/platform-fisco-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /workspace/platform-fisco/target/platform-fisco-0.0.2-SNAPSHOT.jar app.jar
 
 # Directory for TLS certificate files (mount at runtime)
 RUN mkdir -p /app/conf && chown -R app:app /app

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>cn.flying</groupId>
     <artifactId>platform-fisco</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>platform-fisco</name>
     <description>fisco</description>
     <properties>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>cn.flying</groupId>
             <artifactId>platform-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- Actuator + Micrometer for Prometheus metrics -->

--- a/platform-frontend/package.json
+++ b/platform-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-frontend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/platform-storage/Dockerfile
+++ b/platform-storage/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.26.1/opentelemetry-javaagent.jar /opt/otel/opentelemetry-javaagent.jar
 RUN chmod 644 /opt/otel/opentelemetry-javaagent.jar
 
-COPY --from=build /workspace/platform-storage/target/platform-storage-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /workspace/platform-storage/target/platform-storage-0.0.2-SNAPSHOT.jar app.jar
 
 RUN chown -R app:app /app
 USER app

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>cn.flying</groupId>
     <artifactId>platform-storage</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>platform-storage</name>
     <description>S3-compatible distributed storage service</description>
     <properties>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>cn.flying</groupId>
             <artifactId>platform-api</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- Spring Cloud Alibaba Nacos Config -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cn.flying</groupId>
     <artifactId>record-platform</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RecordPlatform</name>
     <description>Enterprise file attestation platform</description>

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -24,9 +24,9 @@ else
     JAR_BASE=""
 fi
 
-export STORAGE_JAR="${JAR_BASE:-$PROJECT_ROOT/platform-storage/target}/platform-storage-0.0.1-SNAPSHOT.jar"
-export FISCO_JAR="${JAR_BASE:-$PROJECT_ROOT/platform-fisco/target}/platform-fisco-0.0.1-SNAPSHOT.jar"
-export BACKEND_JAR="${JAR_BASE:-$PROJECT_ROOT/platform-backend/backend-web/target}/backend-web-0.0.1-SNAPSHOT.jar"
+export STORAGE_JAR="${JAR_BASE:-$PROJECT_ROOT/platform-storage/target}/platform-storage-0.0.2-SNAPSHOT.jar"
+export FISCO_JAR="${JAR_BASE:-$PROJECT_ROOT/platform-fisco/target}/platform-fisco-0.0.2-SNAPSHOT.jar"
+export BACKEND_JAR="${JAR_BASE:-$PROJECT_ROOT/platform-backend/backend-web/target}/backend-web-0.0.2-SNAPSHOT.jar"
 
 # ================================
 # 日志配置


### PR DESCRIPTION
## Summary
- bump Maven module versions from 0.0.1-SNAPSHOT to 0.0.2-SNAPSHOT
- bump the frontend package version to 0.0.2
- align Dockerfile and local script jar paths with the 0.0.2-SNAPSHOT artifacts

## Notes
- existing tag-based release workflow remains unchanged
- after this PR is merged, push tag v0.0.2 from main to publish the new container images

## Verification
- git diff --check
- no full build/test run in this change