### PR TITLE
chore(deps): consolidate backend dependency bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ package-lock.json
 /.sdkmanrc
 /.remember
 /.remember
+/.agents/

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -21,7 +21,7 @@
         <protobuf.version>4.34.1</protobuf.version>
         <dubbo-api-docs.version>2.7.8.1</dubbo-api-docs.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
     </properties>
 
     <dependencies>

--- a/platform-backend/backend-common/pom.xml
+++ b/platform-backend/backend-common/pom.xml
@@ -15,7 +15,7 @@
         <java.version>21</java.version>
         <knife4j.version>4.5.0</knife4j.version>
         <springdoc.version>2.8.16</springdoc.version>
-        <java-jwt.version>4.5.1</java-jwt.version>
+        <java-jwt.version>4.5.2</java-jwt.version>
         <redisson.version>4.3.1</redisson.version>
     </properties>
 

--- a/platform-backend/backend-web/pom.xml
+++ b/platform-backend/backend-web/pom.xml
@@ -16,7 +16,7 @@
         <poi.version>5.5.1</poi.version>
         <logstash.encoder.version>8.1</logstash.encoder.version>
         <skywalking.version>9.6.0</skywalking.version>
-        <spring-cloud-alibaba-dependencies.version>2025.0.0.0</spring-cloud-alibaba-dependencies.version>
+        <spring-cloud-alibaba-dependencies.version>2025.1.0.0</spring-cloud-alibaba-dependencies.version>
     </properties>
 
     <dependencies>

--- a/platform-backend/backend-web/pom.xml
+++ b/platform-backend/backend-web/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <java.version>21</java.version>
         <poi.version>5.5.1</poi.version>
-        <logstash.encoder.version>8.1</logstash.encoder.version>
+        <logstash.encoder.version>9.0</logstash.encoder.version>
         <skywalking.version>9.6.0</skywalking.version>
         <spring-cloud-alibaba-dependencies.version>2025.0.0.0</spring-cloud-alibaba-dependencies.version>
     </properties>

--- a/platform-backend/backend-web/pom.xml
+++ b/platform-backend/backend-web/pom.xml
@@ -16,7 +16,7 @@
         <poi.version>5.5.1</poi.version>
         <logstash.encoder.version>9.0</logstash.encoder.version>
         <skywalking.version>9.6.0</skywalking.version>
-        <spring-cloud-alibaba-dependencies.version>2025.1.0.0</spring-cloud-alibaba-dependencies.version>
+        <spring-cloud-alibaba-dependencies.version>2025.0.0.0</spring-cloud-alibaba-dependencies.version>
     </properties>
 
     <dependencies>

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -35,14 +35,14 @@
             Keep commons-io consistent on test/runtime classpath.
             Apache POI may pull an older commons-io which can break Testcontainers file copy (NoSuchMethodError: FileTimes.toUnixTime).
          -->
-        <commons-io.version>2.21.0</commons-io.version>
+        <commons-io.version>2.22.0</commons-io.version>
         <!--
             commons-compress 1.28+ requires commons-lang3 containing ArrayFill (>= 3.14.0).
             Testcontainers (docker-java) may require SystemProperties.getUserName(String) (>= 3.17.0).
          -->
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <netty.version>4.2.12.Final</netty.version>
-        <aws.sdk.version>2.42.28</aws.sdk.version>
+        <netty.version>4.2.13.Final</netty.version>
+        <aws.sdk.version>2.44.4</aws.sdk.version>
         <!--
             Mockito inline mock maker relies on Byte Buddy instrumentation.
             On some macOS/JDK builds, runtime self-attach is not available; pre-attaching the agent fixes it.

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -31,7 +31,7 @@
         <netty.version>4.2.12.Final</netty.version>
         <commons-io.version>2.21.0</commons-io.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <bcprov.version>1.83</bcprov.version>
+        <bcprov.version>1.84</bcprov.version>
     </properties>
     <dependencies>
         <dependency>

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -28,10 +28,10 @@
         <protobuf.version>4.34.1</protobuf.version>
         <logstash.logback.version>9.0</logstash.logback.version>
         <skywalking.toolkit.version>9.6.0</skywalking.toolkit.version>
