### PR TITLE
fix: 修复链提交耗尽后的租约恢复终态

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,35 @@ jobs:
       - name: Run Backend Tests
         run: mvn -f platform-backend/pom.xml clean verify -pl backend-common,backend-service,backend-web -am -Pit
 
+      - name: Require Attestation Batch Consistency IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.test.attestation.AttestationBatchConsistencyIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          expected_counts = {
+              "tests": 8,
+              "skipped": 0,
+              "failures": 0,
+              "errors": 0,
+          }
+          for name, expected in expected_counts.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"AttestationBatchConsistencyIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Require Signed Proof Concurrency IT Execution
         run: |
           python3 - <<'PY'

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/AttestationBatchMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/AttestationBatchMapper.java
@@ -28,7 +28,7 @@ public interface AttestationBatchMapper extends BaseMapper<AttestationBatch> {
                     (status = 'CHAIN_PENDING' AND attempt_count < #{maxAttempts})
                  OR (status = 'CHAIN_RETRY' AND attempt_count < #{maxAttempts}
                      AND next_attempt_at IS NOT NULL AND next_attempt_at <= #{now})
-                 OR (status = 'CHAIN_SUBMITTING' AND attempt_count <= #{maxAttempts}
+                 OR (status = 'CHAIN_SUBMITTING'
                      AND lease_expires_at IS NOT NULL AND lease_expires_at <= #{now})
               )
             ORDER BY COALESCE(next_attempt_at, create_time) ASC, id ASC
@@ -53,7 +53,7 @@ public interface AttestationBatchMapper extends BaseMapper<AttestationBatch> {
                     (status = 'CHAIN_PENDING' AND attempt_count < #{maxAttempts})
                  OR (status = 'CHAIN_RETRY' AND attempt_count < #{maxAttempts}
                      AND next_attempt_at IS NOT NULL AND next_attempt_at <= #{now})
-                 OR (status = 'CHAIN_SUBMITTING' AND attempt_count <= #{maxAttempts}
+                 OR (status = 'CHAIN_SUBMITTING'
                      AND lease_expires_at IS NOT NULL AND lease_expires_at <= #{now})
               )
             """)
@@ -83,7 +83,7 @@ public interface AttestationBatchMapper extends BaseMapper<AttestationBatch> {
                     (status = 'CHAIN_PENDING' AND attempt_count < #{maxAttempts})
                  OR (status = 'CHAIN_RETRY' AND attempt_count < #{maxAttempts}
                      AND next_attempt_at IS NOT NULL AND next_attempt_at <= #{now})
-                 OR (status = 'CHAIN_SUBMITTING' AND attempt_count <= #{maxAttempts}
+                 OR (status = 'CHAIN_SUBMITTING'
                      AND lease_expires_at IS NOT NULL AND lease_expires_at <= #{now})
               )
             """)

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/remote/FileRemoteClient.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/remote/FileRemoteClient.java
@@ -33,6 +33,7 @@ import io.github.resilience4j.retry.annotation.Retry;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.annotation.Method;
 import org.apache.dubbo.rpc.RpcContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -45,7 +46,11 @@ import java.util.function.Supplier;
 @Component
 public class FileRemoteClient {
 
-    @DubboReference(id = "blockChainServiceFileRemoteClient", version = BlockChainService.VERSION, providedBy = "RecordPlatform_fisco")
+    @DubboReference(
+            id = "blockChainServiceFileRemoteClient",
+            version = BlockChainService.VERSION,
+            providedBy = "RecordPlatform_fisco",
+            methods = @Method(name = "storeAttestationBatch", retries = 0))
     private BlockChainService blockChainService;
 
     @DubboReference(id = "storageServiceFileRemoteClient", version = DistributedStorageService.VERSION, providedBy = "RecordPlatform_storage")

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/attestation/AttestationBatchPersistenceServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/attestation/AttestationBatchPersistenceServiceTest.java
@@ -11,6 +11,8 @@ import cn.flying.dao.mapper.AttestationBatchCandidateMapper;
 import cn.flying.dao.mapper.AttestationBatchMapper;
 import cn.flying.dao.mapper.AttestationLeafMapper;
 import cn.flying.platformapi.response.ContractRegistryEntryResponse;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -361,6 +364,36 @@ class AttestationBatchPersistenceServiceTest {
     }
 
     /**
+     * 验证三个恢复入口都只限制待提交和退避批次，已过期的提交租约不受写入次数限制。
+     */
+    @Test
+    void recoverySql_shouldKeepExpiredSubmittingBatchesRecoverableAfterWriteLimit() throws Exception {
+        List<Method> recoveryMethods = List.of(
+                AttestationBatchMapper.class.getMethod(
+                        "selectDueBatchIds", Long.class, Date.class, int.class, int.class),
+                AttestationBatchMapper.class.getMethod(
+                        "countDueBatches", Long.class, Date.class, int.class),
+                AttestationBatchMapper.class.getMethod(
+                        "claimForSubmission", Long.class, Long.class, String.class,
+                        Date.class, Date.class, int.class));
+
+        assertThat(recoveryMethods)
+                .allSatisfy(method -> {
+                    String sql = normalizedMapperSql(method);
+                    assertThat(sql).contains("tenant_id = #{tenantId}", "deleted = 0");
+                    assertThat(sql.split("attempt_count < #\\{maxAttempts}", -1))
+                            .as(method.getName() + " 仅允许待提交和退避状态消耗链写次数")
+                            .hasSize(3);
+                    assertThat(sql)
+                            .as(method.getName() + " 必须允许恢复任意次数的过期提交租约")
+                            .contains("status = 'CHAIN_SUBMITTING' "
+                                    + "AND lease_expires_at IS NOT NULL "
+                                    + "AND lease_expires_at <= #{now}")
+                            .doesNotContain("status = 'CHAIN_SUBMITTING' AND attempt_count");
+                });
+    }
+
+    /**
      * 验证有效 claim 完成时同时记录确认来源、交易和根。
      */
     @Test
@@ -548,6 +581,16 @@ class AttestationBatchPersistenceServiceTest {
         return new MerkleTreeService().buildTree(List.of(
                 new MerkleLeafInput(11L, "hash-b"),
                 new MerkleLeafInput(12L, "hash-a")));
+    }
+
+    /**
+     * 读取并规范化 MyBatis 注解 SQL，供恢复谓词合同测试复用。
+     */
+    private String normalizedMapperSql(Method method) {
+        Select select = method.getAnnotation(Select.class);
+        Update update = method.getAnnotation(Update.class);
+        String[] fragments = select != null ? select.value() : update.value();
+        return String.join(" ", fragments).replaceAll("\\s+", " ").trim();
     }
 
     /**

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/attestation/AttestationBatchServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/attestation/AttestationBatchServiceImplTest.java
@@ -465,6 +465,131 @@ class AttestationBatchServiceImplTest {
     }
 
     /**
+     * 验证耗尽后的 registry 瞬时异常直接人工终结，不再安排重试或访问业务链记录。
+     */
+    @Test
+    void submitBatch_shouldFailClosedWhenExhaustedRegistryLookupIsTransient() {
+        MerkleTreeResult tree = sampleTree();
+        AttestationBatch claimed = pendingBatch(tree).setStatus("CHAIN_SUBMITTING")
+                .setClaimToken("claim-registry-exhausted").setAttemptCount(6);
+        AttestationBatch manual = pendingBatch(tree).setStatus("MANUAL_REVIEW").setAttemptCount(6);
+        when(persistenceService.claim(
+                eq(TENANT_ID),
+                eq(BATCH_ID),
+                anyString(),
+                any(Date.class),
+                any(Date.class),
+                eq(AttestationBatchServiceImpl.MAX_ATTEMPTS)))
+                .thenReturn(Optional.of(claimed));
+        when(fileRemoteClient.getContractRegistry())
+                .thenThrow(new IllegalStateException("registry unavailable"));
+        when(persistenceService.findById(TENANT_ID, BATCH_ID)).thenReturn(Optional.of(manual));
+
+        AttestationBatch actual = service.submitBatch(BATCH_ID);
+
+        assertThat(actual.getStatus()).isEqualTo("MANUAL_REVIEW");
+        verify(persistenceService, never()).retry(any(), any(), any(), any(), any());
+        verify(persistenceService).manualReview(
+                eq(TENANT_ID), eq(BATCH_ID), eq("claim-registry-exhausted"),
+                anyString(), eq(null), eq(null));
+        verify(persistenceService, never()).verifyContractRegistryClaim(any(), any(), any(), any());
+        verify(fileRemoteClient, never()).getAttestationBatch(any());
+        verify(fileRemoteClient, never()).storeAttestationBatch(any());
+    }
+
+    /**
+     * 验证耗尽后的非法 ACTIVE registry 响应直接人工终结，不得猜测合约或继续链查询。
+     */
+    @Test
+    void submitBatch_shouldFailClosedWhenExhaustedRegistryResponseIsInvalid() {
+        MerkleTreeResult tree = sampleTree();
+        AttestationBatch claimed = pendingBatch(tree).setStatus("CHAIN_SUBMITTING")
+                .setClaimToken("claim-registry-invalid").setAttemptCount(6);
+        AttestationBatch manual = pendingBatch(tree).setStatus("MANUAL_REVIEW").setAttemptCount(6);
+        when(persistenceService.claim(
+                eq(TENANT_ID),
+                eq(BATCH_ID),
+                anyString(),
+                any(Date.class),
+                any(Date.class),
+                eq(AttestationBatchServiceImpl.MAX_ATTEMPTS)))
+                .thenReturn(Optional.of(claimed));
+        when(fileRemoteClient.getContractRegistry()).thenReturn(Result.success(List.of()));
+        when(persistenceService.findById(TENANT_ID, BATCH_ID)).thenReturn(Optional.of(manual));
+
+        AttestationBatch actual = service.submitBatch(BATCH_ID);
+
+        assertThat(actual.getStatus()).isEqualTo("MANUAL_REVIEW");
+        verify(persistenceService, never()).retry(any(), any(), any(), any(), any());
+        verify(persistenceService).manualReview(
+                eq(TENANT_ID), eq(BATCH_ID), eq("claim-registry-invalid"),
+                anyString(), eq(null), eq(null));
+        verify(persistenceService, never()).verifyContractRegistryClaim(any(), any(), any(), any());
+        verify(fileRemoteClient, never()).getAttestationBatch(any());
+        verify(fileRemoteClient, never()).storeAttestationBatch(any());
+    }
+
+    /**
+     * 验证耗尽后的 registry 快照漂移直接人工终结，不能跨合约进入链查询或写入。
+     */
+    @Test
+    void submitBatch_shouldFailClosedWhenExhaustedRegistrySnapshotIsStale() {
+        MerkleTreeResult tree = sampleTree();
+        AttestationBatch claimed = pendingBatch(tree).setStatus("CHAIN_SUBMITTING")
+                .setClaimToken("claim-snapshot-exhausted").setAttemptCount(6);
+        AttestationBatch manual = pendingBatch(tree).setStatus("MANUAL_REVIEW").setAttemptCount(6);
+        when(persistenceService.claim(
+                eq(TENANT_ID),
+                eq(BATCH_ID),
+                anyString(),
+                any(Date.class),
+                any(Date.class),
+                eq(AttestationBatchServiceImpl.MAX_ATTEMPTS)))
+                .thenReturn(Optional.of(claimed));
+        when(persistenceService.verifyContractRegistryClaim(
+                TENANT_ID,
+                BATCH_ID,
+                "claim-snapshot-exhausted",
+                contractRegistry())).thenReturn(Optional.empty());
+        when(persistenceService.findById(TENANT_ID, BATCH_ID)).thenReturn(Optional.of(manual));
+
+        AttestationBatch actual = service.submitBatch(BATCH_ID);
+
+        assertThat(actual.getStatus()).isEqualTo("MANUAL_REVIEW");
+        verify(persistenceService, never()).retry(any(), any(), any(), any(), any());
+        verify(persistenceService).manualReview(
+                eq(TENANT_ID), eq(BATCH_ID), eq("claim-snapshot-exhausted"),
+                anyString(), eq(null), eq(null));
+        verify(fileRemoteClient, never()).getAttestationBatch(any());
+        verify(fileRemoteClient, never()).storeAttestationBatch(any());
+    }
+
+    /**
+     * 验证耗尽后的链查询缺少 exists 结果时人工终结，不得把未知状态当作不存在后写链。
+     */
+    @Test
+    void submitBatch_shouldFailClosedWhenExhaustedChainQueryIsIncomplete() {
+        MerkleTreeResult tree = sampleTree();
+        AttestationBatch claimed = pendingBatch(tree).setStatus("CHAIN_SUBMITTING")
+                .setClaimToken("claim-query-incomplete").setAttemptCount(6);
+        AttestationBatch manual = pendingBatch(tree).setStatus("MANUAL_REVIEW").setAttemptCount(6);
+        stubClaim(claimed);
+        when(fileRemoteClient.getAttestationBatch(any()))
+                .thenReturn(Result.success(new GetAttestationBatchResponse(
+                        null, TENANT_ID, BATCH_ID, null, null, null, null, null)));
+        when(persistenceService.findById(TENANT_ID, BATCH_ID)).thenReturn(Optional.of(manual));
+
+        AttestationBatch actual = service.submitBatch(BATCH_ID);
+
+        assertThat(actual.getStatus()).isEqualTo("MANUAL_REVIEW");
+        verify(persistenceService, never()).retry(any(), any(), any(), any(), any());
+        verify(persistenceService).manualReview(
+                eq(TENANT_ID), eq(BATCH_ID), eq("claim-query-incomplete"),
+                anyString(), eq(null), eq(null));
+        verify(fileRemoteClient, never()).storeAttestationBatch(any());
+    }
+
+    /**
      * 验证并发 worker 未取得 claim 时只返回当前状态，不调用任何链 RPC。
      */
     @Test

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/remote/FileRemoteClientTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/remote/FileRemoteClientTest.java
@@ -17,6 +17,7 @@ import cn.flying.platformapi.response.FileDetailVO;
 import cn.flying.platformapi.response.ContractRegistryEntryResponse;
 import cn.flying.platformapi.response.SharingVO;
 import cn.flying.platformapi.security.BlockChainRpcAuth;
+import org.apache.dubbo.config.annotation.DubboReference;
 import org.apache.dubbo.rpc.RpcContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -190,11 +191,25 @@ class FileRemoteClientTest {
      */
     @Test
     void attestationBatchRpcAnnotations_shouldOnlyRetryReadQuery() throws Exception {
+        DubboReference blockChainReference = FileRemoteClient.class
+                .getDeclaredField("blockChainService")
+                .getAnnotation(DubboReference.class);
         Method write = FileRemoteClient.class.getMethod(
                 "storeAttestationBatch", StoreAttestationBatchRequest.class);
         Method query = FileRemoteClient.class.getMethod(
                 "getAttestationBatch", GetAttestationBatchRequest.class);
 
+        assertThat(blockChainReference).isNotNull();
+        assertThat(blockChainReference.retries())
+                .as("引用级重试策略不得影响无关区块链 RPC")
+                .isEqualTo((Integer) DubboReference.class.getMethod("retries").getDefaultValue());
+        assertThat(blockChainReference.methods())
+                .as("仅批量存证写 RPC 禁用 Dubbo failover 重试")
+                .singleElement()
+                .satisfies(method -> {
+                    assertThat(method.name()).isEqualTo("storeAttestationBatch");
+                    assertThat(method.retries()).isZero();
+                });
         assertThat(write.getAnnotation(io.github.resilience4j.retry.annotation.Retry.class)).isNull();
         assertThat(query.getAnnotation(io.github.resilience4j.retry.annotation.Retry.class)).isNotNull();
     }

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/attestation/AttestationBatchConsistencyIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/attestation/AttestationBatchConsistencyIT.java
@@ -5,8 +5,10 @@ import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.dto.File;
 import cn.flying.dao.entity.AttestationBatch;
+import cn.flying.dao.mapper.AttestationBatchMapper;
 import cn.flying.dao.mapper.FileMapper;
 import cn.flying.platformapi.constant.Result;
+import cn.flying.platformapi.constant.ResultEnum;
 import cn.flying.platformapi.request.GetAttestationBatchRequest;
 import cn.flying.platformapi.request.StoreAttestationBatchRequest;
 import cn.flying.platformapi.response.ContractRegistryEntryResponse;
@@ -39,6 +41,7 @@ import java.util.concurrent.Future;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +60,9 @@ class AttestationBatchConsistencyIT extends BaseIntegrationTest {
 
     @Autowired
     private AttestationBatchPersistenceService persistenceService;
+
+    @Autowired
+    private AttestationBatchMapper batchMapper;
 
     @Autowired
     private MerkleTreeService merkleTreeService;
@@ -276,6 +282,318 @@ class AttestationBatchConsistencyIT extends BaseIntegrationTest {
     }
 
     /**
+     * 验证第六次恢复再次崩溃后仍可被发现和领取，同时待提交与退避状态继续受五次上限约束。
+     */
+    @Test
+    void exhaustedExpiredLease_shouldRemainDueWithoutReopeningPendingOrRetryWrites() {
+        MerkleTreeResult tree = sampleTree();
+        Instant base = Instant.parse("2026-07-14T03:00:00Z");
+        AttestationBatch recovery = persistenceService.createOrGet(
+                TENANT_ID, "f".repeat(64), tree);
+        AttestationBatch sixthClaim = claimThroughAttempt(
+                recovery, 6, base, "claim-exhausted");
+        Instant sixthExpiry = sixthClaim.getLeaseExpiresAt().toInstant();
+        Date beforeExpiry = Date.from(sixthExpiry.minusSeconds(1));
+        Date afterExpiry = Date.from(sixthExpiry.plusSeconds(1));
+
+        AttestationBatch pendingAtLimit = persistenceService.createOrGet(
+                TENANT_ID, "g".repeat(64), tree);
+        AttestationBatch retryAtLimit = persistenceService.createOrGet(
+                TENANT_ID, "h".repeat(64), tree);
+        AttestationBatch deletedSubmitting = persistenceService.createOrGet(
+                TENANT_ID, "n".repeat(64), tree);
+        assertThat(jdbcTemplate.update(
+                "UPDATE attestation_batch SET status = 'CHAIN_PENDING', attempt_count = 5, "
+                        + "next_attempt_at = NULL, claim_token = NULL, lease_expires_at = NULL "
+                        + "WHERE tenant_id = ? AND id = ? AND deleted = 0",
+                TENANT_ID,
+                pendingAtLimit.getId())).isEqualTo(1);
+        assertThat(jdbcTemplate.update(
+                "UPDATE attestation_batch SET status = 'CHAIN_RETRY', attempt_count = 5, "
+                        + "next_attempt_at = ?, claim_token = NULL, lease_expires_at = NULL "
+                        + "WHERE tenant_id = ? AND id = ? AND deleted = 0",
+                Date.from(base.minusSeconds(1)),
+                TENANT_ID,
+                retryAtLimit.getId())).isEqualTo(1);
+        assertThat(jdbcTemplate.update(
+                "UPDATE attestation_batch SET status = 'CHAIN_SUBMITTING', attempt_count = 6, "
+                        + "claim_token = ?, lease_expires_at = ?, deleted = 1 "
+                        + "WHERE tenant_id = ? AND id = ? AND deleted = 0",
+                "claim-deleted",
+                Date.from(base.minusSeconds(1)),
+                TENANT_ID,
+                deletedSubmitting.getId())).isEqualTo(1);
+
+        assertThat(sixthClaim.getAttemptCount()).isEqualTo(6);
+        assertThat(batchMapper.countDueBatches(TENANT_ID, beforeExpiry, 5)).isZero();
+        assertThat(batchMapper.selectDueBatchIds(TENANT_ID, beforeExpiry, 5, 100)).isEmpty();
+        assertThat(persistenceService.claim(
+                TENANT_ID,
+                recovery.getId(),
+                "claim-exhausted-early",
+                beforeExpiry,
+                Date.from(beforeExpiry.toInstant().plusSeconds(120)),
+                5)).isEmpty();
+
+        assertThat(batchMapper.countDueBatches(OTHER_TENANT_ID, afterExpiry, 5)).isZero();
+        assertThat(batchMapper.selectDueBatchIds(OTHER_TENANT_ID, afterExpiry, 5, 100)).isEmpty();
+        assertThat(persistenceService.claim(
+                OTHER_TENANT_ID,
+                recovery.getId(),
+                "claim-other-tenant",
+                afterExpiry,
+                Date.from(afterExpiry.toInstant().plusSeconds(120)),
+                5)).isEmpty();
+
+        assertThat(batchMapper.countDueBatches(TENANT_ID, afterExpiry, 5)).isEqualTo(1);
+        assertThat(batchMapper.selectDueBatchIds(TENANT_ID, afterExpiry, 5, 100))
+                .containsExactly(recovery.getId());
+        assertThat(persistenceService.claim(
+                TENANT_ID,
+                deletedSubmitting.getId(),
+                "claim-deleted-recovery",
+                afterExpiry,
+                Date.from(afterExpiry.toInstant().plusSeconds(120)),
+                5)).isEmpty();
+        Optional<AttestationBatch> seventhClaim = persistenceService.claim(
+                TENANT_ID,
+                recovery.getId(),
+                "claim-exhausted-7",
+                afterExpiry,
+                Date.from(afterExpiry.toInstant().plusSeconds(120)),
+                5);
+
+        assertThat(seventhClaim).isPresent();
+        assertThat(seventhClaim.orElseThrow().getAttemptCount()).isEqualTo(7);
+        assertThat(persistenceService.claim(
+                TENANT_ID,
+                pendingAtLimit.getId(),
+                "claim-pending-limit",
+                afterExpiry,
+                Date.from(afterExpiry.toInstant().plusSeconds(120)),
+                5)).isEmpty();
+        assertThat(persistenceService.claim(
+                TENANT_ID,
+                retryAtLimit.getId(),
+                "claim-retry-limit",
+                afterExpiry,
+                Date.from(afterExpiry.toInstant().plusSeconds(120)),
+                5)).isEmpty();
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attestation_batch_attempt WHERE tenant_id = ? AND batch_id = ?",
+                Integer.class,
+                TENANT_ID,
+                recovery.getId())).isEqualTo(7);
+        assertThat(jdbcTemplate.queryForList(
+                "SELECT attempt_no FROM attestation_batch_attempt "
+                        + "WHERE tenant_id = ? AND batch_id = ? ORDER BY attempt_no",
+                Integer.class,
+                TENANT_ID,
+                recovery.getId())).containsExactly(1, 2, 3, 4, 5, 6, 7);
+    }
+
+    /**
+     * 验证耗尽后的过期租约仍只有一个并发赢家，旧 token 无法迁移状态且人工终态不可再次领取。
+     */
+    @Test
+    void exhaustedConcurrentRecovery_shouldFenceStaleTokensAndKeepTerminalStateClosed()
+            throws Exception {
+        MerkleTreeResult tree = sampleTree();
+        Instant base = Instant.parse("2026-07-14T04:00:00Z");
+        AttestationBatch batch = persistenceService.createOrGet(
+                TENANT_ID, "i".repeat(64), tree);
+        AttestationBatch sixthClaim = claimThroughAttempt(batch, 6, base, "claim-race");
+        Date recoveryTime = Date.from(sixthClaim.getLeaseExpiresAt().toInstant().plusSeconds(1));
+        Date recoveryLease = Date.from(recoveryTime.toInstant().plusSeconds(120));
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        AttestationBatch winner;
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            Future<Optional<AttestationBatch>> first = executor.submit(() -> concurrentClaim(
+                    batch.getId(), "claim-race-a", recoveryTime, recoveryLease, ready, start));
+            Future<Optional<AttestationBatch>> second = executor.submit(() -> concurrentClaim(
+                    batch.getId(), "claim-race-b", recoveryTime, recoveryLease, ready, start));
+            ready.await();
+            start.countDown();
+
+            List<Optional<AttestationBatch>> results = List.of(first.get(), second.get());
+            assertThat(results.stream().filter(Optional::isPresent)).hasSize(1);
+            winner = results.stream().flatMap(Optional::stream).findFirst().orElseThrow();
+        }
+
+        String loserToken = "claim-race-a".equals(winner.getClaimToken())
+                ? "claim-race-b"
+                : "claim-race-a";
+        assertThat(winner.getAttemptCount()).isEqualTo(7);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attestation_batch_attempt WHERE tenant_id = ? AND batch_id = ?",
+                Integer.class,
+                TENANT_ID,
+                batch.getId())).isEqualTo(7);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attestation_batch_attempt "
+                        + "WHERE tenant_id = ? AND batch_id = ? AND attempt_no = 7",
+                Integer.class,
+                TENANT_ID,
+                batch.getId())).isEqualTo(1);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT claim_token FROM attestation_batch_attempt "
+                        + "WHERE tenant_id = ? AND batch_id = ? AND attempt_no = 7",
+                String.class,
+                TENANT_ID,
+                batch.getId())).isEqualTo(winner.getClaimToken());
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attestation_batch_attempt "
+                        + "WHERE tenant_id = ? AND batch_id = ? AND claim_token = ?",
+                Integer.class,
+                TENANT_ID,
+                batch.getId(),
+                loserToken)).isZero();
+
+        assertThat(persistenceService.confirm(
+                TENANT_ID,
+                batch.getId(),
+                "claim-race-6",
+                "c".repeat(64),
+                tree.merkleRoot(),
+                "CHAIN_WRITE")).isFalse();
+        assertThat(persistenceService.retry(
+                TENANT_ID,
+                batch.getId(),
+                "claim-race-6",
+                "stale retry",
+                Date.from(recoveryTime.toInstant().plusSeconds(300)))).isFalse();
+        assertThat(persistenceService.manualReview(
+                TENANT_ID,
+                batch.getId(),
+                loserToken,
+                "loser manual review",
+                null,
+                null)).isFalse();
+        assertThat(persistenceService.findById(TENANT_ID, batch.getId()))
+                .get()
+                .extracting(AttestationBatch::getStatus, AttestationBatch::getClaimToken)
+                .containsExactly("CHAIN_SUBMITTING", winner.getClaimToken());
+        assertThat(persistenceService.manualReview(
+                TENANT_ID,
+                batch.getId(),
+                winner.getClaimToken(),
+                "exhausted recovery reconciled",
+                null,
+                null)).isTrue();
+
+        Date terminalCheckTime = Date.from(recoveryTime.toInstant().plusSeconds(1_000));
+        assertThat(persistenceService.findById(TENANT_ID, batch.getId()))
+                .get()
+                .extracting(
+                        AttestationBatch::getStatus,
+                        AttestationBatch::getAttemptCount,
+                        AttestationBatch::getClaimToken,
+                        AttestationBatch::getLeaseExpiresAt)
+                .containsExactly("MANUAL_REVIEW", 7, null, null);
+        assertThat(batchMapper.countDueBatches(TENANT_ID, terminalCheckTime, 5)).isZero();
+        assertThat(batchMapper.selectDueBatchIds(TENANT_ID, terminalCheckTime, 5, 100)).isEmpty();
+        assertThat(persistenceService.claim(
+                TENANT_ID,
+                batch.getId(),
+                "claim-after-terminal",
+                terminalCheckTime,
+                Date.from(terminalCheckTime.toInstant().plusSeconds(120)),
+                5)).isEmpty();
+        assertThat(attemptStatus(batch.getId(), 6)).isEqualTo("STALE_IGNORED");
+        assertThat(attemptStatus(batch.getId(), 7)).isEqualTo("MANUAL_REVIEW");
+    }
+
+    /**
+     * 验证耗尽后的真实数据库 claim 对匹配、不存在、冲突和查询失败都只做链查询并收敛终态。
+     */
+    @Test
+    void exhaustedRecoveryOutcomes_shouldAlwaysRemainQueryOnlyAndTerminal() {
+        MerkleTreeResult tree = sampleTree();
+        Instant base = Instant.parse("2026-07-14T05:00:00Z");
+        AttestationBatch matching = createRegistryBatch("j", tree);
+        AttestationBatch missing = createRegistryBatch("k", tree);
+        AttestationBatch mismatch = createRegistryBatch("l", tree);
+        AttestationBatch queryError = createRegistryBatch("m", tree);
+        claimThroughAttempt(matching, 6, base, "claim-matching");
+        claimThroughAttempt(missing, 6, base, "claim-missing");
+        claimThroughAttempt(mismatch, 6, base, "claim-mismatch");
+        claimThroughAttempt(queryError, 6, base, "claim-query-error");
+
+        when(remoteClient.getContractRegistry()).thenAnswer(invocation -> {
+            assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+            return Result.success(List.of(testContractRegistry()));
+        });
+        when(remoteClient.getAttestationBatch(any(GetAttestationBatchRequest.class)))
+                .thenAnswer(invocation -> {
+                    assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+                    GetAttestationBatchRequest request = invocation.getArgument(0);
+                    if (matching.getId().equals(request.batchId())) {
+                        return Result.success(chainBatch(matching, matching.getMerkleRoot()));
+                    }
+                    if (missing.getId().equals(request.batchId())) {
+                        return Result.success(GetAttestationBatchResponse.notFound(
+                                TENANT_ID, missing.getId()));
+                    }
+                    if (mismatch.getId().equals(request.batchId())) {
+                        return Result.success(chainBatch(mismatch, "f".repeat(64)));
+                    }
+                    if (queryError.getId().equals(request.batchId())) {
+                        return Result.<GetAttestationBatchResponse>error(
+                                ResultEnum.BLOCKCHAIN_UNREACHABLE, null);
+                    }
+                    throw new AssertionError("Unexpected batch query: " + request.batchId());
+                });
+
+        List<AttestationBatch> outcomes = List.of(
+                attestationBatchService.submitBatch(matching.getId()),
+                attestationBatchService.submitBatch(missing.getId()),
+                attestationBatchService.submitBatch(mismatch.getId()),
+                attestationBatchService.submitBatch(queryError.getId()));
+
+        assertThat(outcomes)
+                .extracting(AttestationBatch::getStatus)
+                .containsExactly("COMPLETED", "MANUAL_REVIEW", "MANUAL_REVIEW", "MANUAL_REVIEW");
+        assertThat(outcomes)
+                .extracting(AttestationBatch::getAttemptCount)
+                .containsOnly(7);
+        verify(remoteClient, times(4)).getContractRegistry();
+        verify(remoteClient, times(4)).getAttestationBatch(any(GetAttestationBatchRequest.class));
+        verify(remoteClient, never()).storeAttestationBatch(any(StoreAttestationBatchRequest.class));
+        assertThat(attemptStatus(matching.getId(), 7)).isEqualTo("COMPLETED");
+        assertThat(attemptStatus(missing.getId(), 7)).isEqualTo("MANUAL_REVIEW");
+        assertThat(attemptStatus(mismatch.getId(), 7)).isEqualTo("MANUAL_REVIEW");
+        assertThat(attemptStatus(queryError.getId(), 7)).isEqualTo("MANUAL_REVIEW");
+        assertThat(attemptConfirmationSource(matching.getId(), 7))
+                .isEqualTo("CHAIN_QUERY_BEFORE_WRITE");
+        assertThat(attemptConfirmationSource(missing.getId(), 7)).isNull();
+        assertThat(attemptConfirmationSource(mismatch.getId(), 7))
+                .isEqualTo("CHAIN_QUERY_BEFORE_WRITE");
+        assertThat(attemptConfirmationSource(queryError.getId(), 7)).isNull();
+
+        Date terminalCheckTime = new Date();
+        assertThat(batchMapper.countDueBatches(TENANT_ID, terminalCheckTime, 5)).isZero();
+        assertThat(batchMapper.selectDueBatchIds(TENANT_ID, terminalCheckTime, 5, 100)).isEmpty();
+        for (AttestationBatch terminal : outcomes) {
+            assertThat(persistenceService.findById(TENANT_ID, terminal.getId()))
+                    .get()
+                    .extracting(
+                            AttestationBatch::getAttemptCount,
+                            AttestationBatch::getClaimToken,
+                            AttestationBatch::getLeaseExpiresAt)
+                    .containsExactly(7, null, null);
+            assertThat(persistenceService.claim(
+                    TENANT_ID,
+                    terminal.getId(),
+                    "claim-terminal-" + terminal.getId(),
+                    terminalCheckTime,
+                    Date.from(terminalCheckTime.toInstant().plusSeconds(120)),
+                    5)).isEmpty();
+        }
+    }
+
+    /**
      * 验证 Flyway JSON 列、MyBatis 映射和 claim CAS 对 registry 快照执行真实数据库闭环。
      */
     @Test
