### PR TITLE
fix: isolate public proof audit tenants

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,35 @@ jobs:
           require_count("errors", 0)
           PY
 
+      - name: Require Public Proof Audit Isolation IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.controller.PublicProofAuditTenantIsolationIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          expected_counts = {
+              "tests": 1,
+              "skipped": 0,
+              "failures": 0,
+              "errors": 0,
+          }
+          for name, expected in expected_counts.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"PublicProofAuditTenantIsolationIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Run FISCO Tests
         run: mvn -f platform-fisco/pom.xml test
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@
 |------|--------|----------|
 | REST 控制器 | 30 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 134 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 148 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 149 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 32（V1.0.0 ~ V1.14.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | CI 流水线（核心） | 5 | `.github/workflows/test.yml`, `perf-smoke.yml`, `docs.yml`, `security-poc.yml`, `docs-consistency.yml` |
 

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/JwtAuthenticationFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/JwtAuthenticationFilter.java
@@ -35,8 +35,8 @@ import java.util.UUID;
  * Validates JWT tokens, sets security context, tenant context and MDC for logging.
  * Also initializes traceId for distributed tracing.
  * 
- * 注意：租户ID由 TenantFilter 从请求头 X-Tenant-ID 设置，
- * 此过滤器验证 JWT 中的 tenantId 与请求头一致，防止跨租户攻击。
+ * 注意：受保护路径的租户ID由 TenantFilter 从请求头 X-Tenant-ID 设置，
+ * 此过滤器验证 JWT 中的 tenantId 与请求头一致；不信任租户头的公开路径则从有效 JWT 恢复真实租户。
  */
 @Component
 @Order(Const.SECURITY_ORDER)
