### PR TITLE
fix: unify public proof audit client IP

### DIFF
--- a/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
@@ -6,8 +6,8 @@ import cn.flying.common.util.IdUtils;
 import cn.flying.common.util.JsonConverter;
 import cn.flying.common.util.SensitiveDataMasker;
 import cn.flying.dao.dto.SysOperationLog;
+import cn.flying.security.TrustedClientIpResolver;
 import cn.flying.service.SysOperationLogService;
-import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
@@ -37,8 +37,18 @@ import java.util.Set;
 @Slf4j
 public class OperationLogAspect {
 
-    @Resource
-    private SysOperationLogService operationLogService;
+    private final SysOperationLogService operationLogService;
+    private final TrustedClientIpResolver trustedClientIpResolver;
+
+    /**
+     * 注入操作日志持久化服务和统一的可信客户端 IP 解析器。
+     */
+    public OperationLogAspect(
+            SysOperationLogService operationLogService,
+            TrustedClientIpResolver trustedClientIpResolver) {
+        this.operationLogService = operationLogService;
+        this.trustedClientIpResolver = trustedClientIpResolver;
+    }
     
     // 忽略的非业务URL前缀（保留 /api/file 等核心接口的审计记录）
     private final Set<String> ignores = Set.of(
@@ -328,26 +338,12 @@ public class OperationLogAspect {
     }
 
     /**
-     * 获取客户端IP
+     * 通过统一可信代理边界获取规范化客户端 IP。
      *
      * @param request 请求对象
      * @return IP地址
      */
     private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("Proxy-Client-IP");
-        }
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getHeader("WL-Proxy-Client-IP");
-        }
-        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getRemoteAddr();
-        }
-        // 多个代理的情况，第一个IP为客户端真实IP
-        if (ip != null && ip.contains(",")) {
-            ip = ip.split(",")[0].trim();
-        }
-        return ip;
+        return trustedClientIpResolver.resolve(request);
     }
-} 
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -1,14 +1,51 @@
 package cn.flying.aspect;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import cn.flying.common.annotation.OperationLog;
