### PR TITLE
fix: 统一证明状态时间戳毫秒精度

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,35 @@ jobs:
           require_count("errors", 0)
           PY
 
+      - name: Require Proof Status Timestamp Migration IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.migration.ProofStatusTimestampMigrationIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          expected_counts = {
+              "tests": 1,
+              "skipped": 0,
+              "failures": 0,
+              "errors": 0,
+          }
+          for name, expected in expected_counts.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"ProofStatusTimestampMigrationIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Require Public Proof Audit Isolation IT Execution
         run: |
           python3 - <<'PY'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,8 +43,8 @@
 |------|--------|----------|
 | REST 控制器 | 30 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 134 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 152 | `platform-backend/**/src/test/java` |
-| 数据库迁移 | 32（V1.0.0 ~ V1.14.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
+| 后端测试文件 | 153 | `platform-backend/**/src/test/java` |
+| 数据库迁移 | 33（V1.0.0 ~ V1.15.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | CI 流水线（核心） | 5 | `.github/workflows/test.yml`, `perf-smoke.yml`, `docs.yml`, `security-poc.yml`, `docs-consistency.yml` |
 
 ### 表 1：PR 合并阻断门禁（已就位）

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/proof/signed/SignedProofArchiveServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/proof/signed/SignedProofArchiveServiceImpl.java
@@ -142,6 +142,7 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
     private final SnowflakeIdGenerator snowflakeIdGenerator;
     private final TransactionTemplate transactionTemplate;
     private final Semaphore exportPermits = new Semaphore(MAX_CONCURRENT_EXPORTS, true);
+    private volatile LongSupplier currentTimeMillisSource = System::currentTimeMillis;
     private volatile LongSupplier nanoTimeSource = System::nanoTime;
     private volatile long storageValidationBudgetNanos = MAX_STORAGE_VALIDATION_NANOS;
 
@@ -228,7 +229,7 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
             throw new GeneralException(ResultEnum.VERSION_CONFLICT, "证明状态版本无效");
         }
         String normalizedReason = normalizeReason(reason, "owner_revoked");
-        Date now = new Date();
+        Date now = currentDate();
         int updated = issuanceMapper.update(null, new LambdaUpdateWrapper<ProofBundleIssuance>()
                 .eq(ProofBundleIssuance::getTenantId, tenantId)
                 .eq(ProofBundleIssuance::getId, issuance.getId())
@@ -402,7 +403,7 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
             return rebuildExistingLocked(file, leaf, batch, payloads, concurrent);
         }
 
-        Date issuedAt = new Date();
+        Date issuedAt = currentDate();
         String issuedStatus = hasNewerSuccessfulVersion(file)
                 ? STATUS_SUPERSEDED
                 : STATUS_ACTIVE;
@@ -1196,7 +1197,7 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
                 || issuance.getStatusVersion() == Long.MAX_VALUE) {
             throw new GeneralException(ResultEnum.VERSION_CONFLICT, "证明状态无法推进为 INVALID");
         }