@@ -63,7 +63,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         request.setAttribute(Const.TRACE_ID, traceId);
 
         try {
-            // 获取 TenantFilter 设置的租户ID（来自请求头 X-Tenant-ID）
+            // 获取 TenantFilter 设置的租户ID；公开路径可能因不信任租户头而没有该属性
             Long headerTenantId = (Long) request.getAttribute(Const.ATTR_TENANT_ID);
 
             String authorization = request.getHeader("Authorization");

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
@@ -25,8 +25,8 @@ import java.util.UUID;
 
 /**
  * 租户过滤器
- * 从请求头 X-Tenant-ID 中解析租户ID，设置到 TenantContext
- * 对于未携带租户ID的请求（白名单除外），返回错误
+ * 对需要租户隔离的请求解析 X-Tenant-ID 并设置 TenantContext。
+ * 公开 proof 路径不信任调用者提供的租户头，其他未携带租户ID的请求（白名单除外）返回错误。
  */
 @Component
 @Order(Const.SECURITY_ORDER - 10)  // 在 JWT 过滤器之前执行
@@ -34,6 +34,14 @@ public class TenantFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(TenantFilter.class);
     private static final String TENANT_HEADER = "X-Tenant-ID";
+
+    /**
+     * 全局公开 proof 路径不依赖租户查询，必须忽略匿名调用者提供的租户头。
+     */
+    private static final Set<String> TENANT_HEADER_IGNORED_PATHS = Set.of(
+            "/api/v1/public/proofs",
+            "/api/v1/public/proof-keys"
+    );
 
     /**
      * 白名单路径 - 这些路径不需要租户ID
@@ -83,17 +91,19 @@ public class TenantFilter extends OncePerRequestFilter {
 
             // 检查是否在白名单中
             if (isWhitelisted(requestPath)) {
-                // 白名单路径不强制要求租户头，但若请求主动携带租户头则仍写入上下文，确保后续 DB 查询具备正确的 tenant_id 条件
-                String tenantIdHeader = request.getHeader(TENANT_HEADER);
-                if (tenantIdHeader != null && !tenantIdHeader.isEmpty()) {
-                    try {
-                        Long tenantId = Long.parseLong(tenantIdHeader);
-                        TenantContext.setTenantId(tenantId);
-                        request.setAttribute(Const.ATTR_TENANT_ID, tenantId);
-                    } catch (NumberFormatException e) {
-                        log.warn("租户ID格式错误: {}", tenantIdHeader);
-                        sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
-                        return;
+                // 公开 proof 必须忽略租户头；其他白名单路径仍可使用租户头完成租户隔离查询
+                if (!shouldIgnoreTenantHeader(requestPath)) {
+                    String tenantIdHeader = request.getHeader(TENANT_HEADER);
+                    if (tenantIdHeader != null && !tenantIdHeader.isEmpty()) {
+                        try {
+                            Long tenantId = Long.parseLong(tenantIdHeader);
+                            TenantContext.setTenantId(tenantId);
+                            request.setAttribute(Const.ATTR_TENANT_ID, tenantId);
+                        } catch (NumberFormatException e) {
+                            log.warn("租户ID格式错误: {}", tenantIdHeader);
+                            sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
+                            return;
+                        }
                     }
                 }
                 filterChain.doFilter(request, response);
@@ -156,6 +166,17 @@ public class TenantFilter extends OncePerRequestFilter {
             return true;
         }
         return WHITELIST_PATHS.stream().anyMatch(uri::startsWith);
+    }
+
+    /**
+     * 判断白名单路径是否必须忽略请求租户头，并使用路径段边界避免相似前缀误匹配。
+     */
+    private boolean shouldIgnoreTenantHeader(String uri) {
+        if (uri == null) {
+            return false;
+        }
+        return TENANT_HEADER_IGNORED_PATHS.stream()
+                .anyMatch(prefix -> uri.equals(prefix) || uri.startsWith(prefix + "/"));
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/PublicProofAuditTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/PublicProofAuditTenantIsolationIT.java
@@ -1,0 +1,63 @@
+package cn.flying.controller;
+
+import cn.flying.test.support.BaseControllerIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+/**
+ * 公共 proof 匿名请求的操作日志租户隔离集成测试。
+ */
+@Transactional
+@DisplayName("Public proof audit tenant isolation integration tests")
+class PublicProofAuditTenantIsolationIT extends BaseControllerIntegrationTest {
+
+    private static final long FORGED_TENANT_ID = 9_876_543_210L;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * 验证伪造租户头经过完整过滤器、控制器 AOP 和 MyBatis 落库链路后不会污染目标租户日志。
+     */
+    @Test
+    @DisplayName("should not attribute anonymous public proof audit logs to forged tenant")
+    void shouldNotAttributeAnonymousPublicProofAuditLogsToForgedTenant() throws Exception {
+        String uniqueSuffix = UUID.randomUUID().toString().replace("-", "");
+        List<String> requestPaths = List.of(
+                "/api/v1/public/proofs/rp-audit-" + uniqueSuffix + "/status",
+                "/api/v1/public/proof-keys/audit-" + uniqueSuffix + "/versions/1");
+
+        for (String requestPath : requestPaths) {
+            mockMvc.perform(get(requestPath)
+                            .header(HEADER_TENANT_ID, FORGED_TENANT_ID))
+                    .andReturn();
+
+            Integer totalLogs = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM sys_operation_log WHERE request_url = ?",
+                    Integer.class,
+                    requestPath);
+            Integer forgedTenantLogs = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM sys_operation_log WHERE tenant_id = ? AND request_url = ?",
+                    Integer.class,
+                    FORGED_TENANT_ID,
+                    requestPath);
+            Integer systemTenantLogs = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM sys_operation_log WHERE tenant_id = 0 AND request_url = ?",
+                    Integer.class,
+                    requestPath);
+
+            assertThat(totalLogs).isEqualTo(1);
+            assertThat(forgedTenantLogs).isZero();
+            assertThat(systemTenantLogs).isEqualTo(1);
+        }
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/JwtAuthenticationFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/JwtAuthenticationFilterTest.java
@@ -1,6 +1,7 @@
 package cn.flying.filter;
 
 import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.JwtUtils;
 import com.auth0.jwt.interfaces.Claim;
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -136,13 +138,51 @@ class JwtAuthenticationFilterTest {
         }
 
         @Test
-        @DisplayName("should proceed when no tenant ID in header (non-tenant request)")
+        @DisplayName("should restore JWT tenant when no tenant request attribute exists")
         void shouldProceedWithoutHeaderTenantId() throws ServletException, IOException {
-            // No tenant ID in request attributes (non-tenant request)
+            AtomicLong capturedTenantId = new AtomicLong(-1L);
+            doAnswer(invocation -> {
+                Long tenantId = TenantContext.getTenantId();
+                capturedTenantId.set(tenantId == null ? -1L : tenantId);
+                return null;
+            }).when(filterChain).doFilter(request, response);
 
             filter.doFilterInternal(request, response, filterChain);
 
             assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+            assertEquals(1L, capturedTenantId.get());
+            assertEquals(1L, request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
+            verify(filterChain).doFilter(request, response);
+        }
+
+        /**
+         * 验证公开 proof 路径忽略伪造租户头后，完整过滤器链仍从有效 JWT 恢复真实租户。
+         */
+        @Test
+        @DisplayName("should use JWT tenant for public proof path with forged tenant header")
+        void shouldUseJwtTenantForPublicProofPathWithForgedTenantHeader() throws ServletException, IOException {
+            String path = "/api/v1/public/proofs/rp-proof-abc/status";
+            request.setRequestURI(path);
+            request.setServletPath(path);
+            request.addHeader("X-Tenant-ID", "999");
+            AtomicLong capturedTenantId = new AtomicLong(-1L);
+            doAnswer(invocation -> {
+                Long tenantId = TenantContext.getTenantId();
+                capturedTenantId.set(tenantId == null ? -1L : tenantId);
+                return null;
+            }).when(filterChain).doFilter(request, response);
+
+            new TenantFilter().doFilterInternal(
+                    request,
+                    response,
+                    (filteredRequest, filteredResponse) ->
+                            filter.doFilterInternal(request, response, filterChain));
+
+            assertEquals(200, response.getStatus());
+            assertEquals(1L, capturedTenantId.get());
+            assertEquals(1L, request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
             verify(filterChain).doFilter(request, response);
         }
     }

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
@@ -113,6 +113,67 @@ class TenantFilterTest {
     }
 
     /**
+     * 公开 proof 端点不得信任调用者提供的租户头，避免匿名请求污染指定租户的操作日志。
+     */
+    @Test
+    @DisplayName("should ignore tenant header for public proof endpoints")
+    void shouldIgnoreTenantHeaderForPublicProofEndpoints() throws ServletException, IOException {
+        AtomicLong chainCalls = new AtomicLong();
+        doAnswer(invocation -> {
+            MockHttpServletRequest chainedRequest = invocation.getArgument(0);
+            assertNull(TenantContext.getTenantId());
+            assertNull(chainedRequest.getAttribute(Const.ATTR_TENANT_ID));
+            chainCalls.incrementAndGet();
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        for (String path : new String[]{
+                "/api/v1/public/proofs/rp-proof-abc/status",
+                "/api/v1/public/proof-keys/key-main/versions/1"}) {
+            for (String tenantHeader : new String[]{"12", "spoofed-tenant", ""}) {
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+                request.setServletPath(path);
+                request.addHeader("X-Tenant-ID", tenantHeader);
+                MockHttpServletResponse response = new MockHttpServletResponse();
+
+                filter.doFilterInternal(request, response, filterChain);
+
+                assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+                assertNull(TenantContext.getTenantId());
+            }
+        }
+
+        assertEquals(6L, chainCalls.get());
+        verify(filterChain, times(6)).doFilter(any(), any());
+    }
+
+    /**
+     * 与公开 proof 前缀相似但不在该路径族内的请求不得误用忽略规则。
+     */
+    @Test
+    @DisplayName("should preserve tenant header for similar public proof prefix")
+    void shouldPreserveTenantHeaderForSimilarPublicProofPrefix() throws ServletException, IOException {
+        String path = "/api/v1/public/proofs-admin";
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        request.setServletPath(path);
+        request.addHeader("X-Tenant-ID", "12");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicLong capturedTenantId = new AtomicLong(-1L);
+        doAnswer(invocation -> {
+            Long tenantId = TenantContext.getTenantId();
+            capturedTenantId.set(tenantId == null ? -1L : tenantId);
+            return null;
+        }).when(filterChain).doFilter(request, response);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(12L, capturedTenantId.get());
+        assertEquals(12L, request.getAttribute(Const.ATTR_TENANT_ID));
+        assertNull(TenantContext.getTenantId());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    /**
      * 白名单路径不强制要求租户头，但若主动携带租户头，应写入 TenantContext 与 request attribute，
      * 以便后续 MyBatis-Plus 租户拦截器能正确注入 tenant_id 条件。
      */


### PR DESCRIPTION
## 关联任务

- Trellis 子任务：`07-15-roadmap-p1-stage-public-proof-audit-isolation`
- 父任务：`07-13-roadmap-p1-proof-productization`
- 阶段：P1 阶段门禁修复 1/4；本 PR 合并前不启动后续子任务

## 问题背景

公开 proof 状态和历史签名公钥接口允许匿名访问，但 `TenantFilter` 原先会解析白名单请求携带的可选 `X-Tenant-ID`。两个接口均使用 `@OperationLog`，日志插入时又会从 `TenantContext` 自动填充 `tenant_id`，导致匿名调用者可以伪造租户头，把自己的请求日志归入任意租户并污染租户审计数据。

## 修改内容

- 只对 `/api/v1/public/proofs/**` 与 `/api/v1/public/proof-keys/**` 忽略 `X-Tenant-ID`；使用精确路径或路径段边界，避免误伤相似前缀。
- 保持其他白名单、公开分享和受保护接口的租户头行为不变。
- 保持有效 JWT 的既有恢复语义：公开 proof 请求的真实租户只从已验证令牌恢复，伪造头不能覆盖。
- 增加数字、畸形、空租户头、相似前缀、JWT 恢复和公开分享兼容回归。
- 增加真实 Spring Filter -> Controller/AOP -> MyBatis -> MySQL 集成测试，覆盖两个公开端点并直接断言 `sys_operation_log.tenant_id`。
- 在 CI 中强制该 Failsafe 用例 `tests=1, skipped=0, failures=0, errors=0`；报告缺失、Docker 跳过或失败都会阻断。
- 将 `ROADMAP.md` 后端测试文件基线从 148 同步为 149。

## 影响范围与兼容性

- 影响模块：`platform-backend/backend-web`、`.github/workflows/test.yml`、`ROADMAP.md`。
- 不改变 API 路径、参数、响应、缓存头、限流、鉴权合同、数据库 schema、配置或依赖。
- 匿名公共 proof 调用仍无需 JWT/租户头；携带数字、畸形或空租户头时均按公开合同处理。
- 公开分享和受保护接口行为不变。

## 测试与验收证据

- 测试先行：旧实现的新增回归按预期失败，过滤链内捕获到伪造租户 `12`。
- 定向过滤器测试：26/26 通过。
- `mvn clean verify -Pit`：14/14 Reactor 模块成功；Surefire 1904 项、0 failure/error；JaCoCo 门禁通过。
- 本地 Failsafe：40 项因本机未安装 Docker 全部 skip，其中新增 IT 为 `tests=1, skipped=1`；该结果不计作通过，PR CI 的新增精确门禁必须实际执行并得到 `skipped=0`。
- 前端：Prettier、ESLint、Svelte check（0 error/0 warning）、33 文件 464/464 coverage tests、生产 build 全部通过。
- OpenAPI -> generated TypeScript：无漂移。
- docs routes/env/roadmap/versions 与 VitePress build：通过。
- 合约部署/指纹回归：34/34；artifact catalog 2 个 entry 验证通过。
- `actionlint`、全部 shell `bash -n`、`git diff --check`：通过。
- Trivy `vuln,secret,misconfig` HIGH/CRITICAL 阻断扫描：通过，0 finding。
- 两路独立只读人工审查分别覆盖生产安全/兼容链路和集成测试/CI 门禁，均无高置信、可执行 finding。

## CI 硬门禁

合并前必须确认：

- Backend Tests 真实执行 `PublicProofAuditTenantIsolationIT`，精确计数为 1/0/0/0；
- Frontend Tests、Contract Consistency、Docs Consistency/Build、Security Scan、Build Verification 以及仓库其他检查全部成功；
- Docker image 构建与 verifier 非 root/read-only 容器健康检查通过；
- 无未解决审查意见、无冲突，PR 可合并。

## 风险评估

- 代码风险低：每次请求只增加两个常量前缀的路径段边界判断，不增加 I/O、锁或共享可变状态。
- 主要兼容风险是误伤公开分享或 JWT 租户恢复，已由专项单元/组合过滤器回归覆盖。
- 历史已污染日志不自动清理，因为缺少可靠证据区分合法和伪造来源。

## 回滚方式

- 无数据库或配置迁移。
- 合并前删除分支即可；合并后 revert 本 PR 的 squash commit。
- 回滚会重新暴露伪造租户头问题；紧急回滚时应先在可信边缘阻断公共 proof 请求的 `X-Tenant-ID`。