+import cn.flying.config.RateLimitClientIpProperties;
+import cn.flying.dao.dto.SysOperationLog;
+import cn.flying.security.TrustedClientIpResolver;
+import cn.flying.service.SysOperationLogService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @DisplayName("OperationLogAspect Tests")
 class OperationLogAspectTest {
+
+    /**
+     * 清理 servlet、安全与 MDC 上下文，避免测试线程复用造成状态泄漏。
+     */
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+        SecurityContextHolder.clearContext();
+        MDC.clear();
+    }
 
     /**
      * 验证操作日志切面会脱敏路径中的分享码和文件哈希。
@@ -16,7 +53,7 @@ class OperationLogAspectTest {
     @Test
     @DisplayName("Should mask sensitive identifiers in operation log path")
     void shouldMaskSensitiveIdentifiersInOperationLogPath() {
-        OperationLogAspect aspect = new OperationLogAspect();
+        OperationLogAspect aspect = newAspect("");
 
         String sanitized = ReflectionTestUtils.invokeMethod(
                 aspect,
@@ -54,7 +91,7 @@ class OperationLogAspectTest {
     @Test
     @DisplayName("Should classify file operations as sensitive")
     void shouldClassifyFileOperationsAsSensitive() {
-        OperationLogAspect aspect = new OperationLogAspect();
+        OperationLogAspect aspect = newAspect("");
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/transactions/0xtxhash");
 
         Boolean result = ReflectionTestUtils.invokeMethod(aspect, "isSensitiveFileOperation", request);
@@ -68,7 +105,7 @@ class OperationLogAspectTest {
     @Test
     @DisplayName("Should classify upload session operations as sensitive")
     void shouldClassifyUploadSessionOperationsAsSensitive() {
-        OperationLogAspect aspect = new OperationLogAspect();
+        OperationLogAspect aspect = newAspect("");
         MockHttpServletRequest request = new MockHttpServletRequest(
                 "POST",
                 "/api/v1/upload-sessions/client-secret/complete"
@@ -85,7 +122,7 @@ class OperationLogAspectTest {
     @Test
     @DisplayName("Should classify sensitive operations behind context path")
     void shouldClassifySensitiveOperationsBehindContextPath() {
-        OperationLogAspect aspect = new OperationLogAspect();
+        OperationLogAspect aspect = newAspect("");
         MockHttpServletRequest request = new MockHttpServletRequest(
                 "GET",
                 "/record-platform/api/v1/public/shares/ABC123/files/hash-secret/chunks"
@@ -103,7 +140,7 @@ class OperationLogAspectTest {
     @Test
     @DisplayName("Should not ignore system audit API paths")
     void shouldNotIgnoreSystemAuditApiPaths() {
-        OperationLogAspect aspect = new OperationLogAspect();
+        OperationLogAspect aspect = newAspect("");
 
         Boolean result = ReflectionTestUtils.invokeMethod(
                 aspect,
@@ -120,7 +157,7 @@ class OperationLogAspectTest {
     @Test
     @DisplayName("Should still ignore API documentation paths")
     void shouldStillIgnoreApiDocumentationPaths() {
-        OperationLogAspect aspect = new OperationLogAspect();
+        OperationLogAspect aspect = newAspect("");
 
         Boolean result = ReflectionTestUtils.invokeMethod(
                 aspect,
@@ -129,5 +166,170 @@ class OperationLogAspectTest {
         );
 
         assertThat(result).isTrue();
+    }
+
+    /**
+     * 验证不可信直接对端不能用任何旧代理头污染文本日志或数据库审计 IP。
+     */
+    @Test
+    @DisplayName("Should use the same untrusted peer IP in text and persisted audit logs")
+    void shouldUseSameUntrustedPeerIpInTextAndPersistedAuditLogs() throws Throwable {
+        SysOperationLogService operationLogService = mock(SysOperationLogService.class);
+        OperationLogAspect aspect = new OperationLogAspect(operationLogService, newResolver("10.0.0.0/8"));
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "GET",
+                "/api/v1/public/proofs/rp-test/status"
+        );
+        request.setServletPath("/api/v1/public/proofs/rp-test/status");
+        request.setRemoteAddr("198.51.100.24");
+        request.addHeader("X-Forwarded-For", "203.0.113.7");
+        request.addHeader("X-Real-IP", "203.0.113.8");
+        request.addHeader("Proxy-Client-IP", "203.0.113.9");
+        request.addHeader("WL-Proxy-Client-IP", "203.0.113.10");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ProceedingJoinPoint joinPoint = auditedJoinPoint();
+        Logger aspectLogger = (Logger) LoggerFactory.getLogger(OperationLogAspect.class);
+        Level previousLevel = aspectLogger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        aspectLogger.setLevel(Level.INFO);
+        aspectLogger.addAppender(appender);
+        try {
+            assertThat(aspect.doAround(joinPoint)).isEqualTo("ok");
+        } finally {
+            aspectLogger.detachAppender(appender);
+            aspectLogger.setLevel(previousLevel);
+            appender.stop();
+        }
+
+        var captor = org.mockito.ArgumentCaptor.forClass(SysOperationLog.class);
+        verify(operationLogService).saveOperationLog(captor.capture());
+        assertThat(captor.getValue().getRequestIp()).isEqualTo("198.51.100.24");
+
+        List<String> messages = appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+        assertThat(messages).anyMatch(message -> message.contains("IP: 198.51.100.24"));
+        assertThat(messages).noneMatch(message -> message.contains("203.0.113."));
+    }
+
+    /**
+     * 验证可信代理携带合法多跳 XFF 时审计切面使用 resolver 选择的规范地址。
+     */
+    @Test
+    @DisplayName("Should resolve a valid multi-hop chain from a trusted peer")
+    void shouldResolveValidMultiHopChainFromTrustedPeer() {
+        OperationLogAspect aspect = newAspect("10.0.0.0/8");
+        MockHttpServletRequest request = requestFrom("10.0.0.20");
+        request.addHeader("X-Forwarded-For", "203.0.113.7, 10.1.0.8, 10.2.0.9");
+
+        String clientIp = ReflectionTestUtils.invokeMethod(aspect, "getClientIp", request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.7");
+    }
+
+    /**
+     * 验证重复、超长、超多跳、非数字和旧代理头均安全回退到可信直接对端。
+     */
+    @Test
+    @DisplayName("Should fall back to the peer for malicious forwarding headers")
+    void shouldFallbackToPeerForMaliciousForwardingHeaders() {
+        OperationLogAspect aspect = newAspect("10.0.0.0/8");
+        List<MockHttpServletRequest> requests = new ArrayList<>();
+
+        MockHttpServletRequest duplicate = requestFrom("10.0.0.20");
+        duplicate.addHeader("X-Forwarded-For", "203.0.113.1");
+        duplicate.addHeader("X-Forwarded-For", "203.0.113.2");
+        requests.add(duplicate);
+
+        MockHttpServletRequest tooLong = requestFrom("10.0.0.20");
+        tooLong.addHeader("X-Forwarded-For", "1".repeat(1025));
+        requests.add(tooLong);
+
+        MockHttpServletRequest tooMany = requestFrom("10.0.0.20");
+        tooMany.addHeader("X-Forwarded-For", IntStream.rangeClosed(1, 17)
+                .mapToObj(index -> "10.0.0." + index)
+                .collect(java.util.stream.Collectors.joining(", ")));
+        requests.add(tooMany);
+
+        MockHttpServletRequest hostname = requestFrom("10.0.0.20");
+        hostname.addHeader("X-Forwarded-For", "attacker.example");
+        requests.add(hostname);
+
+        MockHttpServletRequest legacyHeaders = requestFrom("10.0.0.20");
+        legacyHeaders.addHeader("Proxy-Client-IP", "203.0.113.3");
+        legacyHeaders.addHeader("WL-Proxy-Client-IP", "203.0.113.4");
+        requests.add(legacyHeaders);
+
+        for (MockHttpServletRequest request : requests) {
+            String clientIp = ReflectionTestUtils.invokeMethod(aspect, "getClientIp", request);
+            assertThat(clientIp).isEqualTo("10.0.0.20");
+        }
+    }
+
+    /**
+     * 验证无 HTTP 请求上下文时仍执行目标方法且不会尝试持久化操作日志。
+     */
+    @Test
+    @DisplayName("Should preserve non-HTTP invocation behavior")
+    void shouldPreserveNonHttpInvocationBehavior() throws Throwable {
+        SysOperationLogService operationLogService = mock(SysOperationLogService.class);
+        OperationLogAspect aspect = new OperationLogAspect(operationLogService, newResolver(""));
+        ProceedingJoinPoint joinPoint = auditedJoinPoint();
+
+        assertThat(aspect.doAround(joinPoint)).isEqualTo("ok");
+
+        verify(operationLogService, never()).saveOperationLog(any());
+    }
+
+    /**
+     * 构造带指定可信代理网段的操作日志切面。
+     */
+    private OperationLogAspect newAspect(String trustedProxies) {
+        return new OperationLogAspect(mock(SysOperationLogService.class), newResolver(trustedProxies));
+    }
+
+    /**
+     * 构造启用严格容器头策略的真实可信客户端 IP 解析器。
+     */
+    private TrustedClientIpResolver newResolver(String trustedProxies) {
+        RateLimitClientIpProperties properties = new RateLimitClientIpProperties();
+        properties.setTrustedProxies(trustedProxies);
+        return new TrustedClientIpResolver(properties, "none", "", "");
+    }
+
+    /**
+     * 构造指定直接对端的 Mock servlet 请求。
+     */
+    private MockHttpServletRequest requestFrom(String peer) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr(peer);
+        return request;
+    }
+
+    /**
+     * 构造可被真实操作日志切面读取注解和签名的测试连接点。
+     */
+    private ProceedingJoinPoint auditedJoinPoint() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        Method method = AuditedFixture.class.getDeclaredMethod("execute");
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(joinPoint.getArgs()).thenReturn(new Object[0]);
+        when(joinPoint.proceed()).thenReturn("ok");
+        when(signature.getMethod()).thenReturn(method);
+        when(signature.getDeclaringTypeName()).thenReturn(AuditedFixture.class.getName());
+        when(signature.getName()).thenReturn(method.getName());
+        return joinPoint;
+    }
+
+    private static final class AuditedFixture {
+
+        /**
+         * 提供携带操作日志注解的测试目标方法。
+         */
+        @OperationLog(module = "test", operationType = "query", description = "test audit")
+        private String execute() {
+            return "ok";
+        }
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/PublicProofAuditTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/PublicProofAuditTenantIsolationIT.java
@@ -4,60 +4,183 @@ import cn.flying.test.support.BaseControllerIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 /**
- * 公共 proof 匿名请求的操作日志租户隔离集成测试。
+ * 公共 proof 匿名请求的操作日志租户与可信客户端 IP 集成测试。
  */
 @Transactional
-@DisplayName("Public proof audit tenant isolation integration tests")
+@TestPropertySource(properties = "spring.web.rate-limit.client-ip.trusted-proxies=10.0.0.0/8")
+@DisplayName("Public proof audit tenant and trusted IP integration tests")
 class PublicProofAuditTenantIsolationIT extends BaseControllerIntegrationTest {
 
     private static final long FORGED_TENANT_ID = 9_876_543_210L;
+    private static final String UNTRUSTED_PEER = "198.51.100.24";
+    private static final String TRUSTED_PEER = "10.0.0.20";
+    private static final String TRUSTED_CLIENT = "203.0.113.7";
+    private static final String PUBLIC_PROOF_RATE_KEY_PREFIX =
+            "rate:limit:public:proof-verification:v2:ip:";
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
     /**
-     * 验证伪造租户头经过完整过滤器、控制器 AOP 和 MyBatis 落库链路后不会污染目标租户日志。
+     * 验证两个公开端点在可信、不可信和恶意代理头场景下共享规范化限流与审计主体。
      */
     @Test
-    @DisplayName("should not attribute anonymous public proof audit logs to forged tenant")
-    void shouldNotAttributeAnonymousPublicProofAuditLogsToForgedTenant() throws Exception {
-        String uniqueSuffix = UUID.randomUUID().toString().replace("-", "");
-        List<String> requestPaths = List.of(
+    @DisplayName("should keep public proof rate-limit and audit identities canonical")
+    void shouldKeepPublicProofRateLimitAndAuditIdentitiesCanonical() throws Exception {
+        assertUntrustedRequestsUseDirectPeer();
+        assertTrustedRequestsUseCanonicalClient();
+        assertMaliciousHeadersFallbackToDirectPeer();
+    }
+
+    /**
+     * 验证伪造租户与转发头不能污染两个公开端点的限流或数据库审计主体。
+     */
+    private void assertUntrustedRequestsUseDirectPeer() throws Exception {
+        for (String requestPath : publicProofPaths("untrusted")) {
+            MockHttpServletRequestBuilder request = get(requestPath)
+                    .with(remoteAddress(UNTRUSTED_PEER))
+                    .header(HEADER_TENANT_ID, FORGED_TENANT_ID)
+                    .header("X-Forwarded-For", "203.0.113.91")
+                    .header("X-Real-IP", "203.0.113.92")
+                    .header("Proxy-Client-IP", "203.0.113.93")
+                    .header("WL-Proxy-Client-IP", "203.0.113.94");
+
+            performAndAssertCanonicalAudit(requestPath, request, UNTRUSTED_PEER);
+        }
+    }
+
+    /**
+     * 验证可信代理的合法多跳 XFF 在两个公开端点上同时形成相同限流键和审计 IP。
+     */
+    private void assertTrustedRequestsUseCanonicalClient() throws Exception {
+        for (String requestPath : publicProofPaths("trusted")) {
+            MockHttpServletRequestBuilder request = get(requestPath)
+                    .with(remoteAddress(TRUSTED_PEER))
+                    .header("X-Forwarded-For", TRUSTED_CLIENT + ", 10.1.0.8, 10.2.0.9");
+
+            performAndAssertCanonicalAudit(requestPath, request, TRUSTED_CLIENT);
+        }
+    }
+
+    /**
+     * 验证重复、超长、超多跳、非数字及旧代理头不会污染或丢失任一公开端点的审计行。
+     */
+    private void assertMaliciousHeadersFallbackToDirectPeer() throws Exception {
+        for (MaliciousHeaderCase headerCase : maliciousHeaderCases()) {
+            for (String requestPath : publicProofPaths(headerCase.name())) {
+                MockHttpServletRequestBuilder request = get(requestPath)
+                        .with(remoteAddress(TRUSTED_PEER))
+                        .header(HEADER_TENANT_ID, FORGED_TENANT_ID);
+                headerCase.configure().accept(request);
+
+                performAndAssertCanonicalAudit(requestPath, request, TRUSTED_PEER);
+            }
+        }
+    }
+
+    /**
+     * 执行公共请求并同时断言限流键、唯一审计行、系统租户和数据库字段长度边界。
+     */
+    private void performAndAssertCanonicalAudit(
+            String requestPath,
+            MockHttpServletRequestBuilder request,
+            String expectedClientIp) throws Exception {
+        String rateLimitKey = PUBLIC_PROOF_RATE_KEY_PREFIX + expectedClientIp;
+        redisTemplate.delete(rateLimitKey);
+
+        mockMvc.perform(request).andReturn();
+
+        assertThat(redisTemplate.opsForValue().get(rateLimitKey)).isEqualTo("1");
+        List<AuditRow> rows = jdbcTemplate.query(
+                "SELECT tenant_id, request_ip FROM sys_operation_log WHERE request_url = ?",
+                (resultSet, rowNumber) -> new AuditRow(
+                        resultSet.getLong("tenant_id"),
+                        resultSet.getString("request_ip")),
+                requestPath);
+
+        assertThat(rows).singleElement().satisfies(row -> {
+            assertThat(row.tenantId()).isZero();
+            assertThat(row.requestIp()).isEqualTo(expectedClientIp);
+            assertThat(row.requestIp()).hasSizeLessThanOrEqualTo(50);
+        });
+    }
+
+    /**
+     * 生成状态与历史公钥两个公开端点的唯一请求路径。
+     */
+    private List<String> publicProofPaths(String scenario) {
+        String uniqueSuffix = scenario + "-" + UUID.randomUUID().toString().replace("-", "");
+        return List.of(
                 "/api/v1/public/proofs/rp-audit-" + uniqueSuffix + "/status",
                 "/api/v1/public/proof-keys/audit-" + uniqueSuffix + "/versions/1");
+    }
 
-        for (String requestPath : requestPaths) {
-            mockMvc.perform(get(requestPath)
-                            .header(HEADER_TENANT_ID, FORGED_TENANT_ID))
-                    .andReturn();
+    /**
+     * 构造覆盖 resolver 拒绝边界和已删除旧代理头回退的恶意输入矩阵。
+     */
+    private List<MaliciousHeaderCase> maliciousHeaderCases() {
+        String tooManyHops = IntStream.rangeClosed(1, 17)
+                .mapToObj(index -> "10.0.0." + index)
+                .collect(java.util.stream.Collectors.joining(", "));
+        return List.of(
+                new MaliciousHeaderCase(
+                        "duplicate",
+                        request -> request.header(
+                                "X-Forwarded-For",
+                                "203.0.113.11",
+                                "203.0.113.12")),
+                new MaliciousHeaderCase(
+                        "overlong",
+                        request -> request.header("X-Forwarded-For", "1".repeat(1025))),
+                new MaliciousHeaderCase(
+                        "too-many-hops",
+                        request -> request.header("X-Forwarded-For", tooManyHops)),
+                new MaliciousHeaderCase(
+                        "non-numeric",
+                        request -> request
+                                .header("X-Forwarded-For", "attacker.example")
+                                .header("X-Real-IP", "203.0.113.13")),
+                new MaliciousHeaderCase(
+                        "legacy-headers",
+                        request -> request
+                                .header("Proxy-Client-IP", "203.0.113.14")
+                                .header("WL-Proxy-Client-IP", "203.0.113.15")));
+    }
 
-            Integer totalLogs = jdbcTemplate.queryForObject(
-                    "SELECT COUNT(*) FROM sys_operation_log WHERE request_url = ?",
-                    Integer.class,
-                    requestPath);
-            Integer forgedTenantLogs = jdbcTemplate.queryForObject(
-                    "SELECT COUNT(*) FROM sys_operation_log WHERE tenant_id = ? AND request_url = ?",
-                    Integer.class,
-                    FORGED_TENANT_ID,
-                    requestPath);
-            Integer systemTenantLogs = jdbcTemplate.queryForObject(
-                    "SELECT COUNT(*) FROM sys_operation_log WHERE tenant_id = 0 AND request_url = ?",
-                    Integer.class,
-                    requestPath);
+    /**
+     * 设置 MockMvc 请求的直接 socket 对端地址。
+     */
+    private RequestPostProcessor remoteAddress(String peer) {
+        return request -> {
+            request.setRemoteAddr(peer);
+            return request;
+        };
+    }
 
-            assertThat(totalLogs).isEqualTo(1);
-            assertThat(forgedTenantLogs).isZero();
-            assertThat(systemTenantLogs).isEqualTo(1);
-        }
+    private record MaliciousHeaderCase(
+            String name,
+            Consumer<MockHttpServletRequestBuilder> configure) {
+    }
+
+    private record AuditRow(long tenantId, String requestIp) {
     }
 }


### PR DESCRIPTION
## 关联任务

- Trellis 子任务：`roadmap-p1-public-proof-audit-trusted-ip`
- 阶段：`P1 proof productization`
- 前置基线：`origin/main@25a22559b7c2bfbb515ca00f2435de7cf984a3f1`

## 问题背景

公开 proof 限流已经通过 `TrustedClientIpResolver` 解析可信客户端 IP，但 `OperationLogAspect` 仍无条件读取调用方提供的 `X-Forwarded-For` 和旧代理头并取首项。同一请求因此可能在 Redis 限流、文本日志和数据库审计中被归属为不同主体；超长恶意头还可能超过 `sys_operation_log.request_ip VARCHAR(50)`，造成审计行丢失。

## 修改内容

- 通过构造器向 `OperationLogAspect` 注入现有 `TrustedClientIpResolver`。
- 文本操作日志和数据库 `request_ip` 统一委托该 resolver，删除切面中的原始 XFF、`Proxy-Client-IP`、`WL-Proxy-Client-IP` 回退逻辑。
- 扩展切面单元测试，覆盖不可信和可信 peer、合法多跳 XFF、重复、超长、17 跳、非数字、旧代理头，以及无 HTTP 上下文。
- 扩展 `PublicProofAuditTenantIsolationIT`：对两个公开 proof 端点逐场景断言相同 Redis 限流主体、恰好一条 MySQL 审计行、`tenant_id=0`、规范化 `request_ip` 和 `VARCHAR(50)` 长度边界。

## 影响范围

- 仅 `backend-web` 操作日志客户端 IP 归因及对应测试。
- 不改变 API、认证规则、租户语义、120/60 共享限流配额、Redis key 格式、数据库 schema 或依赖版本。
- 普通 `@OperationLog` 接口继续记录原有字段，但客户端 IP 改为服从统一可信代理边界。

## 本地测试证据

- `OperationLogAspectTest`：10 tests，0 failures/errors/skipped。
- backend 单元测试：`backend-service` 932；`backend-web` 355，0 failures/errors；JaCoCo 门禁通过。
- `platform-api clean install`：7 tests；`platform-verifier clean install`：SDK 119、CLI 10、Web 28；全部通过。
- `platform-fisco test`：130/130；`platform-storage test`：169/169。
- frontend：Prettier、ESLint、Svelte check、464/464 coverage tests、production build 全部通过。
- `OpenApiContractExportTest`：2/2；前端 `types:gen:check` 无漂移。
- docs consistency（routes/env/roadmap/versions）与 VitePress build 通过。
- 合约部署和指纹测试 59/59；signed artifact catalog verify 通过。
- Maven package、`actionlint`、`bash -n`、`git diff --check` 通过。
- Trivy fixed CRITICAL/HIGH dependency scan：0；Trivy secret scan：0。

本机没有 Docker。`mvn ... -Pit` 的单元测试、编译和 JaCoCo 已通过，但 Testcontainers 无法实际运行；目标 Failsafe 报告当地为 `tests=1, skipped=1`。因此真实 MySQL/Redis 验收必须由 CI 强制证明：`PublicProofAuditTenantIsolationIT tests=1, skipped=0, failures=0, errors=0`。未将本地跳过表述为集成测试通过。

全仓 `shellcheck` 仍报告 `main` 已有且与本次三文件差异无关的 `scripts/start.sh` 和 `scripts/env.sh` 告警；本次没有 shell diff，未越界修改。

## 人工审查与验收

- 已复核限流、文本操作日志和数据库审计均使用同一个无状态 resolver。
- 不可信 peer 忽略所有 forwarding header；可信 peer 的重复、超长、超跳、非数字输入均 fail closed 到规范化直接对端。
- resolver 输出仅为规范 IPv4、IPv6 或 `unknown-peer`，满足 `VARCHAR(50)`。
- 未发现新的空指针、资源泄漏、共享可变状态、事务、租户、权限、接口兼容性或性能问题。
- 已授权的 Security PoC run `29553267965` 精确扫描 PR head `1e6bc2ab`；与 exact-main 内容等价基线 run `29549316995` 比对后，Semgrep 42→42 且命中集合完全相同、解析错误签名 8→8、Trivy 0→0、SBOM 336→336。本次 3 个变更文件没有 Semgrep 命中或解析错误；全程未使用 security 插件。

## 风险评估

- 低到中风险。行为变化仅影响客户端 IP 归因：部署在未配置可信代理网段的环境将记录直接 socket peer，这是安全的 fail-closed 行为。
- 构造器签名变化已同步所有仓库内实例化点并通过 Spring 和单元编译验证。

## 回滚方式

- 回滚本 PR 的单一提交即可；无 schema、配置键、数据迁移或 API 回滚步骤。
- 回滚会恢复对调用方代理头的无条件信任，并重新暴露审计主体伪造和超长字段风险。
