### PR TITLE
fix: fail closed on unknown attestation query state

### DIFF
--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/AbstractFiscoAdapter.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/AbstractFiscoAdapter.java
@@ -181,9 +181,10 @@ public abstract class AbstractFiscoAdapter implements BlockChainAdapter {
                 throw new ChainException(getChainType(), "getAttestationBatch", "Invalid return value");
             }
 
-            boolean exists = values.get(0) instanceof Boolean value
-                    ? value
-                    : Boolean.parseBoolean(String.valueOf(values.get(0)));
+            if (!(values.get(0) instanceof Boolean exists)) {
+                throw new ChainException(
+                        getChainType(), "getAttestationBatch", "Invalid exists flag");
+            }
             if (!exists) {
                 return ChainAttestationBatch.notFound(tenantId, batchId);
             }

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/service/BlockChainServiceImpl.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/service/BlockChainServiceImpl.java
@@ -243,7 +243,10 @@ public class BlockChainServiceImpl implements BlockChainService {
 
             ChainAttestationBatch batch = chainAdapter.getAttestationBatch(
                     request.tenantId(), request.batchId());
-            if (batch == null || !Boolean.TRUE.equals(batch.getExists())) {
+            if (batch == null || batch.getExists() == null) {
+                return Result.error(ResultEnum.CONTRACT_ERROR, null);
+            }
+            if (Boolean.FALSE.equals(batch.getExists())) {
                 return Result.success(GetAttestationBatchResponse.notFound(
                         request.tenantId(), request.batchId()));
             }

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/AbstractFiscoAdapterAttestationBatchTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/AbstractFiscoAdapterAttestationBatchTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,6 +103,28 @@ class AbstractFiscoAdapterAttestationBatchTest {
         assertThatThrownBy(() -> adapter.getAttestationBatch(7L, 900L))
                 .isInstanceOf(ChainException.class)
                 .hasMessageContaining("Invalid return value");
+    }
+
+    /**
+     * 验证 exists 只接受 ABI 解码后的布尔值，未知类型不能静默降级为链上不存在。
+     */
+    @Test
+    void getAttestationBatch_shouldRejectNullOrNonBooleanExistsFlag() throws Exception {
+        when(sharingService.getAttestationBatch(any())).thenReturn(callResponse);
+
+        for (Object invalidExists : Arrays.asList(null, "false", 0, "garbage")) {
+            when(callResponse.getReturnObject()).thenReturn(Arrays.asList(
+                    invalidExists,
+                    "",
+                    "",
+                    new byte[32],
+                    BigInteger.ZERO,
+                    BigInteger.ZERO));
+
+            assertThatThrownBy(() -> adapter.getAttestationBatch(7L, 900L))
+                    .isInstanceOf(ChainException.class)
+                    .hasMessageContaining("Invalid exists flag");
+        }
     }
 
     /**

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/service/BlockChainServiceImplTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/service/BlockChainServiceImplTest.java
@@ -364,6 +364,41 @@ class BlockChainServiceImplTest {
         }
 
         /**
+         * 验证 adapter 未返回查询模型时 provider 失败关闭，而不是伪造链上不存在。
+         */
+        @Test
+        @DisplayName("Should reject missing adapter query model")
+        void getAttestationBatch_shouldRejectMissingAdapterModel() {
+            when(chainAdapter.getAttestationBatch(7L, 900L)).thenReturn(null);
+
+            Result<GetAttestationBatchResponse> result = blockChainService.getAttestationBatch(
+                    new GetAttestationBatchRequest(7L, 900L, CONTRACT_REGISTRY));
+
+            assertThat(result.getCode()).isEqualTo(ResultEnum.CONTRACT_ERROR.getCode());
+            assertThat(result.getData()).isNull();
+        }
+
+        /**
+         * 验证 exists 缺失属于未知查询状态，provider 不得把它映射为成功的 notFound。
+         */
+        @Test
+        @DisplayName("Should reject missing adapter exists state")
+        void getAttestationBatch_shouldRejectMissingExistsState() {
+            when(chainAdapter.getAttestationBatch(7L, 900L)).thenReturn(
+                    ChainAttestationBatch.builder()
+                            .exists(null)
+                            .tenantId(7L)
+                            .batchId(900L)
+                            .build());
+
+            Result<GetAttestationBatchResponse> result = blockChainService.getAttestationBatch(
+                    new GetAttestationBatchRequest(7L, 900L, CONTRACT_REGISTRY));
+
+            assertThat(result.getCode()).isEqualTo(ResultEnum.CONTRACT_ERROR.getCode());
+            assertThat(result.getData()).isNull();
+        }
+
+        /**
          * 验证无效业务键在 provider 入口被拒绝且不调用链适配器。
          */
         @Test


### PR DESCRIPTION
## 关联任务

- 父任务：`.trellis/tasks/07-13-roadmap-p1-proof-productization`
- 子任务：`.trellis/tasks/07-16-roadmap-p1-chain-query-tristate-hardening`
- 来源：P1 阶段综合审查对 `44fd794c..c7a3965d` 的高优先级整改项

## 问题背景

批量存证查询原先会通过 `Boolean.parseBoolean(String.valueOf(value))` 宽松解析 FISCO ABI 的 `exists` 返回值，并在 provider 层把空模型或 `exists=null` 一并映射为成功的 `notFound`。这会把 `null`、字符串、数字或 SDK/ABI 漂移等“查询状态未知”伪装成“链上确定不存在”，使 backend 的 query-before-write 状态机可能继续发起链写。

## 修改内容

- `AbstractFiscoAdapter#getAttestationBatch` 只接受 SDK 解码后的真实 `Boolean`：
  - `true`：继续严格解析完整记录；
  - `false`：返回稳定的 `notFound`；
  - `null`、字符串、数字和其他类型：抛出 `ChainException`。
- `BlockChainServiceImpl#getAttestationBatch` 对空 adapter 模型或 `exists=null` 返回 `CONTRACT_ERROR`，仅显式 `Boolean.FALSE` 返回成功 `notFound`。
- 增加 adapter/provider 回归测试，覆盖 `null`、`"false"`、`0`、垃圾字符串、空模型和空状态。
- 保持共享 RPC DTO、合约、数据库、配置和显式 true/false 行为不变。

## 影响范围

- 仅涉及 `platform-fisco` 的批量存证只读查询 adapter/provider 边界及对应测试。
- backend 现有 `ChainQuery.ERROR / NOT_FOUND / FOUND` 三态消费逻辑无需改动；错误状态现在会稳定停在 `ERROR`，不会进入链写路径。
- 不涉及 API 结构、数据库迁移、配置键、合约部署或前端行为。

## 测试证据

- FISCO 定向测试：51 tests，0 failures/errors/skips。
- FISCO 全量：96 tests，全部通过。
- backend fail-closed 回归：`submitBatch_shouldFailClosedWhenExhaustedChainQueryIsIncomplete` 通过，并断言未知查询状态不调用链写。
- platform-api：7 tests；verifier SDK/CLI/Web：119/10/28 tests；storage：169 tests；全部通过。
- backend common/service/web 单元测试与 JaCoCo coverage checks 全部通过。
- frontend：固定 pnpm 10.26.1，format、lint、Svelte check、464 tests、OpenAPI types check、build 全部通过。
- OpenAPI export 2 tests、docs routes/env/roadmap/versions、docs build、Actionlint、部署脚本 `bash -n`/ShellCheck、34 个 contract fixtures、catalog verify/refresh 全部通过。
- CI 同款 Maven package：platform-api、platform-verifier、platform-backend、platform-fisco、platform-storage 全部成功。
- Trivy filesystem（`CRITICAL,HIGH`、`ignore-unfixed`、`exit-code=1`）：全部 Maven/pnpm targets 为 0 findings。
- `git diff --check` 通过；纯人工完整 diff 审查未发现高置信可执行问题，未使用 security 插件。

本地 `mvn clean verify -pl backend-common,backend-service,backend-web -am -Pit` 的单元测试和 JaCoCo 已通过，但当前 macOS 无可用 Docker socket：44 个 Testcontainers 测试跳过，`ProofStatusTimestampMigrationIT` 在容器初始化时报错。因此本 PR 必须以 GitHub Docker CI 在当前提交上真实执行并通过全部 Failsafe IT 作为合并硬条件，不把本地环境阻塞视为通过。

## 验收结果

- [x] 显式 `true` 完整映射不变。
- [x] 显式 `false` 保持稳定 `notFound`。
- [x] 非 Boolean/空查询状态 fail closed 为链/合约错误。
- [x] 未知状态不会进入 backend 链写路径。
- [x] 无接口、schema、配置或性能路径变化。
- [ ] GitHub 全部 CI、Codecov 和审查意见通过。
- [ ] 合并至 `main` 并验证远程 main exact SHA。

## 风险评估

- 预期行为变化：以前被静默降级为“不存在”的畸形链返回现在会暴露为 `CONTRACT_ERROR`；这会提高错误可见性并阻止潜在重复写。
- 兼容性：符合 ABI 的 `Boolean.TRUE/FALSE` 完全兼容；无序列化字段变化。
- 性能：仅增加常量时间类型/空值判断，无额外 RPC、锁或持久化。

## 回滚方式

回滚提交 `ecbf62ac` 即可恢复旧实现；不涉及 schema、数据回填、配置迁移或外部合约回滚。若回滚，必须同时接受未知链查询状态再次可能被误判为不存在的风险。