-        <netty.version>4.2.12.Final</netty.version>
-        <commons-io.version>2.21.0</commons-io.version>
+        <netty.version>4.2.13.Final</netty.version>
+        <commons-io.version>2.22.0</commons-io.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <bcprov.version>1.83</bcprov.version>
+        <bcprov.version>1.84</bcprov.version>
     </properties>
     <dependencies>
         <dependency>
@@ -172,12 +172,12 @@
             <dependency>
                 <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.3</version>
             </dependency>
             <dependency>
                 <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.3</version>
             </dependency>
             <!-- Override transitive okhttp/okio from web3j to fix CVE (certificate validation + conversion error) -->
             <dependency>
@@ -188,7 +188,7 @@
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>3.9.1</version>
+                <version>3.17.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -21,7 +21,7 @@
         <aws.sdk.version>2.44.4</aws.sdk.version>
         <hutool.version>5.8.44</hutool.version>
         <redisson.version>4.3.1</redisson.version>
-        <spring-cloud-alibaba-dependencies.version>2025.1.0.0</spring-cloud-alibaba-dependencies.version>
+        <spring-cloud-alibaba-dependencies.version>2025.0.0.0</spring-cloud-alibaba-dependencies.version>
         <logstash.logback.version>9.0</logstash.logback.version>
         <skywalking.toolkit.version>9.6.0</skywalking.toolkit.version>
         <netty.version>4.2.13.Final</netty.version>

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -18,13 +18,13 @@
         <jackson-bom.version>2.21.1</jackson-bom.version>
         <dubbo.version>3.3.6</dubbo.version>
         <protobuf.version>4.34.1</protobuf.version>
-        <aws.sdk.version>2.42.28</aws.sdk.version>
+        <aws.sdk.version>2.44.4</aws.sdk.version>
         <hutool.version>5.8.44</hutool.version>
         <redisson.version>4.3.1</redisson.version>
-        <spring-cloud-alibaba-dependencies.version>2025.0.0.0</spring-cloud-alibaba-dependencies.version>
+        <spring-cloud-alibaba-dependencies.version>2025.1.0.0</spring-cloud-alibaba-dependencies.version>
         <logstash.logback.version>9.0</logstash.logback.version>
         <skywalking.toolkit.version>9.6.0</skywalking.toolkit.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
     </properties>
     <dependencies>
         <dependency>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.5.0-jre</version>
+            <version>33.6.0-jre</version>
         </dependency>
 
         <!-- api -->
@@ -177,12 +177,12 @@
             <dependency>
                 <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.3</version>
             </dependency>
             <dependency>
                 <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.3</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
## Summary
Consolidate 6 backend dependabot PRs:

- #215: platform-backend minor-and-patch group (6 updates) — **note: spring-cloud-alibaba reverted to 2025.0.0.0**
- #214: platform-storage minor-and-patch group (7 updates) — **note: spring-cloud-alibaba reverted to 2025.0.0.0**
- #213: platform-fisco minor-and-patch group (6 updates)
- #212: platform-api netty-bom 4.2.12 → 4.2.13
- #201: platform-fisco bouncycastle 1.83 → 1.84
- #163: platform-backend logstash-logback-encoder 8.1 → 9.0

## Fixes applied
- `963827b`: platform-backend `spring-cloud-alibaba-dependencies` 2025.1.0.0 → 2025.0.0.0
- `ab148d2`: platform-storage `spring-cloud-alibaba-dependencies` 2025.1.0.0 → 2025.0.0.0

Reason: Spring Cloud Alibaba 2025.1.0.0 depends on Spring Cloud 5.x, which requires Spring Boot 4.x — incompatible with our current Spring Boot 3.5.13.

## Skipped (incompatible with Spring Boot 3.5.x)
- #206, #162, #159, #158: Spring Boot 3.5.x → 4.0.x (major version bump)
- #197: springdoc 2.8.16 → 3.0.3 (requires Spring Boot 4.x)

## Verification
- `mvn -f platform-api install -DskipTests`: BUILD SUCCESS
- `mvn -f platform-backend package -DskipTests`: BUILD SUCCESS
- `mvn -f platform-fisco package -DskipTests`: BUILD SUCCESS
- `mvn -f platform-storage package -DskipTests`: BUILD SUCCESS

## Closes
Closes #215, Closes #214, Closes #213, Closes #212, Closes #201, Closes #163