@@ -389,6 +707,99 @@ class AttestationBatchConsistencyIT extends BaseIntegrationTest {
         assertThatThrownBy(() -> persistenceService.requireContractRegistry(reloadedLegacy))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("no contract registry snapshot");
+    }
+
+    /**
+     * 使用相隔十一秒的领取时间把同一批次推进到目标 attempt，并保留最后一次提交态模拟崩溃。
+     */
+    private AttestationBatch claimThroughAttempt(
+            AttestationBatch batch,
+            int targetAttempt,
+            Instant base,
+            String tokenPrefix
+    ) {
+        AttestationBatch claimed = batch;
+        for (int attempt = 1; attempt <= targetAttempt; attempt++) {
+            Instant claimTime = base.plusSeconds((long) (attempt - 1) * 11L);
+            claimed = persistenceService.claim(
+                            TENANT_ID,
+                            batch.getId(),
+                            tokenPrefix + "-" + attempt,
+                            Date.from(claimTime),
+                            Date.from(claimTime.plusSeconds(10)),
+                            5)
+                    .orElseThrow();
+            assertThat(claimed.getAttemptCount()).isEqualTo(attempt);
+        }
+        return claimed;
+    }
+
+    /**
+     * 创建与测试 provider 当前 ACTIVE registry 完全一致的批次，供真实 service 恢复路径使用。
+     */
+    private AttestationBatch createRegistryBatch(String keySeed, MerkleTreeResult tree) {
+        return persistenceService.createOrGet(
+                TENANT_ID,
+                keySeed.repeat(64),
+                tree,
+                legacyEvidence(tree),
+                testContractRegistry());
+    }
+
+    /**
+     * 为测试 Merkle 叶构造与旧链记录兼容的不可变证据元数据。
+     */
+    private List<AttestationLeafEvidence> legacyEvidence(MerkleTreeResult tree) {
+        return tree.leaves().stream()
+                .map(leaf -> new AttestationLeafEvidence(
+                        leaf.fileId(),
+                        1,
+                        null,
+                        AttestationBatchPersistenceService.EVIDENCE_TYPE_LEGACY_CHAIN_RECORD_ID,
+                        leaf.fileHash(),
+                        leaf.fileHash()))
+                .toList();
+    }
+
+    /**
+     * 构造指定根哈希的链查询结果，其余不可变字段与真实数据库批次保持一致。
+     */
+    private GetAttestationBatchResponse chainBatch(AttestationBatch batch, String merkleRoot) {
+        return new GetAttestationBatchResponse(
+                true,
+                batch.getTenantId(),
+                batch.getId(),
+                batch.getBatchNo(),
+                batch.getProofAlgorithm(),
+                merkleRoot,
+                batch.getLeafCount(),
+                1_700_000_000_000L);
+    }
+
+    /**
+     * 读取指定 attempt 的真实审计终态。
+     */
+    private String attemptStatus(Long batchId, int attemptNo) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM attestation_batch_attempt "
+                        + "WHERE tenant_id = ? AND batch_id = ? AND attempt_no = ?",
+                String.class,
+                TENANT_ID,
+                batchId,
+                attemptNo);
+    }
+
+    /**
+     * 读取指定 attempt 的链确认来源，区分对账完成、冲突和无链证据的人工终结。
+     */
+    private String attemptConfirmationSource(Long batchId, int attemptNo) {
+        return jdbcTemplate.queryForObject(
+                "SELECT confirmation_source FROM attestation_batch_attempt "
+                        + "WHERE tenant_id = ? AND batch_id = ? AND attempt_no = ?",
+                String.class,
+                TENANT_ID,
+                batchId,
+                attemptNo);
     }
 
     /**


### PR DESCRIPTION
## 关联任务

- Trellis 父任务：07-13-roadmap-p1-proof-productization
- Trellis 子任务：07-15-roadmap-p1-chain-submission-recovery-terminal
- ROADMAP 阶段：P1 可信存证产品化，最后一个子任务

## 问题背景

第 5 次链写 worker 崩溃后，第 6 次 query-only worker 会把 attempt_count 增至 6。若它在终态持久化前再次崩溃，原有 due/list/claim SQL 会因 attempt_count 上限永久排除该 CHAIN_SUBMITTING 记录。审查同时确认 Dubbo 默认 failover 可能把一次非幂等 storeAttestationBatch 调用重放为多次 provider 调用，使数据库最多 5 次 attempt 不能严格约束实际链写次数。

## 修改内容

- 统一修正 due 列表、due 计数和原子 claim 三处条件：
  - CHAIN_PENDING 与 CHAIN_RETRY 继续要求 attempt_count 小于 5；
  - 任意次数的 CHAIN_SUBMITTING 只要租约非空且已过期即可恢复。
- 仅对 storeAttestationBatch 配置 Dubbo 方法级 retries=0；引用级、查询和其他 RPC 的既有重试策略不变。
- 增加 mapper 注解 SQL 合同测试和 registry/query fail-closed 单元测试。
- 将真实 MySQL AttestationBatchConsistencyIT 扩充为 8 项，覆盖 attempt 6 再崩溃后的 attempt 7、并发单赢家、旧 token fencing、租户与软删除隔离、终态不可重领，以及匹配/不存在/冲突/查询失败四种 query-only 收敛结果。
- 增加 CI 硬门禁，精确要求该 IT tests=8、skipped=0、failures=0、errors=0，禁止无 Docker 时假绿。

## 影响范围

- backend DAO 的 batch due/claim SQL。
- backend service 单个 Dubbo 写方法的 consumer 重试策略。
- backend service/web 测试与 test workflow。
- 无数据库 migration、REST API、共享 RPC 接口或 DTO、FISCO/Besu adapter、Solidity 合约、proof 格式和前端合同变化。

## 本地测试证据

通过：

- 聚焦 backend-service 单测：72 项，零失败/错误/跳过。
- backend-common 241 项、backend-service 932 项、backend-web unit 351 项：零失败/错误；JaCoCo 门禁通过。
- platform-api 7 项；public verifier SDK 119 项、CLI 10 项、web 28 项。
- FISCO 93 项；storage 169 项。
- frontend：Prettier、ESLint、Svelte check 零诊断、464 项覆盖率测试、生产构建。
- contract：34 项测试、catalog verify/refresh、部署脚本语法。
- docs：routes/env/roadmap/version 一致性与 VitePress 构建。
- backend/FISCO/storage package、actionlint。
- Trivy CRITICAL/HIGH 且 ignore-unfixed：0 个漏洞。
- 两路独立人工代码与安全审查：0 个高置信 finding。

本机没有 Docker 命令，因此 Testcontainers 无法作为本地验收证据。精确 backend clean verify -Pit 已完成所有 unit/JaCoCo，但 AttestationBatchConsistencyIT 报告为 8 项全部跳过，既有 ProofStatusTimestampMigrationIT 因无法连接 Docker 报错；本 PR 必须由 GitHub Actions 真实 MySQL 环境证明 8/0/0/0 后才允许合并。

## 验收结果

静态与非 Docker 动态验收已满足；真实 MySQL、容器构建/启动、CodeQL 和远程 Trivy 以本 PR required CI 为最终证据。CI、审查意见、冲突和子任务验收全部清零前不自动合并。

## 风险评估

- 主要风险是错误放开第 6 次链写、削弱 lease/token 并发互斥或把 retries=0 扩散到其他 RPC。
- 控制措施包括 service RPC 零写断言、真实 MySQL 双线程 claim、三处 SQL 合同测试、引用级默认值断言和精确 Failsafe 零跳过门禁。
- 持续崩溃会增加恢复审计 attempt，但不会增加链写；每次恢复仍受 lease 约束。
- 现有索引、tenant/deleted 条件和接口合同均未改变。

## 回滚方式

关闭 production scheduler，等待当前有效 claim 结束后回滚本提交；保留所有 batch、attempt、registry snapshot 和链上数据。若存在 attempt_count 大于 5 的过期 CHAIN_SUBMITTING 记录，应保留修复版本或立即前滚，禁止绕过链查询直接写成功终态。