-        Date now = new Date();
+        Date now = currentDate();
         int updated = issuanceMapper.update(null, new LambdaUpdateWrapper<ProofBundleIssuance>()
                 .eq(ProofBundleIssuance::getTenantId, issuance.getTenantId())
                 .eq(ProofBundleIssuance::getId, issuance.getId())
@@ -1225,7 +1226,7 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
         if (issuance.getStatusVersion() == null || issuance.getStatusVersion() == Long.MAX_VALUE) {
             throw new GeneralException(ResultEnum.VERSION_CONFLICT, "证明状态版本无效");
         }
-        Date now = new Date();
+        Date now = currentDate();
         int updated = issuanceMapper.update(null, new LambdaUpdateWrapper<ProofBundleIssuance>()
                 .eq(ProofBundleIssuance::getTenantId, file.getTenantId())
                 .eq(ProofBundleIssuance::getId, issuance.getId())
@@ -1509,6 +1510,13 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
     private String normalizeReason(String reason, String fallback) {
         String normalized = StringUtils.hasText(reason) ? reason.trim() : fallback;
         return normalized.length() <= 256 ? normalized : normalized.substring(0, 256);
+    }
+
+    /**
+     * 从统一毫秒时间源创建生命周期时间，生产默认保持系统时钟语义并允许确定性测试。
+     */
+    private Date currentDate() {
+        return new Date(currentTimeMillisSource.getAsLong());
     }
 
     /**

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/proof/signed/SignedProofArchiveServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/proof/signed/SignedProofArchiveServiceImplTest.java
@@ -32,16 +32,8 @@ import cn.flying.service.manifest.ChunkManifestChunk;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
 import cn.flying.service.remote.FileRemoteClient;
-import cn.flying.verifier.DefaultProofVerifier;
-import cn.flying.verifier.VerificationContext;
-import cn.flying.verifier.VerificationLimits;
 import cn.flying.verifier.contract.SignedProofBundleContract;
 import cn.flying.verifier.contract.SignedProofBundleModel;
-import cn.flying.verifier.model.ChainRootEvidence;
-import cn.flying.verifier.model.PublicProofStatus;
-import cn.flying.verifier.model.PublicSigningKey;
-import cn.flying.verifier.model.VerificationOutcome;
-import cn.flying.verifier.resolver.Resolution;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
@@ -51,7 +43,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -67,11 +58,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -121,9 +107,6 @@ class SignedProofArchiveServiceImplTest {
     private static final String CHAIN_RECORD_ID = "chain-record-11";
     private static final String STORAGE_PATH = "tenant/7/file/11/chunk/0";
     private static final Date ISSUED_AT = new Date(1_752_451_200_123L);
-
-    @TempDir
-    Path tempDirectory;
 
     @Mock
     private FileMapper fileMapper;
@@ -262,7 +245,6 @@ class SignedProofArchiveServiceImplTest {
                     .contains("REDEPLOY_ADDRESS")
                     .contains("immutable_snapshot_validation_failed")
                     .contains("exactly one trailing LF byte");
-            assertPublicVerifierAccepts(first, issuance);
             InOrder lifecycleOrder = inOrder(fileMapper, issuanceMapper);
             lifecycleOrder.verify(fileMapper)
                     .lockVersionGroupForProofLifecycle(TENANT_ID, FILE_ID);
@@ -1324,11 +1306,24 @@ class SignedProofArchiveServiceImplTest {
         when(issuanceMapper.selectByLeafForUpdate(TENANT_ID, LEAF_ID)).thenReturn(active, revoked);
         when(issuanceMapper.update(eq(null), any(Wrapper.class))).thenReturn(1);
 
-        try (MockedStatic<SecurityUtils> security = mockStatic(SecurityUtils.class)) {
-            security.when(SecurityUtils::isAdmin).thenReturn(false);
-            ProofStatusVO status = service.revokeByLeafId(USER_ID, LEAF_ID, " owner request ");
-            assertThat(status.status()).isEqualTo("REVOKED");
-            assertThat(status.statusVersion()).isEqualTo(4L);
+        Date deterministicRevokedAt = new Date(ISSUED_AT.getTime() + 333L);
+        ReflectionTestUtils.setField(
+                service,
+                "currentTimeMillisSource",
+                (LongSupplier) deterministicRevokedAt::getTime);
+        try {
+            try (MockedStatic<SecurityUtils> security = mockStatic(SecurityUtils.class)) {
+                security.when(SecurityUtils::isAdmin).thenReturn(false);
+                ProofStatusVO status = service.revokeByLeafId(USER_ID, LEAF_ID, " owner request ");
+                assertThat(status.status()).isEqualTo("REVOKED");
+                assertThat(status.statusVersion()).isEqualTo(4L);
+                assertThat(status.updatedAt()).isEqualTo(deterministicRevokedAt);
+            }
+        } finally {
+            ReflectionTestUtils.setField(
+                    service,
+                    "currentTimeMillisSource",
+                    (LongSupplier) System::currentTimeMillis);
         }
 
         try (MockedStatic<SecurityUtils> security = mockStatic(SecurityUtils.class)) {
@@ -1634,62 +1629,6 @@ class SignedProofArchiveServiceImplTest {
                 .setStatus(status)
                 .setFirstSeenAt(ISSUED_AT)
                 .setDeleted(0);
-    }
-
-    /**
-     * 使用独立 SDK 对后端刚签发的真实 ZIP、JWS 和共享合同执行端到端验收。
-     */
-    private void assertPublicVerifierAccepts(ProofArchive archive, ProofBundleIssuance issuance) {
-        try {
-            Path original = tempDirectory.resolve("backend-produced-original.txt");
-            Path proof = tempDirectory.resolve("backend-produced-proof.zip");
-            Files.writeString(original, ORIGINAL_TEXT);
-            Files.write(proof, archive.toByteArray());
-
-            ProofSigningKeyMetadata key = signingProvider.currentKey();
-            PublicSigningKey publicKey = new PublicSigningKey(
-                    key.keyId(),
-                    key.keyVersion(),
-                    key.algorithm(),
-                    key.publicKeySpki(),
-                    key.publicKeyFingerprint(),
-                    "backend-production-test");
-            Instant issuedAt = issuance.getIssuedAt().toInstant();
-            PublicProofStatus status = new PublicProofStatus(
-                    issuance.getProofId(),
-                    "ACTIVE",
-                    String.valueOf(issuance.getStatusVersion()),
-                    issuance.getIssuedStatus(),
-                    issuance.getKeyId(),
-                    issuance.getKeyVersion(),
-                    null,
-                    issuedAt.toString(),
-                    issuedAt.toString(),
-                    "backend-production-test");
-            ContractRegistryEntryResponse registry = contractRegistry();
-            ChainRootEvidence chain = new ChainRootEvidence(
-                    ChainRootEvidence.SCHEMA_VERSION,
-                    registry.chainType(),
-                    registry.chainId(),
-                    registry.groupId(),
-                    registry.contractAddress(),
-                    "MB-900",
-                    leaf().getLeafHash(),
-                    BATCH_TRANSACTION_HASH,
-                    100L,
-                    "backend-production-test");
-            VerificationContext context = new VerificationContext(
-                    VerificationLimits.defaults(),
-                    (keyId, keyVersion) -> Resolution.resolved(publicKey),
-                    proofId -> Resolution.resolved(status),
-                    query -> Resolution.resolved(chain),
-                    Clock.fixed(issuedAt.plusSeconds(1), ZoneOffset.UTC));
-
-            assertThat(new DefaultProofVerifier().verify(original, proof, context).outcome())
-                    .isEqualTo(VerificationOutcome.VALID);
-        } catch (java.io.IOException e) {
-            throw new AssertionError("公共 verifier 兼容性 fixture 写入失败", e);
-        }
     }
 
     /**

--- a/platform-backend/backend-web/src/main/resources/db/migration/V1.15.0__proof_status_timestamp_precision.sql
+++ b/platform-backend/backend-web/src/main/resources/db/migration/V1.15.0__proof_status_timestamp_precision.sql
@@ -1,0 +1,18 @@
+-- V1.15.0: Preserve millisecond ordering between signed-proof issuance and public status updates.
+
+ALTER TABLE `proof_bundle_issuance`
+    MODIFY COLUMN `create_time` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT 'Create time',
+    MODIFY COLUMN `update_time` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) COMMENT 'Update time';
+
+UPDATE `proof_bundle_issuance`
+SET `create_time` = CASE
+        WHEN `create_time` < `issued_at` THEN `issued_at`
+        ELSE `create_time`
+    END,
+    `update_time` = CASE
+        WHEN `update_time` < `issued_at` THEN `issued_at`
+        ELSE `update_time`
+    END
+WHERE `create_time` < `issued_at`
+   OR `update_time` < `issued_at`;

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
@@ -1,5 +1,6 @@
 package cn.flying.migration;
 
+import org.flywaydb.core.api.MigrationVersion;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,14 +46,16 @@ class FlywayMigrationVersionTest {
         assertTrue(migrationFiles.contains("V1.12.0__attestation_batch_production_trigger.sql"));
         assertTrue(migrationFiles.contains("V1.13.0__attestation_contract_registry_snapshot.sql"));
         assertTrue(migrationFiles.contains("V1.14.0__signed_proof_bundle.sql"));
+        assertTrue(migrationFiles.contains("V1.15.0__proof_status_timestamp_precision.sql"));
         assertFalse(migrationFiles.contains("V1.0.1__add_account_nickname.sql"));
         assertFalse(migrationFiles.contains("V1.5.0__integrity_alert.sql"));
 
-        Set<String> versions = new HashSet<>();
+        Set<MigrationVersion> versions = new HashSet<>();
         for (String fileName : migrationFiles) {
             Matcher matcher = VERSION_PATTERN.matcher(fileName);
             assertTrue(matcher.matches(), "Invalid migration filename: " + fileName);
-            assertTrue(versions.add(matcher.group(1)), "Duplicate migration version: " + matcher.group(1));
+            MigrationVersion version = MigrationVersion.fromVersion(matcher.group(1));
+            assertTrue(versions.add(version), "Duplicate migration version: " + matcher.group(1));
         }
     }
 
@@ -234,6 +238,119 @@ class FlywayMigrationVersionTest {
         assertTrue(sql.contains("`public_key_spki`"));
         assertFalse(sql.matches("(?is).*UPDATE\\s+`file`.*"));
         assertFalse(sql.matches("(?is).*DROP\\s+(TABLE|COLUMN).*"));
+    }
+
+    /**
+     * 验证 proof 状态时间精度通过严格定向的前向迁移修复，且不改写生命周期或签名字段。
+     */
+    @Test
+    @DisplayName("should align proof status timestamp precision through a strict forward migration")
+    void shouldAlignProofStatusTimestampPrecisionThroughForwardMigration() throws IOException {
+        Path migration = resolveMigrationDir().resolve(
+                "V1.15.0__proof_status_timestamp_precision.sql");
+        assertTrue(Files.isRegularFile(migration), "Missing proof status timestamp precision migration");
+        String sql = Files.readString(migration);
+        String normalizedSql = sql.replaceAll("\\s+", " ").trim();
+
+        assertTrue(normalizedSql.contains("ALTER TABLE `proof_bundle_issuance`"));
+        assertTrue(normalizedSql.contains(
+                "MODIFY COLUMN `create_time` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)"));
+        assertTrue(normalizedSql.contains(
+                "MODIFY COLUMN `update_time` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)"));
+        assertTrue(normalizedSql.contains("ON UPDATE CURRENT_TIMESTAMP(3)"));
+        assertTrue(normalizedSql.contains(
+                "WHEN `create_time` < `issued_at` THEN `issued_at` ELSE `create_time` END"));
+        assertTrue(normalizedSql.contains(
+                "WHEN `update_time` < `issued_at` THEN `issued_at` ELSE `update_time` END"));
+        assertTrue(normalizedSql.contains(
+                "WHERE `create_time` < `issued_at` OR `update_time` < `issued_at`"));
+        assertFalse(normalizedSql.matches(
+                "(?is).*`(?:create_time|update_time)`\\s*<=\\s*`issued_at`.*"));
+
+        Pattern alterPattern = Pattern.compile(
+                "(?is)ALTER\\s+TABLE\\s+`proof_bundle_issuance`\\s+(.*?);");
+        Matcher alterMatcher = alterPattern.matcher(sql);
+        assertTrue(alterMatcher.find(), "Missing proof_bundle_issuance ALTER TABLE");
+        String alterClause = alterMatcher.group(1);
+        assertFalse(alterMatcher.find(), "Proof status precision must use one bounded ALTER TABLE");
+        assertEquals(
+                1,
+                countMatches(sql, Pattern.compile("(?i)ALTER\\s+TABLE\\s+")),
+                "Migration must not alter unrelated tables");
+        assertFalse(
+                Pattern.compile("(?i)\\b(?:ADD|DROP|CHANGE|RENAME)\\b")
+                        .matcher(alterClause)
+                        .find(),
+                "Migration ALTER must only modify the two timestamp columns");
+
+        Matcher modifiedColumnMatcher = Pattern.compile(
+                "(?i)MODIFY\\s+COLUMN\\s+`([^`]+)`")
+                .matcher(alterClause);
+        Set<String> modifiedColumns = new HashSet<>();
+        int modifiedColumnCount = 0;
+        while (modifiedColumnMatcher.find()) {
+            modifiedColumns.add(modifiedColumnMatcher.group(1).toLowerCase());
+            modifiedColumnCount++;
+        }
+        assertEquals(2, modifiedColumnCount, "Migration must modify exactly two columns");
+        assertEquals(
+                Set.of("create_time", "update_time"),
+                modifiedColumns,
+                "Migration must not modify lifecycle or signing columns");
+
+        Pattern updatePattern = Pattern.compile(
+                "(?is)UPDATE\\s+`proof_bundle_issuance`\\s+SET\\s+(.*?)\\s+WHERE\\s+.*?;");
+        Matcher updateMatcher = updatePattern.matcher(sql);
+        assertTrue(updateMatcher.find(), "Missing directed proof_bundle_issuance update");
+        String setClause = updateMatcher.group(1);
+        assertFalse(updateMatcher.find(), "Proof status timestamps must be repaired in one update");
+
+        for (String forbiddenColumn : List.of(
+                "issued_at",
+                "revoked_at",
+                "issued_status",
+                "status",
+                "status_version",
+                "status_reason",
+                "proof_id",
+                "manifest_hash",
+                "manifest_json",
+                "signature_jws",
+                "signature_algorithm",
+                "key_id",
+                "key_version",
+                "public_key_spki",
+                "public_key_fingerprint")) {
+            assertFalse(
+                    Pattern.compile("(?i)`?" + forbiddenColumn + "`?\\s*=")
+                            .matcher(setClause)
+                            .find(),
+                    "Migration must not assign protected column: " + forbiddenColumn);
+        }
+
+        assertEquals(
+                1,
+                countMatches(sql, Pattern.compile("(?i)UPDATE\\s+`proof_bundle_issuance`")),
+                "Proof status history must be repaired by exactly one directed update");
+        assertFalse(sql.matches("(?is).*ALTER\\s+TABLE\\s+`proof_signing_key`.*"));
+        assertFalse(sql.matches("(?is).*UPDATE\\s+`proof_signing_key`.*"));
+        assertFalse(sql.matches("(?is).*DROP\\s+(TABLE|COLUMN).*"));
+    }
+
+    /**
+     * 统计正则在迁移脚本中的非重叠匹配数量。
+     *
+     * @param value 待检查迁移文本
+     * @param pattern 目标正则
+     * @return 非重叠匹配数量
+     */
+    private int countMatches(String value, Pattern pattern) {
+        int count = 0;
+        Matcher matcher = pattern.matcher(value);
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/ProofStatusTimestampMigrationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/ProofStatusTimestampMigrationIT.java
@@ -16,10 +16,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -557,17 +560,8 @@ class ProofStatusTimestampMigrationIT {
      */
     private void verifyMillisecondBoundaries(Connection connection, boolean truncateFractional)
             throws SQLException {
-        if (truncateFractional) {
-            execute(
-                    connection,
-                    "SET SESSION sql_mode = "
-                            + "sys.list_add(@@SESSION.sql_mode, 'TIME_TRUNCATE_FRACTIONAL')");
-        } else {
-            execute(
-                    connection,
-                    "SET SESSION sql_mode = "
-                            + "sys.list_drop(@@SESSION.sql_mode, 'TIME_TRUNCATE_FRACTIONAL')");
-        }
+        String currentSqlMode = querySingleString(connection, "SELECT @@SESSION.sql_mode");
+        setSessionSqlMode(connection, sqlModeWithFractionalTruncation(currentSqlMode, truncateFractional));
 
         String activeMode = querySingleString(connection, "SELECT @@SESSION.sql_mode")
                 .toUpperCase(Locale.ROOT);
@@ -599,6 +593,21 @@ class ProofStatusTimestampMigrationIT {
         }
         verifyFractionalModeProbe(connection, truncateFractional);
         deleteBoundaryIssuance(connection);
+    }
+
+    /**
+     * 在 Java 中切换 TIME_TRUNCATE_FRACTIONAL，避免测试用户依赖 MySQL sys schema 的例程权限。
+     */
+    private String sqlModeWithFractionalTruncation(String sqlMode, boolean enabled) {
+        List<String> modes = Arrays.stream(sqlMode.split(","))
+                .map(String::trim)
+                .filter(mode -> !mode.isEmpty())
+                .filter(mode -> !"TIME_TRUNCATE_FRACTIONAL".equalsIgnoreCase(mode))
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (enabled) {
+            modes.add("TIME_TRUNCATE_FRACTIONAL");
+        }
+        return String.join(",", modes);
     }
 
     /**
@@ -651,7 +660,7 @@ class ProofStatusTimestampMigrationIT {
     }
 
     /**
-     * 执行不返回结果集的会话级 SQL。
+     * 执行不返回结果集的固定会话级 SQL。
      */
     private void execute(Connection connection, String sql) throws SQLException {
         try (Statement statement = connection.createStatement()) {

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/ProofStatusTimestampMigrationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/ProofStatusTimestampMigrationIT.java
@@ -1,0 +1,721 @@
+package cn.flying.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 使用独立真实 MySQL 验证 proof 状态时间精度前向迁移及历史数据定向修复。
+ */
+@Testcontainers(disabledWithoutDocker = false)
+class ProofStatusTimestampMigrationIT {
+
+    private static final String VERSION_1_14 = "1.14.0";
+    private static final String VERSION_1_15 = "1.15.0";
+    private static final long TENANT_ID = 98_150_001L;
+    private static final long BATCH_ID = 98_150_010L;
+    private static final long KEY_RECORD_ID = 98_150_020L;
+    private static final long DOUBLE_ANOMALY_ID = 98_150_101L;
+    private static final long CREATE_EARLY_ID = 98_150_102L;
+    private static final long UPDATE_EARLY_ID = 98_150_103L;
+    private static final long LEGAL_ACTIVE_ID = 98_150_104L;
+    private static final long LEGAL_REVOKED_ID = 98_150_105L;
+    private static final long LEGAL_SUPERSEDED_ID = 98_150_106L;
+    private static final long LEGAL_INVALID_ID = 98_150_107L;
+    private static final long BOUNDARY_ID = 98_150_108L;
+    private static final String KEY_ID = "migration-proof-status-key";
+    private static final int KEY_VERSION = 1;
+    private static final String SIGNATURE_ALGORITHM = "Ed25519";
+    private static final String PUBLIC_KEY_SPKI = "cHJvb2Ytc3RhdHVzLW1pZ3JhdGlvbi1rZXk=";
+    private static final String PUBLIC_KEY_FINGERPRINT = "sha256:" + "a".repeat(64);
+    private static final String ISSUED_AT = "2026-07-01 12:00:00.123";
+    private static final String EARLY_TIME = "2026-07-01 12:00:00.000";
+    private static final String LATER_CREATE_TIME = "2026-07-01 12:00:01.000";
+    private static final String LATER_UPDATE_TIME = "2026-07-01 12:00:02.000";
+    private static final String FORMATTED_ISSUED_AT = "2026-07-01 12:00:00.123000";
+    private static final List<String> MILLISECOND_BOUNDARIES =
+            List.of("001", "123", "499", "500", "999");
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                    .withDatabaseName("proof_status_timestamp_migration")
+                    .withUsername("test")
+                    .withPassword("test")
+                    .withCopyFileToContainer(
+                            MountableFile.forClasspathResource("init-test-db.sql"),
+                            "/docker-entrypoint-initdb.d/init-test-db.sql");
+
+    /**
+     * 验证从 V1.14 升级后列合同、历史定向修复和两种 SQL mode 下的毫秒边界均保持正确。
+     */
+    @Test
+    void shouldMigrateProofStatusTimestampsWithoutOverwritingValidLifecycleState() throws SQLException {
+        Flyway version114 = migrateTo(VERSION_1_14);
+        assertCurrentVersion(version114, VERSION_1_14);
+
+        List<HistoricalFixture> historicalFixtures = historicalFixtures();
+        Map<Long, IssuanceSnapshot> snapshotsBeforeMigration = new LinkedHashMap<>();
+        try (Connection connection = openConnection()) {
+            configureUtcSession(connection);
+            assertColumnPrecision(connection, "create_time", 0);
+            assertColumnPrecision(connection, "update_time", 0);
+            insertRequiredProofGraph(connection, historicalFixtures);
+            for (HistoricalFixture fixture : historicalFixtures) {
+                insertIssuance(connection, fixture);
+                snapshotsBeforeMigration.put(fixture.id(), loadSnapshot(connection, fixture.id()));
+            }
+
+            IssuanceSnapshot anomalyBefore = snapshotsBeforeMigration.get(DOUBLE_ANOMALY_ID);
+            assertThat(anomalyBefore.updateTime()).isLessThan(anomalyBefore.issuedAt());
+            assertThat(countImpossibleTimeRows(connection)).isEqualTo(3);
+        }
+
+        Flyway version115 = migrateTo(VERSION_1_15);
+        assertCurrentVersion(version115, VERSION_1_15);
+
+        try (Connection connection = openConnection()) {
+            configureUtcSession(connection);
+            assertMigratedColumnContract(connection, "create_time", false);
+            assertMigratedColumnContract(connection, "update_time", true);
+            assertThat(countImpossibleTimeRows(connection)).isZero();
+
+            IssuanceSnapshot doubleAnomaly = loadSnapshot(connection, DOUBLE_ANOMALY_ID);
+            assertImmutableContractUnchanged(
+                    snapshotsBeforeMigration.get(DOUBLE_ANOMALY_ID), doubleAnomaly);
+            assertThat(doubleAnomaly.createTime()).isEqualTo(FORMATTED_ISSUED_AT);
+            assertThat(doubleAnomaly.updateTime()).isEqualTo(FORMATTED_ISSUED_AT);
+
+            IssuanceSnapshot createEarly = loadSnapshot(connection, CREATE_EARLY_ID);
+            assertImmutableContractUnchanged(snapshotsBeforeMigration.get(CREATE_EARLY_ID), createEarly);
+            assertThat(createEarly.createTime()).isEqualTo(FORMATTED_ISSUED_AT);
+            assertThat(createEarly.updateTime())
+                    .isEqualTo(snapshotsBeforeMigration.get(CREATE_EARLY_ID).updateTime());
+
+            IssuanceSnapshot updateEarly = loadSnapshot(connection, UPDATE_EARLY_ID);
+            assertImmutableContractUnchanged(snapshotsBeforeMigration.get(UPDATE_EARLY_ID), updateEarly);
+            assertThat(updateEarly.createTime())
+                    .isEqualTo(snapshotsBeforeMigration.get(UPDATE_EARLY_ID).createTime());
+            assertThat(updateEarly.updateTime()).isEqualTo(FORMATTED_ISSUED_AT);
+
+            for (long id : List.of(
+                    LEGAL_ACTIVE_ID,
+                    LEGAL_REVOKED_ID,
+                    LEGAL_SUPERSEDED_ID,
+                    LEGAL_INVALID_ID)) {
+                assertThat(loadSnapshot(connection, id))
+                        .as("合法生命周期快照不得被迁移改写，issuanceId=%s", id)
+                        .isEqualTo(snapshotsBeforeMigration.get(id));
+            }
+
+            verifyMillisecondBoundariesAcrossSqlModes(connection);
+        }
+    }
+
+    /**
+     * 构造迁移前覆盖双异常、两个单向异常及四种合法状态的历史 fixture。
+     *
+     * @return 有确定时间和值语义的历史签发记录
+     */
+    private List<HistoricalFixture> historicalFixtures() {
+        return List.of(
+                fixture(DOUBLE_ANOMALY_ID, "ACTIVE", 1L, null, null, EARLY_TIME, EARLY_TIME),
+                fixture(CREATE_EARLY_ID, "ACTIVE", 1L, null, null, EARLY_TIME, LATER_UPDATE_TIME),
+                fixture(UPDATE_EARLY_ID, "ACTIVE", 1L, null, null, LATER_CREATE_TIME, EARLY_TIME),
+                fixture(
+                        LEGAL_ACTIVE_ID,
+                        "ACTIVE",
+                        1L,
+                        null,
+                        null,
+                        LATER_CREATE_TIME,
+                        LATER_UPDATE_TIME),
+                fixture(
+                        LEGAL_REVOKED_ID,
+                        "REVOKED",
+                        2L,
+                        "migration revoked reason",
+                        "2026-07-01 12:00:01.500",
+                        LATER_CREATE_TIME,
+                        LATER_UPDATE_TIME),
+                fixture(
+                        LEGAL_SUPERSEDED_ID,
+                        "SUPERSEDED",
+                        3L,
+                        "migration superseded reason",
+                        null,
+                        LATER_CREATE_TIME,
+                        LATER_UPDATE_TIME),
+                fixture(
+                        LEGAL_INVALID_ID,
+                        "INVALID",
+                        4L,
+                        "migration invalid reason",
+                        null,
+                        LATER_CREATE_TIME,
+                        LATER_UPDATE_TIME));
+    }
+
+    /**
+     * 创建带固定签发时间和不可变签名字段的历史 fixture。
+     */
+    private HistoricalFixture fixture(
+            long id,
+            String status,
+            long statusVersion,
+            String statusReason,
+            String revokedAt,
+            String createTime,
+            String updateTime
+    ) {
+        return new HistoricalFixture(
+                id,
+                status,
+                statusVersion,
+                statusReason,
+                ISSUED_AT,
+                revokedAt,
+                createTime,
+                updateTime);
+    }
+
+    /**
+     * 使用显式 target 迁移到指定版本，避免测试意外消费后续迁移。
+     */
+    private Flyway migrateTo(String targetVersion) {
+        Flyway flyway = Flyway.configure()
+                .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+                .locations("classpath:db/migration")
+                .target(MigrationVersion.fromVersion(targetVersion))
+                .load();
+        flyway.migrate();
+        return flyway;
+    }
+
+    /**
+     * 断言 Flyway 当前版本与分阶段目标完全一致。
+     */
+    private void assertCurrentVersion(Flyway flyway, String expectedVersion) {
+        assertThat(flyway.info().current()).isNotNull();
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo(expectedVersion);
+    }
+
+    /**
+     * 打开测试数据库连接。
+     */
+    private Connection openConnection() throws SQLException {
+        return DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+    }
+
+    /**
+     * 固定当前连接为 UTC，隔离运行节点默认时区差异。
+     */
+    private void configureUtcSession(Connection connection) throws SQLException {
+        execute(connection, "SET SESSION time_zone = '+00:00'");
+    }
+
+    /**
+     * 断言迁移前目标列的实际 DATETIME 精度。
+     */
+    private void assertColumnPrecision(Connection connection, String columnName, int expectedPrecision)
+            throws SQLException {
+        ColumnMetadata metadata = loadColumnMetadata(connection, columnName);
+        assertThat(metadata.columnType()).isEqualToIgnoringCase("datetime");
+        assertThat(metadata.datetimePrecision()).isEqualTo(expectedPrecision);
+    }
+
+    /**
+     * 断言迁移后目标列的精度、可空性、默认值和自动更新表达式。
+     */
+    private void assertMigratedColumnContract(
+            Connection connection,
+            String columnName,
+            boolean autoUpdated
+    ) throws SQLException {
+        ColumnMetadata metadata = loadColumnMetadata(connection, columnName);
+        assertThat(metadata.columnType()).isEqualToIgnoringCase("datetime(3)");
+        assertThat(metadata.datetimePrecision()).isEqualTo(3);
+        assertThat(metadata.nullable()).isEqualTo("NO");
+        assertThat(metadata.columnDefault()).isEqualToIgnoringCase("CURRENT_TIMESTAMP(3)");
+        String normalizedExtra = metadata.extra().toLowerCase(Locale.ROOT);
+        if (autoUpdated) {
+            assertThat(normalizedExtra).contains("on update current_timestamp(3)");
+        } else {
+            assertThat(normalizedExtra).doesNotContain("on update");
+        }
+    }
+
+    /**
+     * 从 INFORMATION_SCHEMA 读取目标列的完整迁移合同。
+     */
+    private ColumnMetadata loadColumnMetadata(Connection connection, String columnName) throws SQLException {
+        String sql = """
+                SELECT COLUMN_TYPE, DATETIME_PRECISION, IS_NULLABLE, COLUMN_DEFAULT, EXTRA
+                  FROM INFORMATION_SCHEMA.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE()
+                   AND TABLE_NAME = 'proof_bundle_issuance'
+                   AND COLUMN_NAME = ?
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, columnName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).as("目标列必须存在: %s", columnName).isTrue();
+                return new ColumnMetadata(
+                        resultSet.getString("COLUMN_TYPE"),
+                        resultSet.getInt("DATETIME_PRECISION"),
+                        resultSet.getString("IS_NULLABLE"),
+                        resultSet.getString("COLUMN_DEFAULT"),
+                        resultSet.getString("EXTRA"));
+            }
+        }
+    }
+
+    /**
+     * 插入满足 V1.14 全部外键约束的 file、batch、leaf 与 signing key fixture。
+     */
+    private void insertRequiredProofGraph(
+            Connection connection,
+            List<HistoricalFixture> historicalFixtures
+    ) throws SQLException {
+        insertBatch(connection, historicalFixtures.size() + 1);
+        insertSigningKey(connection);
+        int leafIndex = 0;
+        for (HistoricalFixture fixture : historicalFixtures) {
+            insertFileAndLeaf(connection, fixture.id(), leafIndex++);
+        }
+        insertFileAndLeaf(connection, BOUNDARY_ID, leafIndex);
+    }
+
+    /**
+     * 插入所有 leaf 共用的 attestation batch。
+     */
+    private void insertBatch(Connection connection, int leafCount) throws SQLException {
+        String sql = """
+                INSERT INTO attestation_batch(
+                    id, tenant_id, batch_no, idempotency_key, merkle_root,
+                    proof_algorithm, leaf_count, status, deleted
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, BATCH_ID);
+            statement.setLong(2, TENANT_ID);
+            statement.setString(3, "proof-status-time-migration");
+            statement.setString(4, "proof-status-time-migration");
+            statement.setString(5, hashFor(BATCH_ID));
+            statement.setString(6, "SHA-256");
+            statement.setInt(7, leafCount);
+            statement.setString(8, "CONFIRMED");
+            statement.setInt(9, 0);
+            assertThat(statement.executeUpdate()).isEqualTo(1);
+        }
+    }
+
+    /**
+     * 插入所有 issuance 共用且身份完整的 proof signing key。
+     */
+    private void insertSigningKey(Connection connection) throws SQLException {
+        String sql = """
+                INSERT INTO proof_signing_key(
+                    id, key_id, key_version, signature_algorithm, public_key_spki,
+                    public_key_fingerprint, status, first_seen_at, deleted
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, KEY_RECORD_ID);
+            statement.setString(2, KEY_ID);
+            statement.setInt(3, KEY_VERSION);
+            statement.setString(4, SIGNATURE_ALGORITHM);
+            statement.setString(5, PUBLIC_KEY_SPKI);
+            statement.setString(6, PUBLIC_KEY_FINGERPRINT);
+            statement.setString(7, "ACTIVE");
+            statement.setString(8, ISSUED_AT);
+            statement.setInt(9, 0);
+            assertThat(statement.executeUpdate()).isEqualTo(1);
+        }
+    }
+
+    /**
+     * 为一个 issuance 插入匹配 composite foreign key 的 file 与 attestation leaf。
+     */
+    private void insertFileAndLeaf(Connection connection, long id, int leafIndex) throws SQLException {
+        String fileSql = """
+                INSERT INTO file(
+                    id, tenant_id, uid, file_name, file_hash, status, deleted,
+                    create_time, version, is_latest, version_group_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(fileSql)) {
+            statement.setLong(1, id);
+            statement.setLong(2, TENANT_ID);
+            statement.setString(3, "migration-user-" + id);
+            statement.setString(4, "proof-status-migration-" + id + ".bin");
+            statement.setString(5, hashFor(id));
+            statement.setInt(6, 2);
+            statement.setInt(7, 0);
+            statement.setString(8, EARLY_TIME);
+            statement.setInt(9, 1);
+            statement.setInt(10, 1);
+            statement.setLong(11, id);
+            assertThat(statement.executeUpdate()).isEqualTo(1);
+        }
+
+        String leafSql = """
+                INSERT INTO attestation_leaf(
+                    id, tenant_id, batch_id, file_id, file_version, file_hash,
+                    evidence_type, evidence_hash, chain_record_id, leaf_hash,
+                    leaf_index, proof_path_json, proof_algorithm, deleted
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(leafSql)) {
+            statement.setLong(1, id);
+            statement.setLong(2, TENANT_ID);
+            statement.setLong(3, BATCH_ID);
+            statement.setLong(4, id);
+            statement.setInt(5, 1);
+            statement.setString(6, hashFor(id));
+            statement.setString(7, "LEGACY_CHAIN_RECORD_ID");
+            statement.setString(8, hashFor(id));
+            statement.setString(9, "chain-record-" + id);
+            statement.setString(10, hashFor(id + 1));
+            statement.setInt(11, leafIndex);
+            statement.setString(12, "[]");
+            statement.setString(13, "SHA-256");
+            statement.setInt(14, 0);
+            assertThat(statement.executeUpdate()).isEqualTo(1);
+        }
+    }
+
+    /**
+     * 插入包含完整状态、签名和时间字段的 proof issuance。
+     */
+    private void insertIssuance(Connection connection, HistoricalFixture fixture) throws SQLException {
+        String sql = """
+                INSERT INTO proof_bundle_issuance(
+                    id, tenant_id, proof_id, file_id, file_version, leaf_id,
+                    manifest_hash, manifest_json, signature_jws, signature_algorithm,
+                    key_id, key_version, public_key_spki, public_key_fingerprint,
+                    issued_status, status, status_version, status_reason,
+                    issued_at, revoked_at, create_time, update_time, deleted
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, fixture.id());
+            statement.setLong(2, TENANT_ID);
+            statement.setString(3, "rp-proof-migration-" + fixture.id());
+            statement.setLong(4, fixture.id());
+            statement.setInt(5, 1);
+            statement.setLong(6, fixture.id());
+            statement.setString(7, hashFor(fixture.id()));
+            statement.setString(8, "{\"fixtureId\":" + fixture.id() + "}");
+            statement.setString(9, "header.payload.signature-" + fixture.id());
+            statement.setString(10, SIGNATURE_ALGORITHM);
+            statement.setString(11, KEY_ID);
+            statement.setInt(12, KEY_VERSION);
+            statement.setString(13, PUBLIC_KEY_SPKI);
+            statement.setString(14, PUBLIC_KEY_FINGERPRINT);
+            statement.setString(15, "ACTIVE");
+            statement.setString(16, fixture.status());
+            statement.setLong(17, fixture.statusVersion());
+            statement.setString(18, fixture.statusReason());
+            statement.setString(19, fixture.issuedAt());
+            setNullableTimestamp(statement, 20, fixture.revokedAt());
+            statement.setString(21, fixture.createTime());
+            statement.setString(22, fixture.updateTime());
+            statement.setInt(23, 0);
+            assertThat(statement.executeUpdate()).isEqualTo(1);
+        }
+    }
+
+    /**
+     * 为 nullable DATETIME 参数设置文本时间或 SQL NULL。
+     */
+    private void setNullableTimestamp(PreparedStatement statement, int index, String value)
+            throws SQLException {
+        if (value == null) {
+            statement.setNull(index, Types.TIMESTAMP);
+        } else {
+            statement.setString(index, value);
+        }
+    }
+
+    /**
+     * 读取包含固定六位小数文本和全部状态签名字段的 issuance 快照。
+     */
+    private IssuanceSnapshot loadSnapshot(Connection connection, long id) throws SQLException {
+        String sql = """
+                SELECT DATE_FORMAT(issued_at, '%Y-%m-%d %H:%i:%s.%f') AS issued_at_text,
+                       DATE_FORMAT(revoked_at, '%Y-%m-%d %H:%i:%s.%f') AS revoked_at_text,
+                       DATE_FORMAT(create_time, '%Y-%m-%d %H:%i:%s.%f') AS create_time_text,
+                       DATE_FORMAT(update_time, '%Y-%m-%d %H:%i:%s.%f') AS update_time_text,
+                       issued_status, status, status_version, status_reason,
+                       manifest_hash, manifest_json, signature_jws, signature_algorithm,
+                       key_id, key_version, public_key_spki, public_key_fingerprint, deleted
+                  FROM proof_bundle_issuance
+                 WHERE id = ?
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, id);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).as("issuance 必须存在: %s", id).isTrue();
+                return new IssuanceSnapshot(
+                        resultSet.getString("issued_at_text"),
+                        resultSet.getString("revoked_at_text"),
+                        resultSet.getString("create_time_text"),
+                        resultSet.getString("update_time_text"),
+                        resultSet.getString("issued_status"),
+                        resultSet.getString("status"),
+                        resultSet.getLong("status_version"),
+                        resultSet.getString("status_reason"),
+                        resultSet.getString("manifest_hash"),
+                        resultSet.getString("manifest_json"),
+                        resultSet.getString("signature_jws"),
+                        resultSet.getString("signature_algorithm"),
+                        resultSet.getString("key_id"),
+                        resultSet.getInt("key_version"),
+                        resultSet.getString("public_key_spki"),
+                        resultSet.getString("public_key_fingerprint"),
+                        resultSet.getInt("deleted"));
+            }
+        }
+    }
+
+    /**
+     * 断言迁移仅能修改 create_time/update_time，不得漂移其余身份和状态合同。
+     */
+    private void assertImmutableContractUnchanged(
+            IssuanceSnapshot before,
+            IssuanceSnapshot after
+    ) {
+        assertThat(after.issuedAt()).isEqualTo(before.issuedAt());
+        assertThat(after.revokedAt()).isEqualTo(before.revokedAt());
+        assertThat(after.issuedStatus()).isEqualTo(before.issuedStatus());
+        assertThat(after.status()).isEqualTo(before.status());
+        assertThat(after.statusVersion()).isEqualTo(before.statusVersion());
+        assertThat(after.statusReason()).isEqualTo(before.statusReason());
+        assertThat(after.manifestHash()).isEqualTo(before.manifestHash());
+        assertThat(after.manifestJson()).isEqualTo(before.manifestJson());
+        assertThat(after.signatureJws()).isEqualTo(before.signatureJws());
+        assertThat(after.signatureAlgorithm()).isEqualTo(before.signatureAlgorithm());
+        assertThat(after.keyId()).isEqualTo(before.keyId());
+        assertThat(after.keyVersion()).isEqualTo(before.keyVersion());
+        assertThat(after.publicKeySpki()).isEqualTo(before.publicKeySpki());
+        assertThat(after.publicKeyFingerprint()).isEqualTo(before.publicKeyFingerprint());
+        assertThat(after.deleted()).isEqualTo(before.deleted());
+    }
+
+    /**
+     * 统计仍违反 create/update 不早于签发时间的不可能历史行。
+     */
+    private int countImpossibleTimeRows(Connection connection) throws SQLException {
+        String sql = """
+                SELECT COUNT(*)
+                  FROM proof_bundle_issuance
+                 WHERE create_time < issued_at
+                    OR update_time < issued_at
+                """;
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getInt(1);
+        }
+    }
+
+    /**
+     * 在默认 rounding 与 TIME_TRUNCATE_FRACTIONAL 模式下验证五个三位毫秒边界。
+     */
+    private void verifyMillisecondBoundariesAcrossSqlModes(Connection connection) throws SQLException {
+        String originalSqlMode = querySingleString(connection, "SELECT @@SESSION.sql_mode");
+        try {
+            verifyMillisecondBoundaries(connection, false);
+            verifyMillisecondBoundaries(connection, true);
+        } finally {
+            setSessionSqlMode(connection, originalSqlMode);
+        }
+    }
+
+    /**
+     * 切换当前连接的小数秒处理模式并逐个验证三位毫秒往返。
+     */
+    private void verifyMillisecondBoundaries(Connection connection, boolean truncateFractional)
+            throws SQLException {
+        if (truncateFractional) {
+            execute(
+                    connection,
+                    "SET SESSION sql_mode = "
+                            + "sys.list_add(@@SESSION.sql_mode, 'TIME_TRUNCATE_FRACTIONAL')");
+        } else {
+            execute(
+                    connection,
+                    "SET SESSION sql_mode = "
+                            + "sys.list_drop(@@SESSION.sql_mode, 'TIME_TRUNCATE_FRACTIONAL')");
+        }
+
+        String activeMode = querySingleString(connection, "SELECT @@SESSION.sql_mode")
+                .toUpperCase(Locale.ROOT);
+        if (truncateFractional) {
+            assertThat(activeMode).contains("TIME_TRUNCATE_FRACTIONAL");
+        } else {
+            assertThat(activeMode).doesNotContain("TIME_TRUNCATE_FRACTIONAL");
+        }
+
+        for (String millisecond : MILLISECOND_BOUNDARIES) {
+            deleteBoundaryIssuance(connection);
+            String value = "2026-07-02 00:00:00." + millisecond;
+            insertIssuance(
+                    connection,
+                    new HistoricalFixture(
+                            BOUNDARY_ID,
+                            "ACTIVE",
+                            1L,
+                            null,
+                            value,
+                            null,
+                            value,
+                            value));
+            IssuanceSnapshot snapshot = loadSnapshot(connection, BOUNDARY_ID);
+            String expected = value + "000";
+            assertThat(snapshot.issuedAt()).isEqualTo(expected);
+            assertThat(snapshot.createTime()).isEqualTo(expected);
+            assertThat(snapshot.updateTime()).isEqualTo(expected);
+        }
+        verifyFractionalModeProbe(connection, truncateFractional);
+        deleteBoundaryIssuance(connection);
+    }
+
+    /**
+     * 使用四位小数输入校准当前 SQL mode，证明 rounding 与 truncation 分支确实生效。
+     */
+    private void verifyFractionalModeProbe(Connection connection, boolean truncateFractional)
+            throws SQLException {
+        deleteBoundaryIssuance(connection);
+        String value = "2026-07-02 00:00:00.1235";
+        insertIssuance(
+                connection,
+                new HistoricalFixture(
+                        BOUNDARY_ID,
+                        "ACTIVE",
+                        1L,
+                        null,
+                        value,
+                        null,
+                        value,
+                        value));
+        String expected = truncateFractional
+                ? "2026-07-02 00:00:00.123000"
+                : "2026-07-02 00:00:00.124000";
+        IssuanceSnapshot snapshot = loadSnapshot(connection, BOUNDARY_ID);
+        assertThat(snapshot.issuedAt()).isEqualTo(expected);
+        assertThat(snapshot.createTime()).isEqualTo(expected);
+        assertThat(snapshot.updateTime()).isEqualTo(expected);
+    }
+
+    /**
+     * 删除可复用的边界 issuance，保留其真实外键图。
+     */
+    private void deleteBoundaryIssuance(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "DELETE FROM proof_bundle_issuance WHERE id = ?")) {
+            statement.setLong(1, BOUNDARY_ID);
+            statement.executeUpdate();
+        }
+    }
+
+    /**
+     * 恢复当前连接原始 SQL mode，不修改全局数据库配置。
+     */
+    private void setSessionSqlMode(Connection connection, String sqlMode) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SET SESSION sql_mode = ?")) {
+            statement.setString(1, sqlMode);
+            statement.execute();
+        }
+    }
+
+    /**
+     * 执行不返回结果集的会话级 SQL。
+     */
+    private void execute(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    /**
+     * 查询单个非空字符串值。
+     */
+    private String querySingleString(Connection connection, String sql) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getString(1);
+        }
+    }
+
+    /**
+     * 构造满足数据库长度合同的确定性 SHA-256 文本 fixture。
+     */
+    private String hashFor(long value) {
+        return "sha256:" + String.format(Locale.ROOT, "%064x", value);
+    }
+
+    private record HistoricalFixture(
+            long id,
+            String status,
+            long statusVersion,
+            String statusReason,
+            String issuedAt,
+            String revokedAt,
+            String createTime,
+            String updateTime
+    ) {
+    }
+
+    private record ColumnMetadata(
+            String columnType,
+            int datetimePrecision,
+            String nullable,
+            String columnDefault,
+            String extra
+    ) {
+    }
+
+    private record IssuanceSnapshot(
+            String issuedAt,
+            String revokedAt,
+            String createTime,
+            String updateTime,
+            String issuedStatus,
+            String status,
+            long statusVersion,
+            String statusReason,
+            String manifestHash,
+            String manifestJson,
+            String signatureJws,
+            String signatureAlgorithm,
+            String keyId,
+            int keyVersion,
+            String publicKeySpki,
+            String publicKeyFingerprint,
+            int deleted
+    ) {
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/proof/SignedProofLifecycleConcurrencyIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/proof/SignedProofLifecycleConcurrencyIT.java
@@ -38,32 +38,70 @@ import cn.flying.service.proof.signed.ProofSigningKeyMetadata;
 import cn.flying.service.proof.signed.ProofSigningProperties;
 import cn.flying.service.proof.signed.SignedProofArchiveService;
 import cn.flying.test.BaseIntegrationTest;
+import cn.flying.verifier.DefaultProofVerifier;
+import cn.flying.verifier.VerificationContext;
+import cn.flying.verifier.VerificationLimits;
+import cn.flying.verifier.model.ChainRootEvidence;
+import cn.flying.verifier.model.PublicProofStatus;
+import cn.flying.verifier.model.VerificationCheck;
+import cn.flying.verifier.model.VerificationCheckStatus;
+import cn.flying.verifier.model.VerificationCode;
+import cn.flying.verifier.model.VerificationOutcome;
+import cn.flying.verifier.model.VerificationReport;
+import cn.flying.verifier.resolver.HttpProofResolvers;
+import cn.flying.verifier.resolver.HttpResolverConfiguration;
+import cn.flying.verifier.resolver.Resolution;
+import cn.flying.verifier.resolver.ResolutionState;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.util.AopTestUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -72,7 +110,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,11 +121,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * 使用真实 MySQL、Redis 和生产 service 入口验证 signed proof 生命周期并发边界。
  */
 @Execution(ExecutionMode.SAME_THREAD)
+@AutoConfigureMockMvc
 class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
 
     private static final Long TENANT_ID = 97_140_001L;
@@ -98,6 +141,9 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     private static final String FILE_PRIMARY_INDEX = "PRIMARY";
     private static final String KEY_TABLE = "proof_signing_key";
     private static final String KEY_IDENTITY_INDEX = "uk_proof_signing_key_identity";
+    private static final String PUBLIC_PROOF_TEST_PEER = "198.51.100.214";
+    private static final String PUBLIC_PROOF_RATE_LIMIT_KEY =
+            "rate:limit:public:proof-verification:v2:ip:" + PUBLIC_PROOF_TEST_PEER;
     private static final int WAIT_SECONDS = 15;
 
     @Autowired
@@ -140,10 +186,23 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     private JdbcTemplate jdbcTemplate;
 
     @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
     private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @TempDir
+    Path tempDirectory;
 
     private ExecutorService executor;
     private List<CountDownLatch> releaseLatches;
+    private List<String> publicAuditRequestPaths;
 
     /**
      * 清理共享容器数据、配置动态 Ed25519 key，并为每个用例创建独立 worker 池。
@@ -151,6 +210,9 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     @BeforeEach
     void setUpLifecycleFixtures() throws GeneralSecurityException {
         TenantContext.setTenantId(TENANT_ID);
+        resetProofCurrentTimeMillisSource();
+        publicAuditRequestPaths = new CopyOnWriteArrayList<>();
+        cleanUpPublicProofSideEffects();
         cleanUpLifecycleFixtures();
         configureSigningKey();
         executor = Executors.newFixedThreadPool(4);
@@ -171,8 +233,10 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
             terminated = executor.awaitTermination(10, TimeUnit.SECONDS);
         }
         try {
+            cleanUpPublicProofSideEffects();
             cleanUpLifecycleFixtures();
         } finally {
+            resetProofCurrentTimeMillisSource();
             resetSigningKey();
             TenantContext.clear();
         }
@@ -227,6 +291,7 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
         assertThat(issuance.statusVersion()).isEqualTo(2L);
         assertThat(issuance.statusReason()).isEqualTo("newer_file_version");
         assertThat(loadFileStatus(versionTwo.getId())).isEqualTo(FileUploadStatus.SUCCESS.getCode());
+        assertSameSecondSupersededVerifierRoundTrip();
     }
 
     /**
@@ -287,6 +352,8 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
      */
     @Test
     void concurrentRevokeShouldPreventExportAfterCurrentRead() throws Exception {
+        RevokedProofFixture sameSecondRevocation = issueAndRevokeWithinSameSecond();
+
         ProofFixture fixture = createProofFixture(FILE_A_ID, "r01");
         assertValidArchive(signedProofArchiveService.exportByFileId(USER_ID, fixture.fileId()));
 
@@ -326,6 +393,14 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
         assertThat(issuance.status()).isEqualTo("REVOKED");
         assertThat(issuance.statusVersion()).isEqualTo(2L);
         assertThat(issuance.statusReason()).isEqualTo("integration revoke");
+        assertPublicVerifierLifecycle(
+                sameSecondRevocation.archive(),
+                sameSecondRevocation.fixture(),
+                sameSecondRevocation.originalPayload(),
+                "REVOKED",
+                2L,
+                VerificationOutcome.INVALID,
+                VerificationCode.STATUS_REVOKED);
     }
 
     /**
@@ -632,6 +707,171 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     }
 
     /**
+     * 使用可控生产时间源和真实签发、撤销入口构造确定性的同秒状态变化。
+     */
+    private RevokedProofFixture issueAndRevokeWithinSameSecond() {
+        String payload = "r10";
+        ProofFixture fixture = createProofFixture(FILE_B_ID, payload);
+        Instant issuedAt = Instant.ofEpochSecond(
+                Instant.now().getEpochSecond() - 5L,
+                123_000_000L);
+        Instant revokedAt = issuedAt.plusMillis(333L);
+        long[] lifecycleTimes = {issuedAt.toEpochMilli(), revokedAt.toEpochMilli()};
+        AtomicInteger timeReadIndex = new AtomicInteger();
+        LongSupplier deterministicTimeSource = () -> {
+            int index = timeReadIndex.getAndIncrement();
+            if (index >= lifecycleTimes.length) {
+                throw new AssertionError("proof 生命周期读取时间次数超出预期: " + (index + 1));
+            }
+            return lifecycleTimes[index];
+        };
+
+        ProofArchive archive;
+        ProofStatusVO revoked;
+        setProofCurrentTimeMillisSource(deterministicTimeSource);
+        try {
+            archive = signedProofArchiveService.exportByFileId(USER_ID, fixture.fileId());
+            assertValidArchive(archive);
+            revoked = signedProofArchiveService.revokeByLeafId(
+                    USER_ID, fixture.leafId(), "same-second revoke");
+        } finally {
+            resetProofCurrentTimeMillisSource();
+        }
+
+        IssuanceStatus persisted = loadIssuanceStatus(fixture.leafId());
+        assertThat(timeReadIndex.get()).isEqualTo(lifecycleTimes.length);
+        assertThat(revoked.issuedAt()).isNotNull();
+        assertThat(revoked.updatedAt()).isNotNull();
+        assertThat(revoked.issuedAt().getTime()).isEqualTo(issuedAt.toEpochMilli());
+        assertThat(revoked.updatedAt().getTime()).isEqualTo(revokedAt.toEpochMilli());
+        assertThat(revoked.status()).isEqualTo("REVOKED");
+        assertThat(revoked.statusVersion()).isEqualTo(2L);
+        assertThat(revoked.reason()).isEqualTo("same-second revoke");
+        assertThat(persisted.issuedStatus()).isEqualTo("ACTIVE");
+        assertThat(persisted.status()).isEqualTo("REVOKED");
+        assertThat(persisted.statusVersion()).isEqualTo(2L);
+        assertThat(persisted.statusReason()).isEqualTo("same-second revoke");
+        assertThat(persisted.issuedAt().getTime()).isEqualTo(issuedAt.toEpochMilli());
+        assertThat(persisted.updateTime().getTime())
+                .as("数据库必须完整保留 revoke 服务返回的毫秒时间")
+                .isEqualTo(revokedAt.toEpochMilli());
+        assertThat(persisted.updateTime().toInstant().getEpochSecond())
+                .as("revoke 必须发生在真实签发的同一秒")
+                .isEqualTo(persisted.issuedAt().toInstant().getEpochSecond());
+        return new RevokedProofFixture(fixture, archive, payload);
+    }
+
+    /**
+     * 通过真实上传入口触发 proof 的 ON UPDATE 时间戳，并验证同秒 SUPERSEDED 公开闭环。
+     */
+    private void assertSameSecondSupersededVerifierRoundTrip() throws Exception {
+        String originalPayload = "u11";
+        ProofFixture fixture = createProofFixture(FILE_B_ID, originalPayload);
+        File versionTwo = fileService.createNewVersion(
+                USER_ID, fixture.fileId(), "same-second-v2.bin", 3L, "application/octet-stream");
+        ProofArchive archive = signedProofArchiveService.exportByFileId(USER_ID, fixture.fileId());
+        assertValidArchive(archive);
+        assertPublicVerifierLifecycle(
+                archive,
+                fixture,
+                originalPayload,
+                "ACTIVE",
+                1L,
+                VerificationOutcome.VALID,
+                VerificationCode.STATUS_ACTIVE);
+
+        IssuanceStatus active = loadIssuanceStatus(fixture.leafId());
+        Instant supersedeTime = Instant.ofEpochSecond(
+                active.issuedAt().toInstant().getEpochSecond(),
+                999_000_000L);
+        assertThat(supersedeTime).isAfterOrEqualTo(active.issuedAt().toInstant());
+
+        File uploaded = inTransactionAtDatabaseTime(
+                supersedeTime,
+                () -> completeDirectUpload(versionTwo, "u12"));
+        assertThat(uploaded.getStatus()).isEqualTo(FileUploadStatus.SUCCESS.getCode());
+
+        IssuanceStatus superseded = loadIssuanceStatus(fixture.leafId());
+        assertThat(superseded.issuedStatus()).isEqualTo("ACTIVE");
+        assertThat(superseded.status()).isEqualTo("SUPERSEDED");
+        assertThat(superseded.statusVersion()).isEqualTo(2L);
+        assertThat(superseded.statusReason()).isEqualTo("newer_file_version");
+        assertThat(superseded.updateTime().toInstant().getEpochSecond())
+                .as("SUPERSEDED 必须发生在真实签发的同一秒")
+                .isEqualTo(superseded.issuedAt().toInstant().getEpochSecond());
+        assertThat(superseded.updateTime().getTime())
+                .as("ON UPDATE 必须完整保留固定的 .999 毫秒时间")
+                .isEqualTo(supersedeTime.toEpochMilli());
+        assertThat(Math.floorMod(superseded.updateTime().getTime(), 1_000L)).isEqualTo(999L);
+
+        awaitWallClockAtLeast(supersedeTime);
+        assertPublicVerifierLifecycle(
+                archive,
+                fixture,
+                originalPayload,
+                "SUPERSEDED",
+                2L,
+                VerificationOutcome.INVALID,
+                VerificationCode.STATUS_SUPERSEDED);
+    }
+
+    /**
+     * 在最多五秒内等待墙上时钟到达目标时刻；中断时恢复中断标记并立即失败。
+     */
+    private void awaitWallClockAtLeast(Instant target) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (Instant.now().isBefore(target)) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("等待墙上时钟到达目标时刻超时: " + target);
+            }
+            long remainingMillis = Math.max(1L, target.toEpochMilli() - System.currentTimeMillis());
+            try {
+                Thread.sleep(Math.min(remainingMillis, 10L));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("等待墙上时钟时被中断", e);
+            }
+        }
+    }
+
+    /**
+     * 在同一事务连接上固定 MySQL CURRENT_TIMESTAMP，使生产 ON UPDATE 路径可重复命中指定毫秒。
+     */
+    private <T> T inTransactionAtDatabaseTime(Instant databaseTime, Supplier<T> action) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setTimeout(30);
+        return template.execute(status -> {
+            String timestampValue = String.format(
+                    Locale.ROOT,
+                    "%d.%06d",
+                    databaseTime.getEpochSecond(),
+                    databaseTime.getNano() / 1_000);
+            jdbcTemplate.execute("SET SESSION timestamp = " + timestampValue);
+            try {
+                // FileService 内部默认 REQUIRED 事务会加入当前连接，沿用这里固定的数据库时钟。
+                return action.get();
+            } finally {
+                jdbcTemplate.execute("SET SESSION timestamp = DEFAULT");
+            }
+        });
+    }
+
+    /**
+     * 在真实 Spring 事务代理的最终目标对象上替换 proof 生命周期毫秒时间源。
+     */
+    private void setProofCurrentTimeMillisSource(LongSupplier source) {
+        Object target = AopTestUtils.getUltimateTargetObject(signedProofArchiveService);
+        ReflectionTestUtils.setField(target, "currentTimeMillisSource", source);
+    }
+
+    /**
+     * 恢复 proof 服务的生产系统时钟，避免共享 Spring context 污染其他测试。
+     */
+    private void resetProofCurrentTimeMillisSource() {
+        setProofCurrentTimeMillisSource(System::currentTimeMillis);
+    }
+
+    /**
      * 构造指纹自洽且字段完整的不可变合约注册表快照。
      */
     private ContractRegistryEntryResponse contractRegistry() {
@@ -932,6 +1172,234 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     }
 
     /**
+     * 使用真实数据库状态、公开控制器 JSON、HTTP resolver 和 SDK verifier 验证一个生命周期状态。
+     */
+    private void assertPublicVerifierLifecycle(
+            ProofArchive archive,
+            ProofFixture fixture,
+            String originalPayload,
+            String expectedStatus,
+            long expectedStatusVersion,
+            VerificationOutcome expectedOutcome,
+            VerificationCode expectedStatusCode
+    ) throws Exception {
+        IssuanceStatus persisted = loadIssuanceStatus(fixture.leafId());
+        assertThat(persisted.status()).isEqualTo(expectedStatus);
+        assertThat(persisted.statusVersion()).isEqualTo(expectedStatusVersion);
+        assertThat(persisted.issuedAt()).isNotNull();
+        assertThat(persisted.createTime()).isNotNull();
+        assertThat(persisted.updateTime()).isNotNull();
+        assertThat(persisted.createTime().getTime()).isGreaterThanOrEqualTo(persisted.issuedAt().getTime());
+        assertThat(persisted.updateTime().getTime()).isGreaterThanOrEqualTo(persisted.issuedAt().getTime());
+
+        ProofStatusVO statusDto = signedProofArchiveService.getPublicStatus(persisted.proofId());
+        assertThat(statusDto.status()).isEqualTo(expectedStatus);
+        assertThat(statusDto.statusVersion()).isEqualTo(expectedStatusVersion);
+        assertThat(statusDto.issuedAt()).isEqualTo(persisted.issuedAt());
+        assertThat(statusDto.updatedAt()).isEqualTo(persisted.updateTime());
+
+        CapturedPublicResponses responses = capturePublicResponses(persisted);
+        Long previousTenantId = TenantContext.getTenantId();
+        HttpServer relay = null;
+        try {
+            relay = startPublicApiRelay(persisted, responses);
+            URI issuerBaseUri = URI.create("http://127.0.0.1:" + relay.getAddress().getPort());
+            HttpProofResolvers resolvers = new HttpProofResolvers(new HttpResolverConfiguration(
+                    issuerBaseUri,
+                    null,
+                    Set.of("127.0.0.1"),
+                    true,
+                    true,
+                    Duration.ofSeconds(2),
+                    Duration.ofSeconds(2),
+                    64 * 1024,
+                    Duration.ZERO,
+                    Duration.ZERO,
+                    8));
+
+            Resolution<PublicProofStatus> resolvedStatus = resolvers.resolve(persisted.proofId());
+            assertThat(resolvedStatus.state()).isEqualTo(ResolutionState.RESOLVED);
+            assertThat(resolvedStatus.value()).isNotNull();
+            assertThat(resolvedStatus.value().status()).isEqualTo(expectedStatus);
+            assertThat(resolvedStatus.value().statusVersion()).isEqualTo(Long.toString(expectedStatusVersion));
+            assertThat(Instant.parse(resolvedStatus.value().issuedAt()))
+                    .isEqualTo(persisted.issuedAt().toInstant());
+            assertThat(Instant.parse(resolvedStatus.value().updatedAt()))
+                    .isEqualTo(persisted.updateTime().toInstant());
+
+            var resolvedKey = resolvers.resolve(persisted.keyId(), persisted.keyVersion());
+            assertThat(resolvedKey.state()).isEqualTo(ResolutionState.RESOLVED);
+            assertThat(resolvedKey.value()).isNotNull();
+            assertThat(resolvedKey.value().keyId()).isEqualTo(persisted.keyId());
+            assertThat(resolvedKey.value().keyVersion()).isEqualTo(persisted.keyVersion());
+
+            AttestationBatch batch = batchMapper.selectById(fixture.batchId());
+            AttestationLeaf leaf = leafMapper.selectById(fixture.leafId());
+            assertThat(batch).isNotNull();
+            assertThat(leaf).isNotNull();
+            assertThat(leaf.getBatchId()).isEqualTo(batch.getId());
+            assertThat(leaf.getLeafHash()).isEqualTo(batch.getChainFileHash());
+            ChainRootEvidence liveChain = new ChainRootEvidence(
+                    ChainRootEvidence.SCHEMA_VERSION,
+                    batch.getChainType(),
+                    batch.getChainId(),
+                    batch.getChainGroupId(),
+                    batch.getContractAddress(),
+                    batch.getBatchNo(),
+                    batch.getChainFileHash(),
+                    batch.getChainTransactionHash(),
+                    100L,
+                    "signed-proof-lifecycle-it");
+
+            String pathSuffix = expectedStatus.toLowerCase(Locale.ROOT);
+            Path original = tempDirectory.resolve(fixture.fileId() + "-" + pathSuffix + "-original.bin");
+            Path proof = tempDirectory.resolve(fixture.fileId() + "-" + pathSuffix + "-proof.zip");
+            Files.write(original, originalPayload.getBytes(StandardCharsets.UTF_8));
+            Files.write(proof, archive.toByteArray());
+            Instant verificationInstant = Instant.now();
+            assertThat(persisted.updateTime().getTime())
+                    .isLessThanOrEqualTo(verificationInstant.toEpochMilli());
+            VerificationContext context = new VerificationContext(
+                    VerificationLimits.defaults(),
+                    resolvers,
+                    resolvers,
+                    query -> Resolution.resolved(liveChain),
+                    Clock.fixed(verificationInstant, ZoneOffset.UTC));
+
+            VerificationReport report = new DefaultProofVerifier().verify(original, proof, context);
+            assertThat(report.outcome()).isEqualTo(expectedOutcome);
+            assertThat(report.summary().currentStatus()).isEqualTo(expectedStatus);
+            assertThat(report.checks())
+                    .filteredOn(check -> "status.current".equals(check.id()))
+                    .singleElement()
+                    .satisfies(check -> {
+                        assertThat(check.code()).isEqualTo(expectedStatusCode);
+                        assertThat(check.status()).isEqualTo(expectedOutcome == VerificationOutcome.VALID
+                                ? VerificationCheckStatus.PASS
+                                : VerificationCheckStatus.FAIL);
+                    });
+            assertThat(report.checks())
+                    .filteredOn(check -> "status.current".equals(check.id()))
+                    .extracting(VerificationCheck::code)
+                    .doesNotContain(VerificationCode.STATUS_INVALID);
+            assertThat(report.checks())
+                    .filteredOn(check -> !"status.current".equals(check.id()))
+                    .allMatch(check -> check.status() == VerificationCheckStatus.PASS);
+        } finally {
+            if (relay != null) {
+                relay.stop(0);
+            }
+            restoreTenantContext(previousTenantId);
+        }
+    }
+
+    /**
+     * 通过完整 MockMvc 控制器链获取公开 status/key 的原始 JSON，并校验数据库时间未在 JSON 边界漂移。
+     */
+    private CapturedPublicResponses capturePublicResponses(IssuanceStatus persisted) throws Exception {
+        Long previousTenantId = TenantContext.getTenantId();
+        String statusPath = "/api/v1/public/proofs/" + persisted.proofId() + "/status";
+        String keyPath = "/api/v1/public/proof-keys/"
+                + persisted.keyId()
+                + "/versions/"
+                + persisted.keyVersion();
+        publicAuditRequestPaths.addAll(List.of(statusPath, keyPath));
+        try {
+            MvcResult statusResult = mockMvc.perform(get(statusPath)
+                            .with(request -> {
+                                request.setRemoteAddr(PUBLIC_PROOF_TEST_PEER);
+                                return request;
+                            }))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            MvcResult keyResult = mockMvc.perform(get(keyPath)
+                            .with(request -> {
+                                request.setRemoteAddr(PUBLIC_PROOF_TEST_PEER);
+                                return request;
+                            }))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            byte[] statusBody = statusResult.getResponse().getContentAsByteArray();
+            byte[] keyBody = keyResult.getResponse().getContentAsByteArray();
+            JsonNode statusRoot = objectMapper.readTree(statusBody);
+            JsonNode statusData = statusRoot.path("data");
+            assertThat(statusRoot.path("code").asInt()).isEqualTo(200);
+            assertThat(statusData.path("status").asText()).isEqualTo(persisted.status());
+            assertThat(statusData.path("statusVersion").isTextual()).isTrue();
+            assertThat(statusData.path("statusVersion").asText())
+                    .isEqualTo(Long.toString(persisted.statusVersion()));
+            assertThat(statusData.path("issuedAt").isIntegralNumber()).isTrue();
+            assertThat(statusData.path("updatedAt").isIntegralNumber()).isTrue();
+            assertThat(statusData.path("issuedAt").longValue()).isEqualTo(persisted.issuedAt().getTime());
+            assertThat(statusData.path("updatedAt").longValue()).isEqualTo(persisted.updateTime().getTime());
+            assertThat(statusResult.getResponse().getHeader(HttpHeaders.CACHE_CONTROL)).contains("no-store");
+            assertThat(keyResult.getResponse().getHeader(HttpHeaders.CACHE_CONTROL))
+                    .contains("max-age=300", "immutable");
+            assertThat(objectMapper.readTree(keyBody).path("code").asInt()).isEqualTo(200);
+            return new CapturedPublicResponses(statusBody, keyBody);
+        } finally {
+            restoreTenantContext(previousTenantId);
+        }
+    }
+
+    /**
+     * 将 MockMvc 可能清理的租户 ThreadLocal 精确恢复到调用前状态。
+     */
+    private void restoreTenantContext(Long tenantId) {
+        if (tenantId == null) {
+            TenantContext.clear();
+        } else {
+            TenantContext.setTenantId(tenantId);
+        }
+    }
+
+    /**
+     * 仅在 127.0.0.1 上启动原样 JSON relay，使 SDK 使用真实 HTTP client 消费控制器响应。
+     */
+    private HttpServer startPublicApiRelay(
+            IssuanceStatus persisted,
+            CapturedPublicResponses responses
+    ) throws IOException {
+        String statusPath = "/api/v1/public/proofs/" + persisted.proofId() + "/status";
+        String keyPath = "/api/v1/public/proof-keys/"
+                + persisted.keyId()
+                + "/versions/"
+                + persisted.keyVersion();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        try {
+            server.createContext("/", exchange -> {
+                String requestPath = exchange.getRequestURI().getPath();
+                if (statusPath.equals(requestPath)) {
+                    writeRelayResponse(exchange, 200, responses.statusBody());
+                } else if (keyPath.equals(requestPath)) {
+                    writeRelayResponse(exchange, 200, responses.keyBody());
+                } else {
+                    writeRelayResponse(exchange, 404, new byte[0]);
+                }
+            });
+            server.start();
+            return server;
+        } catch (RuntimeException exception) {
+            server.stop(0);
+            throw exception;
+        }
+    }
+
+    /**
+     * 写出一个有界 JSON relay 响应并始终关闭 exchange 输出资源。
+     */
+    private void writeRelayResponse(HttpExchange exchange, int statusCode, byte[] body) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(statusCode, body.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(body);
+        } finally {
+            exchange.close();
+        }
+    }
+
+    /**
      * 断言真实签发结果包含固定八条目和 compact JWS。
      */
     private void assertValidArchive(ProofArchive archive) {
@@ -947,15 +1415,23 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     private IssuanceStatus loadIssuanceStatus(Long leafId) {
         return jdbcTemplate.queryForObject(
                 """
-                        SELECT issued_status, status, status_version, status_reason
+                        SELECT proof_id, key_id, key_version,
+                               issued_status, status, status_version, status_reason,
+                               issued_at, create_time, update_time
                           FROM proof_bundle_issuance
                          WHERE tenant_id = ? AND leaf_id = ? AND deleted = 0
                         """,
                 (resultSet, rowNum) -> new IssuanceStatus(
+                        resultSet.getString("proof_id"),
+                        resultSet.getString("key_id"),
+                        resultSet.getInt("key_version"),
                         resultSet.getString("issued_status"),
                         resultSet.getString("status"),
                         resultSet.getLong("status_version"),
-                        resultSet.getString("status_reason")),
+                        resultSet.getString("status_reason"),
+                        resultSet.getTimestamp("issued_at"),
+                        resultSet.getTimestamp("create_time"),
+                        resultSet.getTimestamp("update_time")),
                 TENANT_ID,
                 leafId);
     }
@@ -1024,6 +1500,22 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     }
 
     /**
+     * 精确清理本测试公开请求产生的共享 Redis 限流桶和系统租户审计日志。
+     */
+    private void cleanUpPublicProofSideEffects() {
+        stringRedisTemplate.delete(PUBLIC_PROOF_RATE_LIMIT_KEY);
+        if (publicAuditRequestPaths == null || publicAuditRequestPaths.isEmpty()) {
+            return;
+        }
+        for (String requestPath : publicAuditRequestPaths) {
+            jdbcTemplate.update(
+                    "DELETE FROM sys_operation_log WHERE tenant_id = 0 AND request_url = ?",
+                    requestPath);
+        }
+        publicAuditRequestPaths.clear();
+    }
+
+    /**
      * 一组可直接进入真实 signed-proof 导出链路的不可变证据标识。
      */
     private record ProofFixture(
@@ -1041,13 +1533,49 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
     }
 
     /**
+     * 同秒撤销夹具，保留真实签名包和原始内容以执行公开 verifier 闭环。
+     */
+    private record RevokedProofFixture(
+            ProofFixture fixture,
+            ProofArchive archive,
+            String originalPayload
+    ) {
+    }
+
+    /**
+     * MockMvc 生成且将由本机 HTTP relay 原样返回的公开响应字节。
+     */
+    private record CapturedPublicResponses(byte[] statusBody, byte[] keyBody) {
+        private CapturedPublicResponses {
+            statusBody = statusBody.clone();
+            keyBody = keyBody.clone();
+        }
+
+        @Override
+        public byte[] statusBody() {
+            return statusBody.clone();
+        }
+
+        @Override
+        public byte[] keyBody() {
+            return keyBody.clone();
+        }
+    }
+
+    /**
      * 数据库中的签发时状态与当前在线状态。
      */
     private record IssuanceStatus(
+            String proofId,
+            String keyId,
+            Integer keyVersion,
             String issuedStatus,
             String status,
             Long statusVersion,
-            String statusReason
+            String statusReason,
+            Date issuedAt,
+            Date createTime,
+            Date updateTime
     ) {
     }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/proof/SignedProofLifecycleConcurrencyIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/proof/SignedProofLifecycleConcurrencyIT.java
@@ -94,6 +94,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Date;
@@ -1329,10 +1330,12 @@ class SignedProofLifecycleConcurrencyIT extends BaseIntegrationTest {
             assertThat(statusData.path("statusVersion").isTextual()).isTrue();
             assertThat(statusData.path("statusVersion").asText())
                     .isEqualTo(Long.toString(persisted.statusVersion()));
-            assertThat(statusData.path("issuedAt").isIntegralNumber()).isTrue();
-            assertThat(statusData.path("updatedAt").isIntegralNumber()).isTrue();
-            assertThat(statusData.path("issuedAt").longValue()).isEqualTo(persisted.issuedAt().getTime());
-            assertThat(statusData.path("updatedAt").longValue()).isEqualTo(persisted.updateTime().getTime());
+            assertThat(statusData.path("issuedAt").isTextual()).isTrue();
+            assertThat(statusData.path("updatedAt").isTextual()).isTrue();
+            assertThat(OffsetDateTime.parse(statusData.path("issuedAt").textValue()).toInstant())
+                    .isEqualTo(persisted.issuedAt().toInstant());
+            assertThat(OffsetDateTime.parse(statusData.path("updatedAt").textValue()).toInstant())
+                    .isEqualTo(persisted.updateTime().toInstant());
             assertThat(statusResult.getResponse().getHeader(HttpHeaders.CACHE_CONTROL)).contains("no-store");
             assertThat(keyResult.getResponse().getHeader(HttpHeaders.CACHE_CONTROL))
                     .contains("max-age=300", "immutable");

--- a/platform-verifier/sdk/src/test/java/cn/flying/verifier/DefaultProofVerifierTest.java
+++ b/platform-verifier/sdk/src/test/java/cn/flying/verifier/DefaultProofVerifierTest.java
@@ -321,6 +321,22 @@ class DefaultProofVerifierTest {
                 .contains(VerificationCode.STATUS_INVALID);
     }
 
+    /** 验证状态更新时间早于签发时间时，严格拒绝该公开状态身份。 */
+    @Test
+    void shouldRejectStatusUpdatedBeforeIssuance() {
+        String updatedAt = Instant.parse(fixture.status().issuedAt()).minusMillis(1).toString();
+
+        assertStatusTimestampRejected(updatedAt);
+    }
+
+    /** 验证状态更新时间晚于校验时钟时，严格拒绝该未来状态时间。 */
+    @Test
+    void shouldRejectStatusUpdatedAfterVerificationClock() {
+        String updatedAt = VerifierTestFixture.NOW.plusMillis(1).toString();
+
+        assertStatusTimestampRejected(updatedAt);
+    }
+
     /** Rejects non-canonical or out-of-range lifecycle version strings from custom resolvers. */
     @ParameterizedTest
     @ValueSource(strings = {"+1", "01", "9223372036854775808"})
@@ -1187,6 +1203,38 @@ class DefaultProofVerifierTest {
                 fixture.original(), archive, VerifierTestFixture.context(fixture));
         assertThat(report.outcome()).isEqualTo(VerificationOutcome.INVALID);
         assertThat(report.checks()).extracting(check -> check.code()).contains(code);
+    }
+
+    /** 使用完整可信身份仅替换状态更新时间，并断言时间顺序失败唯一落到当前状态检查。 */
+    private void assertStatusTimestampRejected(String updatedAt) {
+        PublicProofStatus status = new PublicProofStatus(
+                fixture.status().proofId(),
+                fixture.status().status(),
+                fixture.status().statusVersion(),
+                fixture.status().issuedStatus(),
+                fixture.status().keyId(),
+                fixture.status().keyVersion(),
+                fixture.status().reason(),
+                fixture.status().issuedAt(),
+                updatedAt,
+                fixture.status().source());
+        VerificationContext context = new VerificationContext(
+                VerificationLimits.defaults(),
+                (keyId, keyVersion) -> Resolution.resolved(fixture.key()),
+                proofId -> Resolution.resolved(status),
+                query -> Resolution.resolved(fixture.chain()),
+                Clock.fixed(VerifierTestFixture.NOW, ZoneOffset.UTC));
+
+        VerificationReport report = verifier.verify(fixture.original(), fixture.proof(), context);
+
+        assertThat(report.outcome()).isEqualTo(VerificationOutcome.INVALID);
+        assertThat(report.checks())
+                .filteredOn(check -> "status.current".equals(check.id()))
+                .singleElement()
+                .satisfies(check -> {
+                    assertThat(check.status()).isEqualTo(VerificationCheckStatus.FAIL);
+                    assertThat(check.code()).isEqualTo(VerificationCode.STATUS_INVALID);
+                });
     }
 
     /** Requires a stable archive input error for one malformed ZIP path. */


### PR DESCRIPTION
## 关联任务

- Trellis 子任务：`.trellis/tasks/07-15-roadmap-p1-proof-status-time-precision`
- 父任务：`.trellis/tasks/07-13-roadmap-p1-proof-productization`
- ROADMAP 优先级：P1；该 PR 合并前不开始后续子任务。

## 问题背景

`proof_bundle_issuance.issued_at` 已使用 `DATETIME(3)`，但 `create_time` / `update_time` 仍是默认 `DATETIME(0)`。同秒签发、撤销或 supersede 时，MySQL 对小数秒的舍入/截断可能使公开状态中的 `updatedAt` 早于 `issuedAt`，从而让严格的 SDK verifier 把合法证明误判为 `STATUS_INVALID`。

## 修改内容

- 新增只向前迁移 `V1.15.0__proof_status_timestamp_precision.sql`：
  - 仅将 `proof_bundle_issuance.create_time`、`update_time` 扩大为 `DATETIME(3)`；
  - 默认值和自动更新时间统一为 `CURRENT_TIMESTAMP(3)`；
  - 使用一条带严格 `< issued_at` 条件的定向 `UPDATE` 修复历史不可能时间序；
  - 不修改状态、状态版本、撤销时间、签名材料、proofId 或 key identity。
- 为 proof 生命周期引入私有、默认等价于系统时钟的毫秒时间源，使同秒签发/撤销回归可确定性复现；不新增公共配置或 API，不改变事务/CAS 行为。
- 增加真实 MySQL/Flyway `V1.14.0 → V1.15.0` 迁移集成测试，覆盖：
  - 列精度、默认值、`ON UPDATE`；
  - 异常历史行定向修复与合法晚时间保持；
  - `.001/.123/.499/.500/.999` 毫秒边界；
  - 默认 rounding 与 `TIME_TRUNCATE_FRACTIONAL` 两种 SQL mode；
  - ACTIVE/REVOKED/SUPERSEDED/INVALID 与签名/key 字段不变。
- 增加 producer → MySQL → 公开 status/key → HTTP resolver → `DefaultProofVerifier` 的真实闭环，验证 ACTIVE、同秒 REVOKED、同秒 SUPERSEDED 的精确状态结果。
- 保持 verifier 时间顺序校验严格，并新增 `updatedAt < issuedAt`、`updatedAt > verifiedAt` 负向用例。
- CI 明确要求迁移 IT 报告存在且 `tests=1, skipped=0, failures=0, errors=0`，禁止 Docker 缺失时静默跳过。
- 同步 `ROADMAP.md` 的测试文件与 Flyway 迁移数量。

## 影响范围与兼容性

- 涉及：`platform-backend/backend-service`、`platform-backend/backend-web`、`platform-verifier/sdk`、后端 CI 门禁及 `ROADMAP.md`。
- 不改变公开 proof/key API 路径、字段、OpenAPI/generated types、缓存合同、JWS、签名 ZIP 字节、proofId、key identity 或状态语义。
- 不修改 `proof_signing_key`，不放宽 verifier/resolver 信任边界。

## 本地测试与检查

- Backend `clean verify`：
  - backend-common：241 tests，0 failures/errors/skipped；
  - backend-api：2 tests，0 failures/errors/skipped；
  - backend-service：927 tests，0 failures/errors/skipped；
  - backend-web：351 tests，0 failures/errors，21 个 Testcontainers 用例因本机无 Docker 跳过；JaCoCo 通过。
- 定向测试：
  - `SignedProofArchiveServiceImplTest`：37/0/0/0；
  - `FlywayMigrationVersionTest`：11/0/0/0；
  - `DefaultProofVerifierTest`：59/0/0/0；
  - 迁移测试在迁移脚本加入前按预期失败，加入后静态迁移合同测试通过。
- 其他 Maven 模块：
  - platform-api：7/0/0/0；
  - platform-verifier：157/0/0/0，JaCoCo 通过；
  - platform-fisco：93/0/0/0；
  - platform-storage：169/0/0/0。
- Frontend：frozen install、format、lint、Svelte check、464 tests coverage、生产 build 全部通过。
- Docs/contract：docs build、文档一致性、routes/env/roadmap/version、OpenAPI 类型漂移、34 个 Python contract tests、fingerprint 全部通过。
- 静态与安全检查：`actionlint`、`git diff --check`、Trivy filesystem（HIGH/CRITICAL vuln、secret、misconfiguration，`--ignore-unfixed`）全部通过；未启用 security 插件。
- 三轮独立人工差异审查均未发现高置信可执行问题，重点复核了迁移更新范围、事务代理、时间源恢复、旧 schema 可证伪性、接口兼容和 verifier 严格性。

### 本地环境限制

本机没有可用的 `/var/run/docker.sock`，因此不能把真实 MySQL/Testcontainers 用例声明为本地通过。该用例配置为不可静默跳过，CI 还会精确校验 Failsafe 报告必须为 `1/0/0/0`；第二轮 CI 已在真实 MySQL/Testcontainers 环境取得该证据，并由工作流精确报告门禁确认；本地 Docker 限制不再构成未验证项。

## 验收结果

- [x] 修改范围符合 P1 时间戳精度子任务，无无关生产改动。
- [x] verifier/resolver 严格规则未被放宽。
- [x] 历史修复仅提升早于 `issued_at` 的对应时间列，并保留合法晚时间。
- [x] API、签名资产、key identity 和并发事务合同无漂移。
- [x] 本地可执行的测试、构建、文档、合同、静态和安全门禁通过。
- [x] GitHub CI 的真实 MySQL/Testcontainers、全量测试、安全扫描和其余仓库门禁全部通过。
- [x] 无未解决审查意见、无冲突，PR 状态为 `MERGEABLE/CLEAN`。
- [x] squash 合并后远程 `main` 验证：merge SHA `ed18419824e5d58fa430de58f136a6df9ed07a8b`，同 SHA 的 8 条 push/dynamic 工作流全部 `success`。


## CI 最终证据

- 第二轮 Test Suite：[`29442165937`](https://github.com/SoarCollab/RecordPlatform/actions/runs/29442165937)，结论 `success`。
- Backend Tests：22m16s 成功；主测试完成后，Signed Proof 并发 IT、Proof Status Timestamp Migration IT、公共审计隔离和公共限流的精确报告门禁均成功；迁移 IT 被要求为 `tests=1, skipped=0, failures=0, errors=0`；FISCO、Storage、覆盖率与产物上传成功。
- Frontend Tests：成功；Contract Consistency：成功；Build Verification：后端、Public Verifier 镜像及前端构建成功。
- CodeQL（Java/Kotlin、JavaScript/TypeScript、Python、Actions）、Trivy、Security Scan、Docs Consistency、Docs Site、OpenAPI、dependency submission 与 Codecov check 全部成功。
- 首轮失败及最小修复证据记录于 [PR comment](https://github.com/SoarCollab/RecordPlatform/pull/294#issuecomment-4984195189)；第二轮未复现，未修改生产 API 或降低门禁。

## 风险评估

- `ALTER TABLE` 可能重建表或占用元数据锁，且 MySQL DDL 会隐式提交；生产部署应在维护窗口执行，事前确认表规模、备份和在线 DDL 能力。
- 历史整秒值无法还原已丢失的真实毫秒；迁移只把违反合同的时间提升到 `issued_at`，不声称恢复原始时间。
- 数据修复属于只向前变更，合法的 later update/revoke/supersede/invalid 时间不会被覆盖。

## 回滚方式

- 应用层可回滚本提交，但保留向后兼容的 `DATETIME(3)` 列，不降回 `DATETIME(0)`。
- 已提升的历史时间无法可靠逆推，不执行自动反向数据回滚；需要恢复时使用部署前备份或新的只向前迁移。
- 紧急止损时关闭 proof signing/export，保留公开状态查询，再按维护窗口处理数据库恢复。