### PR TITLE
fix: coordinate BSN Besu transaction nonces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,14 @@ FISCO_CERT_PATH=conf
 FISCO_PRIVATE_KEY=
 # 仅 blockchain.active=bsn-fisco 时必填；禁止依赖隐式 chain ID
 BSN_FISCO_CHAIN_ID=
+# 仅 BLOCKCHAIN_ACTIVE=bsn-besu 时使用；私钥必须由部署环境注入，禁止提交真实值
+BSN_BESU_RPC_URL=
+BSN_BESU_CHAIN_ID=
+BSN_BESU_PRIVATE_KEY=
+BSN_BESU_CONTRACT_STORAGE=
+BSN_BESU_CONTRACT_SHARING=
+# 必须指向支持原子替换和可靠文件锁的持久目录，且由同 signer 的受支持实例共享
+BSN_BESU_NONCE_STATE_DIRECTORY=/var/lib/record-platform/besu-nonce
 # 合约地址 (部署后更新)
 FISCO_SHARING_CONTRACT=0x6d5de407db930fd7f5a0d9f19be7ec7bc7b36a2a
 FISCO_STORAGE_CONTRACT=0xe7d7b002e51431b300ddc00b2c059ccc41ce4660

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -454,10 +454,34 @@ jobs:
           mvn -f platform-fisco/pom.xml clean package -DskipTests -q
           mvn -f platform-storage/pom.xml clean package -DskipTests -q
 
-      - name: Build Backend and Public Verifier Images
+      - name: Build Backend, FISCO and Public Verifier Images
         run: |
           docker build -f platform-backend/Dockerfile -t recordplatform-backend:pr .
+          docker build -f platform-fisco/Dockerfile -t recordplatform-fisco:pr .
           docker build -f platform-verifier/web-verifier/Dockerfile -t recordplatform-verifier-web:pr .
+
+      - name: Verify FISCO Non-Root Nonce Volume
+        run: |
+          fisco_uid="$(docker run --rm --entrypoint id recordplatform-fisco:pr -u)"
+          test "$fisco_uid" != "0"
+
+          volume_name="recordplatform-fisco-nonce-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          docker volume create "$volume_name" >/dev/null
+          trap 'docker volume rm -f "$volume_name" >/dev/null 2>&1 || true' EXIT
+
+          docker run --rm \
+            --read-only \
+            --entrypoint sh \
+            -v "$volume_name:/var/lib/record-platform/besu-nonce" \
+            recordplatform-fisco:pr \
+            -c 'test "$(id -u)" != "0" && touch /var/lib/record-platform/besu-nonce/first.state'
+
+          docker run --rm \
+            --read-only \
+            --entrypoint sh \
+            -v "$volume_name:/var/lib/record-platform/besu-nonce" \
+            recordplatform-fisco:pr \
+            -c 'test -f /var/lib/record-platform/besu-nonce/first.state && touch /var/lib/record-platform/besu-nonce/second.state'
 
       - name: Verify Public Verifier Container
         run: |

--- a/docs/en/deployment/docker-compose.md
+++ b/docs/en/deployment/docker-compose.md
@@ -210,9 +210,29 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - NACOS_HOST=nacos
+      - NACOS_PORT=${NACOS_PORT:-8848}
+      - NACOS_USERNAME=${NACOS_USERNAME:?Set NACOS_USERNAME in .env}
+      - NACOS_PASSWORD=${NACOS_PASSWORD:?Set NACOS_PASSWORD in .env}
       - DUBBO_HOST=${DUBBO_HOST:-host.docker.internal}  # Required for Docker
+      - BLOCKCHAIN_RPC_TOKEN=${BLOCKCHAIN_RPC_TOKEN:?Set BLOCKCHAIN_RPC_TOKEN in .env}
+      - BLOCKCHAIN_ACTIVE=${BLOCKCHAIN_ACTIVE:-local-fisco}
+      - BSN_BESU_RPC_URL=${BSN_BESU_RPC_URL:-}
+      - BSN_BESU_CHAIN_ID=${BSN_BESU_CHAIN_ID:-}
+      - BSN_BESU_PRIVATE_KEY=${BSN_BESU_PRIVATE_KEY:-}  # Use a deployment secret in production
+      - BSN_BESU_CONTRACT_STORAGE=${BSN_BESU_CONTRACT_STORAGE:-}
+      - BSN_BESU_CONTRACT_SHARING=${BSN_BESU_CONTRACT_SHARING:-}
+      - BSN_BESU_NONCE_STATE_DIRECTORY=/var/lib/record-platform/besu-nonce
+      # Required deployment receipt evidence for the selected active chain.
+      - FISCO_SHARING_DEPLOYMENT_TX=${FISCO_SHARING_DEPLOYMENT_TX:?Set FISCO_SHARING_DEPLOYMENT_TX in .env}
+      - FISCO_SHARING_DEPLOYMENT_BLOCK=${FISCO_SHARING_DEPLOYMENT_BLOCK:?Set FISCO_SHARING_DEPLOYMENT_BLOCK in .env}
+      - FISCO_SHARING_DEPLOYMENT_EFFECTIVE_AT=${FISCO_SHARING_DEPLOYMENT_EFFECTIVE_AT:?Set FISCO_SHARING_DEPLOYMENT_EFFECTIVE_AT in .env}
+      - FISCO_STORAGE_DEPLOYMENT_TX=${FISCO_STORAGE_DEPLOYMENT_TX:?Set FISCO_STORAGE_DEPLOYMENT_TX in .env}
+      - FISCO_STORAGE_DEPLOYMENT_BLOCK=${FISCO_STORAGE_DEPLOYMENT_BLOCK:?Set FISCO_STORAGE_DEPLOYMENT_BLOCK in .env}
+      - FISCO_STORAGE_DEPLOYMENT_EFFECTIVE_AT=${FISCO_STORAGE_DEPLOYMENT_EFFECTIVE_AT:?Set FISCO_STORAGE_DEPLOYMENT_EFFECTIVE_AT in .env}
     volumes:
       - ./platform-fisco/src/main/resources/conf:/app/conf
+      # Required when BLOCKCHAIN_ACTIVE=bsn-besu; the image prepares this path for user app.
+      - besu_nonce_data:/var/lib/record-platform/besu-nonce
     depends_on:
       - nacos
     restart: unless-stopped
@@ -248,6 +268,10 @@ services:
     depends_on:
       - backend
     restart: unless-stopped
+
+volumes:
+  # Local named volume: durable across container replacement on this Docker host.
+  besu_nonce_data:
 ```
 
 ## Deployment Steps
@@ -304,6 +328,8 @@ docker-compose -f docker-compose.app.yml up -d --scale backend=3
 ```
 
 Use a load balancer (nginx, traefik) in front of backend instances.
+
+Do not scale the `fisco` service when `BLOCKCHAIN_ACTIVE=bsn-besu` instances share one signer. The fixed container name is only an additional Compose guard; the authoritative JVM startup gate is the exclusive `(chainId, signer)` file lock in `BSN_BESU_NONCE_STATE_DIRECTORY`. The example uses an image-prepared named volume so the non-root `app` user can write it; keep that volume durable and attach it to only the fenced replacement on the same Docker host. If an operator replaces it with a bind/shared mount, that mount must be pre-provisioned writable by the image's `app` user and verified for atomic-move, directory-fsync, and file-lock semantics before activation. Independent host directories and ordinary remote filesystems with unverified lock semantics do not provide cross-host fencing; same-signer active-active therefore remains unsupported.
 
 ## DUBBO_HOST Configuration
 

--- a/docs/en/deployment/environment-setup.md
+++ b/docs/en/deployment/environment-setup.md
@@ -107,7 +107,7 @@ Nacos serves as the configuration center. Application configs must be imported.
 | `platform-storage.yaml` | DEFAULT_GROUP | Storage service config (S3 node list, encryption params) |
 
 ::: warning Important
-Sensitive credentials (DB password, Redis password, etc.) are stored in Nacos configurations, not in `.env`. The infrastructure credentials in `.env` are only used by docker-compose. `platform-fisco` reads blockchain node and contract settings from `.env` (`FISCO_*`), not from a Nacos Data ID.
+Sensitive credentials (DB password, Redis password, etc.) are stored in Nacos configurations, not in `.env`. The infrastructure credentials in `.env` are only used by docker-compose. `platform-fisco` reads blockchain node, contract, signer, and nonce-state settings from deployment environment variables (`FISCO_*` or `BSN_*`), not from a Nacos Data ID. Supply `BSN_BESU_PRIVATE_KEY` through the deployment secret manager rather than committing it to `.env`.
 :::
 
 ## Step 4: FISCO BCOS Node

--- a/docs/en/deployment/production.md
+++ b/docs/en/deployment/production.md
@@ -69,12 +69,14 @@ flowchart TB
 |-----------|------------|-------------|
 | backend | 2 instances | 3+ instances |
 | storage | 2 instances | 3+ instances |
-| fisco | 1 instance | 2 instances |
+| fisco | 1 active writer per signer | BSN Besu same-signer mode: 1 active + fenced cold standby |
 | MySQL | 1 primary + 1 replica | 1 primary + 2 replicas + MHA |
 | Redis | Sentinel (3 nodes) | Cluster (6 nodes) |
 | S3 Storage | 2 nodes (A/B domains) | 3+ nodes (A/B/STANDBY) |
 | Nacos | 3 nodes | 3 nodes |
 | RabbitMQ | 3 nodes (cluster) | 3 nodes (mirrored) |
+
+The `fisco` recommendation is chain-mode dependent. With `BLOCKCHAIN_ACTIVE=bsn-besu` and one local signer key, only one active writer may own that `(chainId, signer)`. It must use a durable `BSN_BESU_NONCE_STATE_DIRECTORY`; a cold standby can start only after the old writer is externally fenced and the same reliable lock/state volume is available. Do not place two same-signer instances behind a load balancer or perform a rolling update with overlap. Multi-host active-active requires different signers or a separate distributed nonce/lease design and is not supported by the file-lock gate.
 
 ### Storage Fault Domains
 

--- a/docs/en/getting-started/configuration.md
+++ b/docs/en/getting-started/configuration.md
@@ -62,6 +62,12 @@ Fault domain configuration is managed through Nacos and supports runtime refresh
 | `FISCO_CHAIN_ID` | Expected local FISCO chain ID | `chain0` |
 | `FISCO_GROUP_ID` | Expected local FISCO group ID | `group0` |
 | `BSN_FISCO_CHAIN_ID` | Expected BSN FISCO chain ID; required with no default when `BLOCKCHAIN_ACTIVE=bsn-fisco` | Provider-assigned value |
+| `BSN_BESU_RPC_URL` | BSN Besu JSON-RPC endpoint; required when `BLOCKCHAIN_ACTIVE=bsn-besu` | Provider-assigned HTTPS URL |
+| `BSN_BESU_CHAIN_ID` | Expected BSN Besu numeric chain ID | Provider-assigned value |
+| `BSN_BESU_PRIVATE_KEY` | Local Besu signer private key | Deployment secret; never commit a value |
+| `BSN_BESU_CONTRACT_STORAGE` | Verified BSN Besu Storage contract address | `0x...` |
+| `BSN_BESU_CONTRACT_SHARING` | Verified BSN Besu Sharing contract address | `0x...` |
+| `BSN_BESU_NONCE_STATE_DIRECTORY` | Durable nonce journal and signer ownership-lock directory | `/var/lib/record-platform/besu-nonce` |
 | `FISCO_STORAGE_CONTRACT` | Storage contract address | `0x...` |
 | `FISCO_SHARING_CONTRACT` | Sharing contract address | `0x...` |
 | `FISCO_{STORAGE,SHARING}_DEPLOYMENT_TX` | Required deployment transaction hash; the active-chain receipt must exist and match the configured address/block | `0x` + 64 hex |
@@ -70,6 +76,8 @@ Fault domain configuration is managed through Nacos and supports runtime refresh
 | `CONTRACT_DEPLOYMENT_RECEIPT_DIR` | Durable restricted directory for public deployment audit receipts | `log/contract-deployments` for local development |
 
 `scripts/contract-deploy.sh` requires explicit local chain/group values and compares them with Console `getGroupInfo` before compilation and every deployment. It fetches each transaction receipt together with `getGroupInfo` in one Console session, requires explicit FISCO success status `0`, and derives the final transaction/address/block fields from that one receipt. All three deployment evidence fields are mandatory for both contracts; an entirely empty legacy triplet now fails startup. The same variable names carry reviewed BSN deployment evidence, where startup revalidates the receipt through the selected BSN FISCO or Besu client (Besu requires explicit status `1`). The guarded local script writes both triplets with one shared effective time and first publishes a credential-free structured receipt; production should place that receipt directory outside ephemeral application storage. `env-check.sh` validates shape only; restart `platform-fisco` to perform the authoritative active-chain receipt, runtime-code, and identity checks.
+
+BSN Besu raw writes reserve nonces per canonical signer from the node's `PENDING` count and a durable local high-watermark. `BSN_BESU_NONCE_STATE_DIRECTORY` has no runtime default: it must support reliable Java/POSIX file locks and atomic replacement, survive process/container restarts, and be shared by every supported process that could use the same `(chainId, signer)`. Startup holds an exclusive signer lock for the JVM lifetime, so a second writer on that shared directory fails closed. The configured signer key is exclusive to this coordinator and must not be used by an external wallet or uncoordinated process. Do not place the directory on ephemeral container storage, delete its state files to clear an incident, or run the same signer active-active on independent hosts. A cold standby may take over only after the old writer is externally fenced and its lock/state volume is available.
 
 ### SSL Configuration (Production)
 

--- a/docs/en/troubleshooting/common-issues.md
+++ b/docs/en/troubleshooting/common-issues.md
@@ -327,6 +327,37 @@ Solutions for frequently encountered problems.
              max-attempts: 5
    ```
 
+## BSN Besu Nonce Coordination
+
+### Signer Writer Lock Prevents Startup
+
+**Symptom**: `platform-fisco` fails with `current chainId/signer is already owned by another writer` (the runtime log may be localized).
+
+**Resolution**:
+
+1. Treat this as a safety gate. Do not point the new process at a different or empty `BSN_BESU_NONCE_STATE_DIRECTORY` to bypass it.
+2. Locate every process/container that has the same signer secret. Fence and stop the old active writer first.
+3. Verify the replacement uses the same durable state directory and a filesystem with reliable file-lock and atomic-move semantics.
+4. Start exactly one replacement. The empty `.lock` file may remain after shutdown; ownership is the live OS file lock, so deleting that file is neither required nor a safe fencing mechanism.
+
+Same-signer active-active across independent hosts is unsupported. Use a cold standby, distinct signers, or a separately reviewed distributed lease/nonce coordinator.
+
+### Unresolved Broadcast Blocks New Writes
+
+**Symptom**: a send timed out, disconnected, returned `already known`/a nonce conflict, or returned an invalid transaction hash; subsequent writes fail with `unresolved broadcast; manual reconciliation is required`.
+
+This is fail-closed behavior. The durable `.state` file records the schema, chain ID, signer, `lastNonce`, `nextNonce`, outcome, local transaction hash, optional remote hash, and update time. It never records the private key or signed raw transaction.
+
+**Reconciliation**:
+
+1. Stop new writes for this signer and fence every possible writer. Keep the state file as incident evidence; never delete or edit it while a process is running.
+2. Read `lastNonce` and `localTransactionHash` from the state file. Against the same BSN provider endpoint, query the transaction by that exact hash and query both `eth_getTransactionCount(signer, "pending")` and `"latest"`.
+3. If the exact transaction exists, keep the state file and wait for the provider's `pending` nonce to advance beyond `lastNonce`. Transaction visibility confirms that `lastNonce` must not be reused, but it does not bypass the coordinator's PENDING gate.
+4. Only after the provider's `pending` nonce is greater than `lastNonce` should you restart the single writer. The coordinator will then observe the advanced PENDING value and continue at `max(nodePending, durableNextNonce)`. If the transaction is absent and PENDING has not advanced, that observation alone does not prove the request was never accepted. Wait for provider reconciliation or obtain explicit provider evidence that the transaction was definitively rejected. Do not submit a different payload with `lastNonce`.
+5. Only after conclusive non-acceptance evidence, with every old writer fenced and the service stopped, archive the complete `.state` file with the incident record and move it out of the configured directory. Restart the single writer so it rebuilds from the node's stable PENDING nonce. If acceptance remains uncertain, preserve the state and keep writes blocked.
+
+A contract revert or failed receipt still consumes the nonce and never justifies rolling the state back. Rollback of this code must also preserve the state directory until all recorded transactions are reconciled.
+
 ## Quota Issues
 
 ### Upload Fails with QUOTA_EXCEEDED

--- a/docs/zh/deployment/docker-compose.md
+++ b/docs/zh/deployment/docker-compose.md
@@ -210,9 +210,29 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
       - NACOS_HOST=nacos
+      - NACOS_PORT=${NACOS_PORT:-8848}
+      - NACOS_USERNAME=${NACOS_USERNAME:?Set NACOS_USERNAME in .env}
+      - NACOS_PASSWORD=${NACOS_PASSWORD:?Set NACOS_PASSWORD in .env}
       - DUBBO_HOST=${DUBBO_HOST:-host.docker.internal}  # Docker 环境必须配置
+      - BLOCKCHAIN_RPC_TOKEN=${BLOCKCHAIN_RPC_TOKEN:?Set BLOCKCHAIN_RPC_TOKEN in .env}
+      - BLOCKCHAIN_ACTIVE=${BLOCKCHAIN_ACTIVE:-local-fisco}
+      - BSN_BESU_RPC_URL=${BSN_BESU_RPC_URL:-}
+      - BSN_BESU_CHAIN_ID=${BSN_BESU_CHAIN_ID:-}
+      - BSN_BESU_PRIVATE_KEY=${BSN_BESU_PRIVATE_KEY:-}  # 生产环境应使用部署密钥
+      - BSN_BESU_CONTRACT_STORAGE=${BSN_BESU_CONTRACT_STORAGE:-}
+      - BSN_BESU_CONTRACT_SHARING=${BSN_BESU_CONTRACT_SHARING:-}
+      - BSN_BESU_NONCE_STATE_DIRECTORY=/var/lib/record-platform/besu-nonce
+      # 所选活动链必须提供完整的部署回执证据。
+      - FISCO_SHARING_DEPLOYMENT_TX=${FISCO_SHARING_DEPLOYMENT_TX:?Set FISCO_SHARING_DEPLOYMENT_TX in .env}
+      - FISCO_SHARING_DEPLOYMENT_BLOCK=${FISCO_SHARING_DEPLOYMENT_BLOCK:?Set FISCO_SHARING_DEPLOYMENT_BLOCK in .env}
+      - FISCO_SHARING_DEPLOYMENT_EFFECTIVE_AT=${FISCO_SHARING_DEPLOYMENT_EFFECTIVE_AT:?Set FISCO_SHARING_DEPLOYMENT_EFFECTIVE_AT in .env}
+      - FISCO_STORAGE_DEPLOYMENT_TX=${FISCO_STORAGE_DEPLOYMENT_TX:?Set FISCO_STORAGE_DEPLOYMENT_TX in .env}
+      - FISCO_STORAGE_DEPLOYMENT_BLOCK=${FISCO_STORAGE_DEPLOYMENT_BLOCK:?Set FISCO_STORAGE_DEPLOYMENT_BLOCK in .env}
+      - FISCO_STORAGE_DEPLOYMENT_EFFECTIVE_AT=${FISCO_STORAGE_DEPLOYMENT_EFFECTIVE_AT:?Set FISCO_STORAGE_DEPLOYMENT_EFFECTIVE_AT in .env}
     volumes:
       - ./platform-fisco/src/main/resources/conf:/app/conf
+      # BLOCKCHAIN_ACTIVE=bsn-besu 时必需；镜像已为 app 用户预建该目录。
+      - besu_nonce_data:/var/lib/record-platform/besu-nonce
     depends_on:
       - nacos
     restart: unless-stopped
@@ -248,6 +268,10 @@ services:
     depends_on:
       - backend
     restart: unless-stopped
+
+volumes:
+  # 本地具名卷：在当前 Docker 主机上替换容器后仍保留。
+  besu_nonce_data:
 ```
 
 ## 部署步骤
@@ -304,6 +328,8 @@ docker-compose -f docker-compose.app.yml up -d --scale backend=3
 ```
 
 在 backend 实例前使用负载均衡器（nginx, traefik）。
+
+当 `BLOCKCHAIN_ACTIVE=bsn-besu` 的实例共享同一 signer 时，禁止扩容 `fisco` 服务。固定容器名只是额外的 Compose 防误操作措施；权威 JVM 启动门禁是 `BSN_BESU_NONCE_STATE_DIRECTORY` 中按 `(chainId, signer)` 持有的独占文件锁。示例使用镜像预建权限的具名卷，使非 root `app` 用户能够写入；该卷必须持久化，并且在同一 Docker 主机上只能挂给已完成 fencing 的替代实例。若运维改成 bind/shared mount，必须先把挂载预配为镜像 `app` 用户可写，并在激活前验证 atomic move、目录 fsync 和文件锁语义。独立主机目录以及未经验证锁语义的普通远程文件系统不能提供跨主机 fencing，因此当前不支持同 signer active-active。
 
 ## DUBBO_HOST 配置说明
 

--- a/docs/zh/deployment/environment-setup.md
+++ b/docs/zh/deployment/environment-setup.md
@@ -107,7 +107,7 @@ Nacos 作为配置中心，需要导入应用配置。
 | `platform-storage.yaml` | DEFAULT_GROUP | 存储服务配置（S3 节点列表、加密参数） |
 
 ::: warning 重要
-数据库密码、Redis 密码等敏感信息存储在 Nacos 配置中，而非 `.env` 文件。`.env` 中的基础设施凭据仅供 docker-compose 使用。`platform-fisco` 的区块链节点与合约地址配置来自 `.env` 中的 `FISCO_*` 变量，而不是 Nacos Data ID。
+数据库密码、Redis 密码等敏感信息存储在 Nacos 配置中，而非 `.env` 文件。`.env` 中的基础设施凭据仅供 docker-compose 使用。`platform-fisco` 的区块链节点、合约、签名账户和 nonce 状态配置来自部署环境变量（`FISCO_*` 或 `BSN_*`），而不是 Nacos Data ID。`BSN_BESU_PRIVATE_KEY` 应由部署密钥管理器注入，不得提交到 `.env`。
 :::
 
 ## 步骤 4：FISCO BCOS 节点

--- a/docs/zh/deployment/production.md
+++ b/docs/zh/deployment/production.md
@@ -69,12 +69,14 @@ flowchart TB
 |------|---------|----------|
 | backend | 2 实例 | 3+ 实例 |
 | storage | 2 实例 | 3+ 实例 |
-| fisco | 1 实例 | 2 实例 |
+| fisco | 每个 signer 1 个 active writer | BSN Besu 同 signer：1 active + 已 fencing 的冷备 |
 | MySQL | 1 主 + 1 从 | 1 主 + 2 从 + MHA |
 | Redis | Sentinel (3 节点) | Cluster (6 节点) |
 | S3 存储 | 2 节点 (A/B 域) | 3+ 节点 (A/B/STANDBY) |
 | Nacos | 3 节点 | 3 节点 |
 | RabbitMQ | 3 节点 (集群) | 3 节点 (镜像) |
+
+`fisco` 建议必须按链模式理解。`BLOCKCHAIN_ACTIVE=bsn-besu` 且使用同一份本地 signer key 时，一个 `(chainId, signer)` 只允许一个 active writer，并必须使用持久化的 `BSN_BESU_NONCE_STATE_DIRECTORY`。冷备只能在旧 writer 已从外部 fence 且能够使用同一个可靠锁/状态卷后启动。禁止把两个同 signer 实例放在负载均衡后，也禁止有新旧实例重叠的滚动更新。多主机 active-active 必须使用不同 signer，或另行实现分布式 nonce/租约；当前文件锁门禁不支持该拓扑。
 
 ### 存储故障域
 

--- a/docs/zh/getting-started/configuration.md
+++ b/docs/zh/getting-started/configuration.md
@@ -62,6 +62,12 @@ S3 兼容存储通过 Nacos 配置。基本环境变量：
 | `FISCO_CHAIN_ID` | 预期的本地 FISCO chain ID | `chain0` |
 | `FISCO_GROUP_ID` | 预期的本地 FISCO group ID | `group0` |
 | `BSN_FISCO_CHAIN_ID` | 预期的 BSN FISCO chain ID；`BLOCKCHAIN_ACTIVE=bsn-fisco` 时无默认值且必填 | 服务商分配值 |
+| `BSN_BESU_RPC_URL` | BSN Besu JSON-RPC 地址；`BLOCKCHAIN_ACTIVE=bsn-besu` 时必填 | 服务商分配的 HTTPS URL |
+| `BSN_BESU_CHAIN_ID` | 预期的 BSN Besu 数字 chain ID | 服务商分配值 |
+| `BSN_BESU_PRIVATE_KEY` | 本地 Besu signer 私钥 | 仅由部署密钥注入，禁止提交值 |
+| `BSN_BESU_CONTRACT_STORAGE` | 已核验的 BSN Besu Storage 合约地址 | `0x...` |
+| `BSN_BESU_CONTRACT_SHARING` | 已核验的 BSN Besu Sharing 合约地址 | `0x...` |
+| `BSN_BESU_NONCE_STATE_DIRECTORY` | 持久 nonce journal 与 signer 所有权锁目录 | `/var/lib/record-platform/besu-nonce` |
 | `FISCO_STORAGE_CONTRACT` | Storage 合约地址 | `0x...` |
 | `FISCO_SHARING_CONTRACT` | Sharing 合约地址 | `0x...` |
 | `FISCO_{STORAGE,SHARING}_DEPLOYMENT_TX` | 必填部署交易哈希；活动链回执必须存在并匹配配置地址/区块 | `0x` + 64 位 hex |
@@ -70,6 +76,8 @@ S3 兼容存储通过 Nacos 配置。基本环境变量：
 | `CONTRACT_DEPLOYMENT_RECEIPT_DIR` | 保存公开部署审计回执的持久化受限目录 | 本地开发使用 `log/contract-deployments` |
 
 `scripts/contract-deploy.sh` 要求显式配置本地 chain/group，并在编译及每笔部署前与 Console `getGroupInfo` 完全对账。脚本在同一个 Console 会话中查询每笔交易回执和 `getGroupInfo`，要求 FISCO 显式成功状态 `0`，最终 transaction/address/block 全部取自该同一回执。两个合约的三项部署证据均为必填；legacy 整组空值现在会阻止服务启动。经审查的 BSN 部署沿用这些变量名，启动时由所选 BSN FISCO 或 Besu 客户端重新验证（Besu 必须显式为状态 `1`）。门禁脚本用同一个生效时间原子写回两个三元组，并先发布不含凭据的结构化回执；生产环境应把回执目录放在非临时应用存储之外。`env-check.sh` 只校验格式，最终必须重启 `platform-fisco` 执行活动链回执、runtime code 和身份核验。
+
+BSN Besu 原始交易按规范化 signer，以节点 `PENDING` nonce 和本地持久高水位共同保留 nonce。`BSN_BESU_NONCE_STATE_DIRECTORY` 没有运行时默认值：目录必须支持可靠的 Java/POSIX 文件锁和原子替换，能够跨进程/容器重启保留，并由所有可能使用同一 `(chainId, signer)` 的受支持进程共享。服务在整个 JVM 生命周期持有 signer 独占锁，因此共享该目录的第二个 writer 会启动失败。配置的 signer key 只能由该 coordinator 使用，禁止外部钱包或未协调进程复用。禁止把目录放在容器临时层、通过删除状态文件处理事故，或让同一 signer 在独立主机上 active-active。冷备接管前必须先从外部 fence 旧 writer，并复用同一锁/状态卷。
 
 ### SSL 配置（生产环境）
 

--- a/docs/zh/troubleshooting/common-issues.md
+++ b/docs/zh/troubleshooting/common-issues.md
@@ -327,6 +327,37 @@
              max-attempts: 5
    ```
 
+## BSN Besu nonce 协调
+
+### signer writer 锁阻止启动
+
+**现象**：`platform-fisco` 启动失败，提示当前 `chainId/signer` 已被另一个 writer 持有。
+
+**处理方式**：
+
+1. 这是安全门禁，禁止通过给新进程改成另一个空的 `BSN_BESU_NONCE_STATE_DIRECTORY` 绕过。
+2. 找到所有持有同一 signer secret 的进程/容器，先从外部 fence 并停止旧 active writer。
+3. 确认替代实例仍使用同一持久状态目录，且文件系统支持可靠文件锁和原子 move。
+4. 只启动一个替代实例。正常停止后空 `.lock` 文件可以保留；真实所有权是仍存活的 OS 文件锁，删除文件既非必要操作，也不能替代 fencing。
+
+当前不支持独立主机上的同 signer active-active。应使用冷备、不同 signer，或另行实现并审查分布式租约/nonce coordinator。
+
+### 未决广播阻止新写入
+
+**现象**：发送发生超时、断连、`already known`/nonce 冲突，或节点返回错误交易哈希；后续写入提示 `unresolved broadcast; manual reconciliation is required`。
+
+这是失败关闭行为。持久 `.state` 文件记录 schema、chain ID、signer、`lastNonce`、`nextNonce`、outcome、本地交易哈希、可选远端哈希和更新时间；其中不包含私钥或签名 raw transaction。
+
+**对账步骤**：
+
+1. 停止该 signer 的新写入并 fence 所有可能 writer。保留状态文件作为事故证据，进程运行期间禁止删除或编辑。
+2. 从状态文件读取 `lastNonce` 和 `localTransactionHash`。在同一个 BSN provider 端点按精确哈希查询交易，并分别查询 `eth_getTransactionCount(signer, "pending")` 与 `"latest"`。
+3. 若精确交易存在，保留状态文件并等待 provider 的 `pending` nonce 前进到大于 `lastNonce`。查到交易只能证明 `lastNonce` 不得复用，不能绕过 coordinator 的 PENDING 门禁。
+4. 只有 provider 的 `pending` nonce 已大于 `lastNonce` 时，才重启唯一 writer。coordinator 会识别已前进的 PENDING，并按 `max(nodePending, durableNextNonce)` 继续。若交易不存在且 PENDING 未前进，仅凭一次空查询不能证明请求从未被接受；必须等待 provider 对账或取得其明确拒绝证据，禁止用 `lastNonce` 发送不同 payload。
+5. 只有在取得确定未接受证据、所有旧 writer 已 fence 且服务停止后，才可把完整 `.state` 文件连同事故记录归档并移出配置目录，然后重启唯一 writer，从稳定的节点 PENDING 重新建立状态。若是否接受仍不确定，必须保留状态并继续阻止写入。
+
+合约 revert 或失败 receipt 仍会消耗 nonce，绝不能据此回滚状态。回滚本次代码时也必须保留状态目录，直到其中记录的交易全部完成对账。
+
 ## 配额问题
 
 ### 上传失败，提示 QUOTA_EXCEEDED

--- a/platform-fisco/Dockerfile
+++ b/platform-fisco/Dockerfile
@@ -31,8 +31,9 @@ RUN chmod 644 /opt/otel/opentelemetry-javaagent.jar
 
 COPY --from=build /workspace/platform-fisco/target/platform-fisco-0.0.2-SNAPSHOT.jar app.jar
 
-# Directory for TLS certificate files (mount at runtime)
-RUN mkdir -p /app/conf && chown -R app:app /app
+# Prepare writable runtime directories before switching to the non-root user.
+RUN mkdir -p /app/conf /var/lib/record-platform/besu-nonce \
+    && chown -R app:app /app /var/lib/record-platform
 USER app
 
 EXPOSE 8091

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuAdapter.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuAdapter.java
@@ -57,6 +57,7 @@ public class BsnBesuAdapter implements BlockChainAdapter {
     private final StaticGasProvider gasProvider;
     private final BsnBesuConfig besuConfig;
     private final ContractRegistryService contractRegistryService;
+    private final BsnBesuNonceCoordinator nonceCoordinator;
 
     private String sharingContractAddress;
 
@@ -729,13 +730,55 @@ public class BsnBesuAdapter implements BlockChainAdapter {
         return FunctionReturnDecoder.decode(response.getValue(), abiFunction.getOutputParameters());
     }
 
-    private EthSendTransaction sendTransaction(org.web3j.abi.datatypes.Function abiFunction) throws Exception {
+    /**
+     * 通过按 signer 协调器完成 PENDING 同步、本地签名和一次同步广播。
+     */
+    private EthSendTransaction sendTransaction(
+            org.web3j.abi.datatypes.Function abiFunction
+    ) throws Exception {
+        return nonceCoordinator.send(
+                credentials.getAddress(),
+                this::loadPendingNonce,
+                nonce -> buildSignedRawTransaction(abiFunction, nonce),
+                signedRawTransaction -> web3j
+                        .ethSendRawTransaction(signedRawTransaction)
+                        .send()
+        );
+    }
+
+    /**
+     * 查询并严格校验节点 PENDING nonce，避免忽略 JSON-RPC 错误。
+     */
+    private BigInteger loadPendingNonce() throws Exception {
+        EthGetTransactionCount response = web3j.ethGetTransactionCount(
+                credentials.getAddress(),
+                DefaultBlockParameterName.PENDING
+        ).send();
+        if (response == null) {
+            throw new ChainException(
+                    ChainType.BSN_BESU,
+                    "getPendingNonce",
+                    "Empty PENDING nonce response"
+            );
+        }
+        if (response.hasError()) {
+            throw new ChainException(
+                    ChainType.BSN_BESU,
+                    "getPendingNonce",
+                    response.getError().getMessage()
+            );
+        }
+        return response.getTransactionCount();
+    }
+
+    /**
+     * 使用已保留 nonce 在本地完成 ABI 编码、原始交易构造和签名。
+     */
+    private String buildSignedRawTransaction(
+            org.web3j.abi.datatypes.Function abiFunction,
+            BigInteger nonce
+    ) {
         String encodedFunction = FunctionEncoder.encode(abiFunction);
-
-        BigInteger nonce = web3j.ethGetTransactionCount(
-                credentials.getAddress(), DefaultBlockParameterName.LATEST
-        ).send().getTransactionCount();
-
         RawTransaction rawTransaction = RawTransaction.createTransaction(
                 nonce,
                 gasProvider.getGasPrice(),
@@ -745,9 +788,7 @@ public class BsnBesuAdapter implements BlockChainAdapter {
         );
 
         byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, credentials);
-        String hexValue = Numeric.toHexString(signedMessage);
-
-        return web3j.ethSendRawTransaction(hexValue).send();
+        return Numeric.toHexString(signedMessage);
     }
 
     private TransactionReceipt waitForReceipt(String txHash) throws Exception {

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuFileNonceStateStore.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuFileNonceStateStore.java
@@ -1,0 +1,464 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import cn.flying.fisco_bcos.config.BsnBesuConfig;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.web3j.crypto.Credentials;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+
+/**
+ * 使用共享持久目录保存 Besu nonce 状态，并持有 signer 进程生命周期独占锁。
+ *
+ * <p>文件锁是当前仓库单主机或可靠共享卷部署的单 writer 门禁；不同主机使用独立目录时
+ * 无法形成互斥，必须由部署侧 fencing 或不同 signer 保证隔离。
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "blockchain.active", havingValue = "bsn-besu")
+public final class BsnBesuFileNonceStateStore implements BsnBesuNonceStateStore {
+
+    static final String SCHEMA_VERSION = "record-platform-besu-nonce-state.v1";
+
+    private static final Pattern SIGNER_PATTERN = Pattern.compile("^0x[0-9a-f]{40}$");
+
+    private final BsnBesuConfig besuConfig;
+    private final Credentials credentials;
+    private final ReentrantLock ioLock = new ReentrantLock();
+
+    private String canonicalSigner;
+    private String chainId;
+    private Path stateDirectory;
+    private Path stateFile;
+    private FileChannel ownershipChannel;
+    private FileLock ownershipLock;
+    private PersistedState persistedState;
+
+    /**
+     * 校验持久目录并为当前 chainId/signer 获取独占 writer 锁。
+     */
+    @PostConstruct
+    public void initialize() {
+        if (ownershipLock != null && ownershipLock.isValid()) {
+            throw new IllegalStateException("[BSN Besu] nonce state store 已初始化");
+        }
+        Long configuredChainId = besuConfig.getChainId();
+        if (configuredChainId == null || configuredChainId < 0) {
+            throw new IllegalStateException("[BSN Besu] chainId 必须配置为非负整数");
+        }
+        this.chainId = String.valueOf(configuredChainId);
+        this.canonicalSigner = canonicalizeSigner(credentials.getAddress());
+
+        BsnBesuConfig.NonceConfig nonceConfig = besuConfig.getNonce();
+        String configuredDirectory = nonceConfig == null
+                ? null
+                : nonceConfig.getStateDirectory();
+        if (configuredDirectory == null || configuredDirectory.isBlank()) {
+            throw new IllegalStateException("[BSN Besu] nonce state directory 未配置");
+        }
+
+        try {
+            this.stateDirectory = Path.of(configuredDirectory).toAbsolutePath().normalize();
+            Files.createDirectories(stateDirectory);
+            if (Files.isSymbolicLink(stateDirectory)
+                    || !Files.isDirectory(stateDirectory, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IllegalStateException("[BSN Besu] nonce state directory 必须是真实目录");
+            }
+
+            String filePrefix = "chain-" + chainId + "-signer-"
+                    + canonicalSigner.substring(2);
+            Path ownershipFile = stateDirectory.resolve(filePrefix + ".lock");
+            this.stateFile = stateDirectory.resolve(filePrefix + ".state");
+            this.ownershipChannel = FileChannel.open(
+                    ownershipFile,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE,
+                    LinkOption.NOFOLLOW_LINKS
+            );
+            this.ownershipLock = tryAcquireOwnershipLock(ownershipChannel);
+            if (ownershipLock == null) {
+                closeOwnershipChannel();
+                throw new IllegalStateException(
+                        "[BSN Besu] 当前 chainId/signer 已被另一个 writer 持有"
+                );
+            }
+            this.persistedState = readPersistedState();
+            log.info(
+                    "[BSN Besu nonce] 已获取 signer writer 所有权, chainId={}, signer={}, stateFile={}",
+                    chainId,
+                    canonicalSigner,
+                    stateFile
+            );
+        } catch (IOException exception) {
+            closeOwnershipResources();
+            throw new IllegalStateException("[BSN Besu] 无法初始化 nonce 持久状态", exception);
+        } catch (RuntimeException exception) {
+            closeOwnershipResources();
+            throw exception;
+        }
+    }
+
+    /**
+     * 返回当前 signer 已持久化的安全高水位快照。
+     */
+    @Override
+    public PersistedState load(String requestedSigner) throws IOException {
+        ioLock.lock();
+        try {
+            requireOwnedSigner(requestedSigner);
+            requireValidOwnershipLock();
+            return persistedState;
+        } finally {
+            ioLock.unlock();
+        }
+    }
+
+    /**
+     * 通过临时文件、force 和原子替换持久化新的 nonce 状态。
+     */
+    @Override
+    public void save(String requestedSigner, PersistedState state) throws IOException {
+        ioLock.lock();
+        try {
+            requireOwnedSigner(requestedSigner);
+            requireValidOwnershipLock();
+            if (state == null) {
+                throw new IllegalArgumentException("Nonce persisted state is required");
+            }
+            writeStateAtomically(state);
+            this.persistedState = state;
+        } finally {
+            ioLock.unlock();
+        }
+    }
+
+    /**
+     * 释放 signer 文件锁和底层 channel，允许受控冷备接管。
+     */
+    @PreDestroy
+    public void close() {
+        ioLock.lock();
+        try {
+            closeOwnershipResources();
+        } finally {
+            ioLock.unlock();
+        }
+    }
+
+    /**
+     * 尝试获取非阻塞独占文件锁；同 JVM 重复持有也按冲突处理。
+     */
+    private FileLock tryAcquireOwnershipLock(FileChannel channel) throws IOException {
+        try {
+            return channel.tryLock();
+        } catch (OverlappingFileLockException exception) {
+            return null;
+        }
+    }
+
+    /**
+     * 读取并严格校验已有状态文件；首次启动时返回空状态。
+     */
+    private PersistedState readPersistedState() throws IOException {
+        if (!Files.exists(stateFile, LinkOption.NOFOLLOW_LINKS)) {
+            return null;
+        }
+        if (Files.isSymbolicLink(stateFile)
+                || !Files.isRegularFile(stateFile, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalStateException("[BSN Besu] nonce state file 必须是普通文件");
+        }
+
+        Map<String, String> values = parseStateLines(
+                Files.readAllLines(stateFile, StandardCharsets.UTF_8)
+        );
+        requireValue(values, "schema", SCHEMA_VERSION);
+        requireValue(values, "chainId", chainId);
+        requireValue(values, "signer", canonicalSigner);
+        parseUpdatedAt(requireValue(values, "updatedAt"));
+
+        try {
+            return new PersistedState(
+                    parseNonce(requireValue(values, "nextNonce"), "nextNonce"),
+                    parseOptionalNonce(requireValue(values, "lastNonce"), "lastNonce"),
+                    parseOutcome(requireValue(values, "outcome")),
+                    optionalValue(requireValue(values, "localTransactionHash")),
+                    optionalValue(requireValue(values, "remoteTransactionHash"))
+            );
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalStateException("[BSN Besu] nonce state 语义不一致", exception);
+        }
+    }
+
+    /**
+     * 将状态内容完整写入同目录临时文件，原子替换后同步目录元数据。
+     */
+    private void writeStateAtomically(PersistedState state) throws IOException {
+        String temporaryName = stateFile.getFileName() + ".tmp-" + UUID.randomUUID();
+        Path temporaryFile = stateDirectory.resolve(temporaryName);
+        byte[] content = serializeState(state).getBytes(StandardCharsets.UTF_8);
+        try {
+            try (FileChannel channel = FileChannel.open(
+                    temporaryFile,
+                    StandardOpenOption.CREATE_NEW,
+                    StandardOpenOption.WRITE,
+                    LinkOption.NOFOLLOW_LINKS
+            )) {
+                ByteBuffer buffer = ByteBuffer.wrap(content);
+                while (buffer.hasRemaining()) {
+                    channel.write(buffer);
+                }
+                channel.force(true);
+            }
+            try {
+                Files.move(
+                        temporaryFile,
+                        stateFile,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING
+                );
+                forceStateDirectory();
+            } catch (AtomicMoveNotSupportedException exception) {
+                throw new IOException(
+                        "Nonce state directory does not support atomic replacement",
+                        exception
+                );
+            }
+        } finally {
+            Files.deleteIfExists(temporaryFile);
+        }
+    }
+
+    /**
+     * 同步状态目录，确保原子替换的目录项在返回并进入广播前已经持久化。
+     */
+    private void forceStateDirectory() throws IOException {
+        try (FileChannel directoryChannel = FileChannel.open(
+                stateDirectory,
+                StandardOpenOption.READ,
+                LinkOption.NOFOLLOW_LINKS
+        )) {
+            directoryChannel.force(true);
+        }
+    }
+
+    /**
+     * 生成不包含私钥或原始签名 payload 的版本化状态文本。
+     */
+    private String serializeState(PersistedState state) {
+        return "schema=" + SCHEMA_VERSION + "\n"
+                + "chainId=" + chainId + "\n"
+                + "signer=" + canonicalSigner + "\n"
+                + "nextNonce=" + state.nextNonce() + "\n"
+                + "lastNonce=" + nullableValue(state.lastNonce()) + "\n"
+                + "outcome=" + state.outcome().name() + "\n"
+                + "localTransactionHash=" + nullableValue(state.localTransactionHash()) + "\n"
+                + "remoteTransactionHash=" + nullableValue(state.remoteTransactionHash()) + "\n"
+                + "updatedAt=" + Instant.now() + "\n";
+    }
+
+    /**
+     * 解析固定 key=value 状态格式并拒绝重复或未知字段。
+     */
+    private Map<String, String> parseStateLines(List<String> lines) {
+        Map<String, String> values = new LinkedHashMap<>();
+        for (String line : lines) {
+            if (line.isBlank()) {
+                continue;
+            }
+            int separator = line.indexOf('=');
+            if (separator <= 0) {
+                throw new IllegalStateException("[BSN Besu] nonce state file 格式错误");
+            }
+            String key = line.substring(0, separator);
+            String value = line.substring(separator + 1);
+            if (!isKnownStateKey(key) || values.putIfAbsent(key, value) != null) {
+                throw new IllegalStateException("[BSN Besu] nonce state file 包含未知或重复字段");
+            }
+        }
+        if (values.size() != 9) {
+            throw new IllegalStateException("[BSN Besu] nonce state file 字段不完整");
+        }
+        return values;
+    }
+
+    /**
+     * 判断状态字段是否属于受支持的固定 schema。
+     */
+    private boolean isKnownStateKey(String key) {
+        return switch (key) {
+            case "schema", "chainId", "signer", "nextNonce", "lastNonce", "outcome",
+                    "localTransactionHash", "remoteTransactionHash", "updatedAt" -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * 校验调用者 signer 与启动时独占 signer 完全一致。
+     */
+    private void requireOwnedSigner(String requestedSigner) {
+        if (!canonicalSigner.equals(canonicalizeSigner(requestedSigner))) {
+            throw new IllegalArgumentException("Nonce state store does not own the requested signer");
+        }
+    }
+
+    /**
+     * 确认进程仍持有有效 signer 文件锁。
+     */
+    private void requireValidOwnershipLock() throws IOException {
+        if (ownershipLock == null || !ownershipLock.isValid()) {
+            throw new IOException("BSN Besu signer ownership lock is not held");
+        }
+    }
+
+    /**
+     * 规范化并校验 Ethereum signer 地址。
+     */
+    private String canonicalizeSigner(String signer) {
+        if (signer == null) {
+            throw new IllegalArgumentException("BSN Besu signer address is required");
+        }
+        String normalized = signer.trim().toLowerCase(Locale.ROOT);
+        if (!normalized.startsWith("0x")) {
+            normalized = "0x" + normalized;
+        }
+        if (!SIGNER_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException("BSN Besu signer address is invalid");
+        }
+        return normalized;
+    }
+
+    /**
+     * 解析非负十进制 nonce。
+     */
+    private BigInteger parseNonce(String value, String field) {
+        try {
+            BigInteger nonce = new BigInteger(value);
+            if (nonce.signum() < 0) {
+                throw new NumberFormatException("negative nonce");
+            }
+            return nonce;
+        } catch (NumberFormatException exception) {
+            throw new IllegalStateException("[BSN Besu] nonce state " + field + " 格式错误", exception);
+        }
+    }
+
+    /**
+     * 解析允许为空的 nonce 字段。
+     */
+    private BigInteger parseOptionalNonce(String value, String field) {
+        return value.isEmpty() ? null : parseNonce(value, field);
+    }
+
+    /**
+     * 解析持久化广播状态枚举。
+     */
+    private Outcome parseOutcome(String value) {
+        try {
+            return Outcome.valueOf(value);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalStateException("[BSN Besu] nonce state outcome 格式错误", exception);
+        }
+    }
+
+    /**
+     * 校验状态更新时间格式。
+     */
+    private void parseUpdatedAt(String value) {
+        try {
+            Instant.parse(value);
+        } catch (DateTimeParseException exception) {
+            throw new IllegalStateException("[BSN Besu] nonce state updatedAt 格式错误", exception);
+        }
+    }
+
+    /**
+     * 读取必填字段。
+     */
+    private String requireValue(Map<String, String> values, String key) {
+        String value = values.get(key);
+        if (value == null) {
+            throw new IllegalStateException("[BSN Besu] nonce state 缺少字段 " + key);
+        }
+        return value;
+    }
+
+    /**
+     * 校验字段值与当前运行身份一致。
+     */
+    private void requireValue(Map<String, String> values, String key, String expected) {
+        if (!expected.equals(requireValue(values, key))) {
+            throw new IllegalStateException("[BSN Besu] nonce state " + key + " 不匹配");
+        }
+    }
+
+    /**
+     * 将空字符串转成 null。
+     */
+    private String optionalValue(String value) {
+        return value.isEmpty() ? null : value;
+    }
+
+    /**
+     * 将可空状态值序列化为空字符串或原值。
+     */
+    private String nullableValue(Object value) {
+        return value == null ? "" : value.toString();
+    }
+
+    /**
+     * 关闭文件锁和 channel，不删除持久状态或锁文件。
+     */
+    private void closeOwnershipResources() {
+        if (ownershipLock != null) {
+            try {
+                ownershipLock.release();
+            } catch (IOException exception) {
+                log.warn("[BSN Besu nonce] 释放 signer 文件锁失败", exception);
+            } finally {
+                ownershipLock = null;
+            }
+        }
+        closeOwnershipChannel();
+    }
+
+    /**
+     * 关闭 writer ownership channel。
+     */
+    private void closeOwnershipChannel() {
+        if (ownershipChannel != null) {
+            try {
+                ownershipChannel.close();
+            } catch (IOException exception) {
+                log.warn("[BSN Besu nonce] 关闭 signer 锁文件失败", exception);
+            } finally {
+                ownershipChannel = null;
+            }
+        }
+    }
+}

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuNonceCoordinator.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuNonceCoordinator.java
@@ -1,0 +1,482 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.web3j.crypto.Hash;
+import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
+
+/**
+ * 按签名地址协调 BSN Besu 原始交易 nonce。
+ *
+ * <p>同一 signer 的临界区覆盖 PENDING 同步、本地构造/签名、广播结果分类和状态推进，
+ * 但不覆盖交易回执确认；不同 signer 使用独立锁并行发送。
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "blockchain.active", havingValue = "bsn-besu")
+public final class BsnBesuNonceCoordinator {
+
+    private static final Pattern SIGNER_PATTERN = Pattern.compile("^[0-9a-f]{40}$");
+    private static final Pattern TRANSACTION_HASH_PATTERN =
+            Pattern.compile("^0x[0-9a-fA-F]{64}$");
+    private static final Set<Integer> DEFINITE_JSON_RPC_REJECT_CODES =
+            Set.of(-32700, -32600, -32601, -32602);
+    private static final List<String> DEFINITE_BESU_REJECT_MESSAGES = List.of(
+            "insufficient funds",
+            "up-front cost",
+            "intrinsic gas",
+            "gasprice is less than the current basefee",
+            "max priority fee per gas cannot be greater",
+            "transaction gas limit must be",
+            "transaction was meant for chain id",
+            "sender could not be extracted",
+            "invalid signature",
+            "is invalid, accepted transaction types",
+            "transaction type not supported",
+            "nonce must be less than",
+            "initcode size"
+    );
+
+    private final ConcurrentMap<String, SignerState> signerStates = new ConcurrentHashMap<>();
+    private final BsnBesuNonceStateStore stateStore;
+
+    /**
+     * 创建使用指定 durable state store 的 nonce coordinator。
+     */
+    public BsnBesuNonceCoordinator(BsnBesuNonceStateStore stateStore) {
+        this.stateStore = stateStore;
+    }
+
+    /**
+     * 为指定 signer 安全选择 nonce、构造签名交易并完成一次同步广播。
+     *
+     * @param signer 签名地址
+     * @param pendingNonceSupplier 节点 PENDING nonce 查询器
+     * @param transactionFactory 仅执行本地构造和签名的工厂
+     * @param broadcaster 已签名原始交易广播器
+     * @return Web3j 广播响应
+     * @throws Exception 查询、本地构造或广播失败时抛出原始异常
+     */
+    public EthSendTransaction send(
+            String signer,
+            PendingNonceSupplier pendingNonceSupplier,
+            SignedRawTransactionFactory transactionFactory,
+            RawTransactionBroadcaster broadcaster
+    ) throws Exception {
+        String canonicalSigner = canonicalizeSigner(signer);
+        SignerState state = signerStates.computeIfAbsent(
+                canonicalSigner,
+                ignored -> new SignerState()
+        );
+
+        lockInterruptibly(state.lock);
+        try {
+            initializeState(canonicalSigner, state);
+            BigInteger nodePending = requireValidNonce(pendingNonceSupplier.get());
+            requireResolvedBroadcast(canonicalSigner, state, nodePending);
+            BigInteger nonce = state.nextNonce == null
+                    ? nodePending
+                    : nodePending.max(state.nextNonce);
+
+            String signedRawTransaction;
+            String localTransactionHash;
+            try {
+                signedRawTransaction = requireSignedRawTransaction(transactionFactory.build(nonce));
+                localTransactionHash = Hash.sha3(signedRawTransaction);
+            } catch (Exception exception) {
+                persistLocalFailure(canonicalSigner, state, nonce, exception);
+                log.warn(
+                        "[BSN Besu nonce] 本地构造或签名失败，保留 nonce 供重同步, signer={}, nonce={}",
+                        canonicalSigner,
+                        nonce
+                );
+                throw exception;
+            }
+
+            persistState(
+                    canonicalSigner,
+                    state,
+                    new BsnBesuNonceStateStore.PersistedState(
+                            nonce.add(BigInteger.ONE),
+                            nonce,
+                            BsnBesuNonceStateStore.Outcome.BROADCASTING,
+                            localTransactionHash,
+                            null
+                    )
+            );
+
+            EthSendTransaction response;
+            try {
+                response = broadcaster.broadcast(signedRawTransaction);
+            } catch (Exception exception) {
+                persistUnknownAfterBroadcastFailure(
+                        canonicalSigner,
+                        state,
+                        nonce,
+                        localTransactionHash,
+                        exception
+                );
+                log.warn(
+                        "[BSN Besu nonce] 广播结果不确定，禁止回退 nonce, signer={}, nonce={}, cause={}",
+                        canonicalSigner,
+                        nonce,
+                        exception.getClass().getSimpleName()
+                );
+                throw exception;
+            }
+
+            BroadcastOutcome outcome = classify(response, localTransactionHash);
+            String remoteTransactionHash = response == null
+                    ? null
+                    : normalizeOptionalTransactionHash(response.getTransactionHash());
+            if (outcome == BroadcastOutcome.DEFINITE_REJECT) {
+                persistState(
+                        canonicalSigner,
+                        state,
+                        new BsnBesuNonceStateStore.PersistedState(
+                                nonce,
+                                nonce,
+                                BsnBesuNonceStateStore.Outcome.DEFINITE_REJECT,
+                                localTransactionHash,
+                                remoteTransactionHash
+                        )
+                );
+                log.warn(
+                        "[BSN Besu nonce] 节点明确拒绝交易，下一请求将从 PENDING 重同步, signer={}, nonce={}, code={}",
+                        canonicalSigner,
+                        nonce,
+                        response.getError().getCode()
+                );
+            } else {
+                if (outcome == BroadcastOutcome.UNKNOWN) {
+                    persistState(
+                            canonicalSigner,
+                            state,
+                            new BsnBesuNonceStateStore.PersistedState(
+                                    nonce.add(BigInteger.ONE),
+                                    nonce,
+                                    BsnBesuNonceStateStore.Outcome.UNKNOWN,
+                                    localTransactionHash,
+                                    remoteTransactionHash
+                            )
+                    );
+                    log.warn(
+                            "[BSN Besu nonce] 广播响应无法证明交易未进入 mempool，禁止回退 nonce, signer={}, nonce={}",
+                            canonicalSigner,
+                            nonce
+                    );
+                } else {
+                    persistState(
+                            canonicalSigner,
+                            state,
+                            new BsnBesuNonceStateStore.PersistedState(
+                                    nonce.add(BigInteger.ONE),
+                                    nonce,
+                                    BsnBesuNonceStateStore.Outcome.ACCEPTED,
+                                    localTransactionHash,
+                                    remoteTransactionHash
+                            )
+                    );
+                    log.debug(
+                            "[BSN Besu nonce] 交易已接受, signer={}, nonce={}, txHash={}",
+                            canonicalSigner,
+                            nonce,
+                            response.getTransactionHash()
+                    );
+                }
+            }
+
+            if (response == null || (!response.hasError()
+                    && outcome != BroadcastOutcome.ACCEPTED)) {
+                throw new IOException("BSN Besu returned an empty or invalid transaction response");
+            }
+            return response;
+        } finally {
+            state.lock.unlock();
+        }
+    }
+
+    /**
+     * 首次使用 signer 时从 durable state 恢复本地 nonce 高水位和未决广播。
+     */
+    private void initializeState(String canonicalSigner, SignerState state) throws IOException {
+        if (state.initialized) {
+            return;
+        }
+        BsnBesuNonceStateStore.PersistedState persistedState = stateStore.load(canonicalSigner);
+        state.persistedState = persistedState;
+        state.nextNonce = persistedState == null ? null : persistedState.nextNonce();
+        state.initialized = true;
+    }
+
+    /**
+     * 未决广播只有在节点 PENDING 已越过对应 nonce 时才允许继续分配新 payload。
+     */
+    private void requireResolvedBroadcast(
+            String canonicalSigner,
+            SignerState state,
+            BigInteger nodePending
+    ) {
+        BsnBesuNonceStateStore.PersistedState persistedState = state.persistedState;
+        if (persistedState == null || !persistedState.isUnresolvedBroadcast()) {
+            return;
+        }
+        BigInteger unresolvedNonce = persistedState.lastNonce();
+        if (unresolvedNonce == null || nodePending.compareTo(unresolvedNonce) <= 0) {
+            throw new IllegalStateException(
+                    "BSN Besu signer has an unresolved broadcast; manual reconciliation is required"
+            );
+        }
+        log.info(
+                "[BSN Besu nonce] PENDING 已越过未决 nonce，允许继续发送, signer={}, nonce={}, pending={}",
+                canonicalSigner,
+                unresolvedNonce,
+                nodePending
+        );
+    }
+
+    /**
+     * 以可中断方式获取 signer 锁，并在中断时恢复线程中断标记。
+     */
+    private void lockInterruptibly(ReentrantLock lock) throws InterruptedException {
+        try {
+            lock.lockInterruptibly();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw exception;
+        }
+    }
+
+    /**
+     * 校验节点返回的 nonce，拒绝空值和负数。
+     */
+    private BigInteger requireValidNonce(BigInteger nonce) {
+        if (nonce == null || nonce.signum() < 0) {
+            throw new IllegalStateException("BSN Besu returned an invalid PENDING nonce");
+        }
+        return nonce;
+    }
+
+    /**
+     * 校验本地签名结果，避免把空 payload 误判为广播失败。
+     */
+    private String requireSignedRawTransaction(String signedRawTransaction) {
+        if (signedRawTransaction == null || signedRawTransaction.isBlank()) {
+            throw new IllegalStateException("BSN Besu signed raw transaction is empty");
+        }
+        return signedRawTransaction;
+    }
+
+    /**
+     * 根据同步 RPC 响应保守区分成功、明确拒绝和不确定结果。
+     */
+    private BroadcastOutcome classify(
+            EthSendTransaction response,
+            String localTransactionHash
+    ) {
+        if (response == null) {
+            return BroadcastOutcome.UNKNOWN;
+        }
+        if (!response.hasError()) {
+            return isMatchingTransactionHash(
+                    response.getTransactionHash(),
+                    localTransactionHash
+            )
+                    ? BroadcastOutcome.ACCEPTED
+                    : BroadcastOutcome.UNKNOWN;
+        }
+        if (response.getResult() != null) {
+            return BroadcastOutcome.UNKNOWN;
+        }
+        return isDefiniteReject(response.getError())
+                ? BroadcastOutcome.DEFINITE_REJECT
+                : BroadcastOutcome.UNKNOWN;
+    }
+
+    /**
+     * 持久化本地确定失败；持久化异常作为 suppressed 信息附加到原失败。
+     */
+    private void persistLocalFailure(
+            String canonicalSigner,
+            SignerState state,
+            BigInteger nonce,
+            Exception originalException
+    ) {
+        try {
+            persistState(
+                    canonicalSigner,
+                    state,
+                    new BsnBesuNonceStateStore.PersistedState(
+                            nonce,
+                            nonce,
+                            BsnBesuNonceStateStore.Outcome.LOCAL_FAILURE,
+                            null,
+                            null
+                    )
+            );
+        } catch (IOException persistenceException) {
+            originalException.addSuppressed(persistenceException);
+        }
+    }
+
+    /**
+     * 广播异常后尽力把预写 BROADCASTING 状态提升为 UNKNOWN，保留安全高水位。
+     */
+    private void persistUnknownAfterBroadcastFailure(
+            String canonicalSigner,
+            SignerState state,
+            BigInteger nonce,
+            String localTransactionHash,
+            Exception originalException
+    ) {
+        try {
+            persistState(
+                    canonicalSigner,
+                    state,
+                    new BsnBesuNonceStateStore.PersistedState(
+                            nonce.add(BigInteger.ONE),
+                            nonce,
+                            BsnBesuNonceStateStore.Outcome.UNKNOWN,
+                            localTransactionHash,
+                            null
+                    )
+            );
+        } catch (IOException persistenceException) {
+            originalException.addSuppressed(persistenceException);
+            log.error(
+                    "[BSN Besu nonce] UNKNOWN 状态持久化失败，保留预写 BROADCASTING 状态, signer={}, nonce={}",
+                    canonicalSigner,
+                    nonce,
+                    persistenceException
+            );
+        }
+    }
+
+    /**
+     * 原子保存 durable 状态，并仅在落盘成功后更新进程内快照。
+     */
+    private void persistState(
+            String canonicalSigner,
+            SignerState state,
+            BsnBesuNonceStateStore.PersistedState persistedState
+    ) throws IOException {
+        stateStore.save(canonicalSigner, persistedState);
+        state.persistedState = persistedState;
+        state.nextNonce = persistedState.nextNonce();
+    }
+
+    /**
+     * 仅把标准协议拒绝和明确的 Besu 本地校验错误视为未进入 mempool。
+     */
+    private boolean isDefiniteReject(Response.Error error) {
+        if (DEFINITE_JSON_RPC_REJECT_CODES.contains(error.getCode())) {
+            return true;
+        }
+        String message = error.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalizedMessage = message.toLowerCase(Locale.ROOT);
+        return DEFINITE_BESU_REJECT_MESSAGES.stream().anyMatch(normalizedMessage::contains);
+    }
+
+    /**
+     * 校验节点成功响应中的交易哈希，畸形成功响应按不确定结果处理。
+     */
+    private boolean isValidTransactionHash(String transactionHash) {
+        return transactionHash != null
+                && TRANSACTION_HASH_PATTERN.matcher(transactionHash).matches();
+    }
+
+    /**
+     * 验证节点交易哈希与本地签名 payload 的 Keccak-256 完全一致。
+     */
+    private boolean isMatchingTransactionHash(
+            String remoteTransactionHash,
+            String localTransactionHash
+    ) {
+        return isValidTransactionHash(remoteTransactionHash)
+                && remoteTransactionHash.equalsIgnoreCase(localTransactionHash);
+    }
+
+    /**
+     * 将可选交易哈希规范化为小写；畸形值保留为空以避免写入损坏状态。
+     */
+    private String normalizeOptionalTransactionHash(String transactionHash) {
+        return isValidTransactionHash(transactionHash)
+                ? transactionHash.toLowerCase(Locale.ROOT)
+                : null;
+    }
+
+    /**
+     * 将同一 signer 的大小写和 0x 前缀形式归一到同一个状态键。
+     */
+    private String canonicalizeSigner(String signer) {
+        if (signer == null) {
+            throw new IllegalArgumentException("BSN Besu signer address is required");
+        }
+        String normalized = signer.trim().toLowerCase(Locale.ROOT);
+        if (normalized.startsWith("0x")) {
+            normalized = normalized.substring(2);
+        }
+        if (!SIGNER_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException("BSN Besu signer address is invalid");
+        }
+        return "0x" + normalized;
+    }
+
+    /**
+     * 查询节点当前 PENDING nonce。
+     */
+    @FunctionalInterface
+    public interface PendingNonceSupplier {
+        BigInteger get() throws Exception;
+    }
+
+    /**
+     * 使用已保留 nonce 在本地构造并签名原始交易。
+     */
+    @FunctionalInterface
+    public interface SignedRawTransactionFactory {
+        String build(BigInteger nonce) throws Exception;
+    }
+
+    /**
+     * 将已签名原始交易提交给 Besu 节点。
+     */
+    @FunctionalInterface
+    public interface RawTransactionBroadcaster {
+        EthSendTransaction broadcast(String signedRawTransaction) throws Exception;
+    }
+
+    /**
+     * 同一 signer 的本地 nonce 高水位和互斥状态。
+     */
+    private static final class SignerState {
+        private final ReentrantLock lock = new ReentrantLock();
+        private boolean initialized;
+        private BigInteger nextNonce;
+        private BsnBesuNonceStateStore.PersistedState persistedState;
+    }
+
+    /**
+     * 同步广播调用的保守结果分类。
+     */
+    private enum BroadcastOutcome {
+        ACCEPTED,
+        DEFINITE_REJECT,
+        UNKNOWN
+    }
+}

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuNonceStateStore.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuNonceStateStore.java
@@ -1,0 +1,118 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.regex.Pattern;
+
+/**
+ * 持久化 BSN Besu signer 的 nonce 高水位和最近一次广播状态。
+ */
+public interface BsnBesuNonceStateStore {
+
+    /**
+     * 读取 signer 已持久化的 nonce 状态；首次启动时返回 {@code null}。
+     */
+    PersistedState load(String canonicalSigner) throws IOException;
+
+    /**
+     * 原子持久化 signer 的最新 nonce 状态。
+     */
+    void save(String canonicalSigner, PersistedState state) throws IOException;
+
+    /**
+     * 广播阶段的持久化状态。
+     */
+    enum Outcome {
+        LOCAL_FAILURE,
+        BROADCASTING,
+        ACCEPTED,
+        DEFINITE_REJECT,
+        UNKNOWN
+    }
+
+    /**
+     * signer 的 durable nonce 快照；nextNonce 是后续分配不得低于的本地高水位。
+     */
+    record PersistedState(
+            BigInteger nextNonce,
+            BigInteger lastNonce,
+            Outcome outcome,
+            String localTransactionHash,
+            String remoteTransactionHash
+    ) {
+        private static final Pattern TRANSACTION_HASH_PATTERN =
+                Pattern.compile("^0x[0-9a-f]{64}$");
+
+        /**
+         * 校验快照字段和状态转换关系，拒绝会降低 nonce 安全性的语义损坏状态。
+         */
+        public PersistedState {
+            if (nextNonce == null || nextNonce.signum() < 0) {
+                throw new IllegalArgumentException("nextNonce must be non-negative");
+            }
+            if (lastNonce == null || lastNonce.signum() < 0) {
+                throw new IllegalArgumentException("lastNonce must be non-negative");
+            }
+            if (outcome == null) {
+                throw new IllegalArgumentException("outcome is required");
+            }
+            BigInteger expectedNextNonce = switch (outcome) {
+                case LOCAL_FAILURE, DEFINITE_REJECT -> lastNonce;
+                case BROADCASTING, ACCEPTED, UNKNOWN -> lastNonce.add(BigInteger.ONE);
+            };
+            if (!expectedNextNonce.equals(nextNonce)) {
+                throw new IllegalArgumentException("nextNonce is inconsistent with outcome");
+            }
+            requireValidTransactionHash(localTransactionHash, "localTransactionHash");
+            requireValidTransactionHash(remoteTransactionHash, "remoteTransactionHash");
+            switch (outcome) {
+                case LOCAL_FAILURE -> requireHashPresence(
+                        localTransactionHash == null && remoteTransactionHash == null,
+                        outcome
+                );
+                case BROADCASTING -> requireHashPresence(
+                        localTransactionHash != null && remoteTransactionHash == null,
+                        outcome
+                );
+                case ACCEPTED -> requireHashPresence(
+                        localTransactionHash != null
+                                && remoteTransactionHash != null
+                                && localTransactionHash.equalsIgnoreCase(remoteTransactionHash),
+                        outcome
+                );
+                case DEFINITE_REJECT -> requireHashPresence(
+                        localTransactionHash != null && remoteTransactionHash == null,
+                        outcome
+                );
+                case UNKNOWN -> requireHashPresence(localTransactionHash != null, outcome);
+            }
+        }
+
+        /**
+         * 判断该快照是否仍包含无法证明已接受或已拒绝的广播。
+         */
+        public boolean isUnresolvedBroadcast() {
+            return outcome == Outcome.BROADCASTING || outcome == Outcome.UNKNOWN;
+        }
+
+        /**
+         * 校验可选交易哈希为规范化 32 字节小写十六进制值。
+         */
+        private static void requireValidTransactionHash(String hash, String field) {
+            if (hash != null && !TRANSACTION_HASH_PATTERN.matcher(hash).matches()) {
+                throw new IllegalArgumentException(field + " is invalid");
+            }
+        }
+
+        /**
+         * 校验不同广播结果允许的本地与远端哈希组合。
+         */
+        private static void requireHashPresence(boolean valid, Outcome outcome) {
+            if (!valid) {
+                throw new IllegalArgumentException(
+                        "transaction hashes are inconsistent with outcome " + outcome
+                );
+            }
+        }
+    }
+}

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/config/BsnBesuConfig.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/config/BsnBesuConfig.java
@@ -42,6 +42,11 @@ public class BsnBesuConfig {
      */
     private GasConfig gas = new GasConfig();
 
+    /**
+     * Nonce 协调与单 writer 状态配置
+     */
+    private NonceConfig nonce = new NonceConfig();
+
     @Data
     public static class Wallet {
         /**
@@ -79,5 +84,13 @@ public class BsnBesuConfig {
          * Gas 限制
          */
         private Long gasLimit = 4_500_000L;
+    }
+
+    @Data
+    public static class NonceConfig {
+        /**
+         * 持久 nonce 状态和 signer 独占锁目录
+         */
+        private String stateDirectory;
     }
 }

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/config/Web3jConfig.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/config/Web3jConfig.java
@@ -32,7 +32,7 @@ public class Web3jConfig {
 
     @Bean
     public Web3j web3j() {
-        log.info("[BSN Besu] 初始化 Web3j 连接, rpcUrl={}", besuConfig.getRpcUrl());
+        log.info("[BSN Besu] 初始化 Web3j 连接");
         this.web3jInstance = Web3j.build(new HttpService(besuConfig.getRpcUrl()));
         return this.web3jInstance;
     }

--- a/platform-fisco/src/main/resources/application.yml
+++ b/platform-fisco/src/main/resources/application.yml
@@ -31,6 +31,9 @@ blockchain:
     gas:
       gas-price: 0
       gas-limit: 4500000
+    nonce:
+      # 必须是可持久化且仅由同一 signer writer 共享的原子替换/文件锁目录
+      state-directory: ${BSN_BESU_NONCE_STATE_DIRECTORY:}
 
 ### Java sdk configuration (Local FISCO BCOS)
 bcos:

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuAdapterTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuAdapterTest.java
@@ -1,0 +1,484 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import cn.flying.fisco_bcos.adapter.model.ChainException;
+import cn.flying.fisco_bcos.config.BsnBesuConfig;
+import cn.flying.fisco_bcos.registry.ContractRegistryService;
+import cn.flying.platformapi.response.ContractRegistryEntryResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.Hash;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionDecoder;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+import org.web3j.protocol.core.methods.response.EthGetTransactionReceipt;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.tx.gas.StaticGasProvider;
+import org.web3j.utils.Numeric;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BsnBesuAdapterTest {
+
+    private static final String SHARING_ADDRESS =
+            "0x3333333333333333333333333333333333333333";
+    private static final String FILE_HASH = "0x" + "4".repeat(64);
+    private static final String MERKLE_ROOT = "0x" + "5".repeat(64);
+    private static final Credentials CREDENTIALS = Credentials.create("3".repeat(64));
+
+    @Mock
+    private Web3j web3j;
+
+    @Mock
+    private ContractRegistryService contractRegistryService;
+
+    @Mock
+    private ContractRegistryEntryResponse registryEntry;
+
+    @Mock
+    private Request<?, EthGetTransactionCount> nonceRequest;
+
+    private final AtomicReference<BigInteger> nodePending =
+            new AtomicReference<>(BigInteger.ZERO);
+    private final List<String> capturedRawTransactions =
+            Collections.synchronizedList(new ArrayList<>());
+
+    private BsnBesuAdapter adapter;
+
+    /**
+     * 构造使用真实签名和内存 durable store 的 Besu adapter 测试实例。
+     */
+    @BeforeEach
+    void setUp() throws Exception {
+        when(contractRegistryService.getActiveEntry("Sharing")).thenReturn(registryEntry);
+        when(registryEntry.contractAddress()).thenReturn(SHARING_ADDRESS);
+        doReturn(nonceRequest).when(web3j).ethGetTransactionCount(
+                eq(CREDENTIALS.getAddress()),
+                eq(DefaultBlockParameterName.PENDING)
+        );
+        when(nonceRequest.send()).thenAnswer(invocation -> nonceResponse(nodePending.get()));
+        lenient().doAnswer(invocation -> {
+            String raw = invocation.getArgument(0);
+            capturedRawTransactions.add(raw);
+            return requestReturning(accepted(raw));
+        }).when(web3j).ethSendRawTransaction(anyString());
+        lenient().doAnswer(invocation -> requestReturning(successfulReceiptResponse()))
+                .when(web3j).ethGetTransactionReceipt(anyString());
+
+        BsnBesuConfig config = new BsnBesuConfig();
+        config.setChainId(1337L);
+        BsnBesuNonceCoordinator coordinator =
+                new BsnBesuNonceCoordinator(new InMemoryStateStore());
+        adapter = new BsnBesuAdapter(
+                web3j,
+                CREDENTIALS,
+                new StaticGasProvider(BigInteger.ONE, BigInteger.valueOf(4_500_000L)),
+                config,
+                contractRegistryService,
+                coordinator
+        );
+        adapter.init();
+    }
+
+    /**
+     * 验证 batch 与普通文件写并发时获得唯一连续 nonce 和不同 payload。
+     */
+    @Test
+    void shouldCoordinateConcurrentBatchAndFileWrites() throws Exception {
+        nodePending.set(BigInteger.valueOf(50));
+
+        runConcurrently(
+                () -> adapter.storeAttestationBatch(
+                        1L,
+                        101L,
+                        "BATCH-101",
+                        "SHA-256-MERKLE-V1",
+                        MERKLE_ROOT,
+                        2
+                ),
+                () -> adapter.storeFile("uploader", "file.txt", "[]", "{}")
+        );
+
+        assertUniqueContinuousNonces(BigInteger.valueOf(50), 2);
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getData)
+                .doesNotHaveDuplicates();
+        verifyPendingNonceOnly();
+    }
+
+    /**
+     * 验证两个 batch 写并发时不会为不同业务 payload 分配相同 nonce。
+     */
+    @Test
+    void shouldCoordinateTwoConcurrentBatchWrites() throws Exception {
+        nodePending.set(BigInteger.valueOf(60));
+
+        runConcurrently(
+                () -> adapter.storeAttestationBatch(
+                        2L,
+                        201L,
+                        "BATCH-201",
+                        "SHA-256-MERKLE-V1",
+                        "0x" + "6".repeat(64),
+                        3
+                ),
+                () -> adapter.storeAttestationBatch(
+                        2L,
+                        202L,
+                        "BATCH-202",
+                        "SHA-256-MERKLE-V1",
+                        "0x" + "7".repeat(64),
+                        4
+                )
+        );
+
+        assertUniqueContinuousNonces(BigInteger.valueOf(60), 2);
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getData)
+                .doesNotHaveDuplicates();
+    }
+
+    /**
+     * 验证广播异常后的 public 写路径不会复用可能已提交的 nonce。
+     */
+    @Test
+    void shouldNotReuseNonceAfterUnknownBroadcast() throws Exception {
+        nodePending.set(BigInteger.valueOf(70));
+        AtomicInteger broadcastCount = new AtomicInteger();
+        doAnswer(invocation -> {
+            String raw = invocation.getArgument(0);
+            capturedRawTransactions.add(raw);
+            if (broadcastCount.getAndIncrement() == 0) {
+                return requestThrowing(new IOException("connection reset"));
+            }
+            return requestReturning(accepted(raw));
+        }).when(web3j).ethSendRawTransaction(anyString());
+
+        assertThatThrownBy(() -> adapter.storeFile("uploader", "first", "[]", "{}"))
+                .isInstanceOf(ChainException.class)
+                .hasMessageContaining("connection reset");
+
+        nodePending.set(BigInteger.valueOf(71));
+        adapter.storeFile("uploader", "second", "[]", "{}");
+
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getNonce)
+                .containsExactly(BigInteger.valueOf(70), BigInteger.valueOf(71));
+    }
+
+    /**
+     * 验证明确 JSON-RPC 拒绝后重新同步可安全复用未广播 nonce。
+     */
+    @Test
+    void shouldResyncAfterDefiniteReject() throws Exception {
+        nodePending.set(BigInteger.valueOf(80));
+        AtomicInteger broadcastCount = new AtomicInteger();
+        doAnswer(invocation -> {
+            String raw = invocation.getArgument(0);
+            capturedRawTransactions.add(raw);
+            if (broadcastCount.getAndIncrement() == 0) {
+                EthSendTransaction rejected = new EthSendTransaction();
+                rejected.setError(new Response.Error(-32602, "invalid params"));
+                return requestReturning(rejected);
+            }
+            return requestReturning(accepted(raw));
+        }).when(web3j).ethSendRawTransaction(anyString());
+
+        assertThatThrownBy(() -> adapter.storeFile("uploader", "first", "[]", "{}"))
+                .isInstanceOf(ChainException.class)
+                .hasMessageContaining("invalid params");
+        adapter.storeFile("uploader", "second", "[]", "{}");
+
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getNonce)
+                .containsExactly(BigInteger.valueOf(80), BigInteger.valueOf(80));
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getData)
+                .doesNotHaveDuplicates();
+    }
+
+    /**
+     * 验证 receipt 等待不占用 signer nonce 临界区。
+     */
+    @Test
+    void shouldNotHoldSignerLockWhileWaitingForReceipt() throws Exception {
+        nodePending.set(BigInteger.valueOf(90));
+        CountDownLatch firstReceiptEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstReceipt = new CountDownLatch(1);
+        CountDownLatch secondBroadcasted = new CountDownLatch(1);
+        AtomicReference<String> firstTransactionHash = new AtomicReference<>();
+        AtomicInteger broadcastCount = new AtomicInteger();
+
+        doAnswer(invocation -> {
+            String raw = invocation.getArgument(0);
+            capturedRawTransactions.add(raw);
+            String transactionHash = Hash.sha3(raw);
+            if (broadcastCount.getAndIncrement() == 0) {
+                firstTransactionHash.set(transactionHash);
+            } else {
+                secondBroadcasted.countDown();
+            }
+            return requestReturning(responseWithHash(transactionHash));
+        }).when(web3j).ethSendRawTransaction(anyString());
+        doAnswer(invocation -> {
+            String transactionHash = invocation.getArgument(0);
+            if (transactionHash.equals(firstTransactionHash.get())) {
+                return receiptRequestWaiting(firstReceiptEntered, releaseFirstReceipt);
+            }
+            return requestReturning(successfulReceiptResponse());
+        }).when(web3j).ethGetTransactionReceipt(anyString());
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> first = executor.submit(
+                    () -> adapter.storeFile("uploader", "first", "[]", "{}")
+            );
+            assertThat(firstReceiptEntered.await(3, TimeUnit.SECONDS)).isTrue();
+            Future<?> second = executor.submit(
+                    () -> adapter.storeFile("uploader", "second", "[]", "{}")
+            );
+
+            assertThat(secondBroadcasted.await(3, TimeUnit.SECONDS)).isTrue();
+            releaseFirstReceipt.countDown();
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+        } finally {
+            releaseFirstReceipt.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * 验证五类 Besu 写入口全部共享同一 PENDING nonce 协调发送缝。
+     */
+    @Test
+    void shouldRouteAllWriteOperationsThroughOneCoordinator() {
+        nodePending.set(BigInteger.valueOf(100));
+
+        adapter.storeFile("uploader", "file", "[]", "{}");
+        adapter.storeAttestationBatch(
+                3L,
+                301L,
+                "BATCH-301",
+                "SHA-256-MERKLE-V1",
+                MERKLE_ROOT,
+                1
+        );
+        adapter.deleteFiles("uploader", List.of(FILE_HASH));
+        adapter.shareFiles("uploader", List.of(FILE_HASH), 30);
+        adapter.cancelShare("share-code", "uploader");
+
+        assertUniqueContinuousNonces(BigInteger.valueOf(100), 5);
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getData)
+                .doesNotHaveDuplicates();
+        verifyPendingNonceOnly();
+    }
+
+    /**
+     * 同步启动两个写调用，并在有界时间内等待完成。
+     */
+    private void runConcurrently(Runnable firstAction, Runnable secondAction) throws Exception {
+        CyclicBarrier startBarrier = new CyclicBarrier(3);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> first = executor.submit(() -> runAfterBarrier(startBarrier, firstAction));
+            Future<?> second = executor.submit(() -> runAfterBarrier(startBarrier, secondAction));
+            startBarrier.await(3, TimeUnit.SECONDS);
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * 等待并发起点 barrier 后执行写操作。
+     */
+    private void runAfterBarrier(CyclicBarrier barrier, Runnable action) {
+        try {
+            barrier.await(3, TimeUnit.SECONDS);
+            action.run();
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    /**
+     * 断言捕获的签名交易从指定 nonce 开始唯一连续。
+     */
+    private void assertUniqueContinuousNonces(BigInteger firstNonce, int count) {
+        List<BigInteger> expected = new ArrayList<>();
+        for (int index = 0; index < count; index++) {
+            expected.add(firstNonce.add(BigInteger.valueOf(index)));
+        }
+        assertThat(decodedTransactions())
+                .extracting(RawTransaction::getNonce)
+                .containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    /**
+     * 解码全部已捕获的真实签名 raw transaction。
+     */
+    private List<RawTransaction> decodedTransactions() {
+        synchronized (capturedRawTransactions) {
+            return capturedRawTransactions.stream()
+                    .map(TransactionDecoder::decode)
+                    .toList();
+        }
+    }
+
+    /**
+     * 验证写发送只查询 PENDING nonce，不回退到 LATEST。
+     */
+    private void verifyPendingNonceOnly() {
+        verify(web3j, atLeastOnce()).ethGetTransactionCount(
+                CREDENTIALS.getAddress(),
+                DefaultBlockParameterName.PENDING
+        );
+        verify(web3j, never()).ethGetTransactionCount(
+                CREDENTIALS.getAddress(),
+                DefaultBlockParameterName.LATEST
+        );
+    }
+
+    /**
+     * 创建指定节点 PENDING nonce 的 Web3j 响应。
+     */
+    private static EthGetTransactionCount nonceResponse(BigInteger nonce) {
+        EthGetTransactionCount response = new EthGetTransactionCount();
+        response.setResult(Numeric.encodeQuantity(nonce));
+        return response;
+    }
+
+    /**
+     * 创建与签名 payload 本地哈希一致的成功广播响应。
+     */
+    private static EthSendTransaction accepted(String signedRawTransaction) {
+        return responseWithHash(Hash.sha3(signedRawTransaction));
+    }
+
+    /**
+     * 创建指定交易哈希的成功广播响应。
+     */
+    private static EthSendTransaction responseWithHash(String transactionHash) {
+        EthSendTransaction response = new EthSendTransaction();
+        response.setResult(transactionHash);
+        return response;
+    }
+
+    /**
+     * 创建 status=1 的确定成功交易回执响应。
+     */
+    private static EthGetTransactionReceipt successfulReceiptResponse() {
+        TransactionReceipt receipt = new TransactionReceipt();
+        receipt.setStatus("0x1");
+        receipt.setBlockNumber("0x1");
+        receipt.setGasUsed("0x5208");
+        receipt.setLogs(List.of());
+        EthGetTransactionReceipt response = new EthGetTransactionReceipt();
+        response.setResult(receipt);
+        return response;
+    }
+
+    /**
+     * 创建在首笔 receipt 上受 latch 控制的 Web3j Request。
+     */
+    @SuppressWarnings("unchecked")
+    private static Request<?, EthGetTransactionReceipt> receiptRequestWaiting(
+            CountDownLatch entered,
+            CountDownLatch release
+    ) throws IOException {
+        Request<?, EthGetTransactionReceipt> request = mock(Request.class);
+        when(request.send()).thenAnswer(invocation -> {
+            entered.countDown();
+            if (!release.await(3, TimeUnit.SECONDS)) {
+                throw new IOException("receipt wait timed out");
+            }
+            return successfulReceiptResponse();
+        });
+        return request;
+    }
+
+    /**
+     * 创建返回固定响应的 Web3j Request。
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends Response<?>> Request<?, T> requestReturning(T response)
+            throws IOException {
+        Request<?, T> request = mock(Request.class);
+        doReturn(response).when(request).send();
+        return request;
+    }
+
+    /**
+     * 创建在同步 send 阶段抛出指定异常的 Web3j Request。
+     */
+    @SuppressWarnings("unchecked")
+    private static Request<?, EthSendTransaction> requestThrowing(IOException exception)
+            throws IOException {
+        Request<?, EthSendTransaction> request = mock(Request.class);
+        when(request.send()).thenThrow(exception);
+        return request;
+    }
+
+    /**
+     * 为 adapter 测试提供按 signer 隔离的线程安全 durable store。
+     */
+    private static final class InMemoryStateStore implements BsnBesuNonceStateStore {
+        private final Map<String, PersistedState> states = new ConcurrentHashMap<>();
+
+        /**
+         * 读取规范化 signer 状态。
+         */
+        @Override
+        public PersistedState load(String canonicalSigner) {
+            return states.get(canonicalSigner.toLowerCase(Locale.ROOT));
+        }
+
+        /**
+         * 保存规范化 signer 状态。
+         */
+        @Override
+        public void save(String canonicalSigner, PersistedState state) {
+            states.put(canonicalSigner.toLowerCase(Locale.ROOT), state);
+        }
+    }
+}

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuFileNonceStateStoreTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuFileNonceStateStoreTest.java
@@ -1,0 +1,374 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import cn.flying.fisco_bcos.config.BsnBesuConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.Hash;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BsnBesuFileNonceStateStoreTest {
+
+    private static final long CHAIN_ID = 1337L;
+    private static final String FIRST_PRIVATE_KEY = "1".repeat(64);
+    private static final Credentials FIRST_CREDENTIALS =
+            Credentials.create(FIRST_PRIVATE_KEY);
+    private static final Credentials SECOND_CREDENTIALS =
+            Credentials.create("2".repeat(64));
+
+    @TempDir
+    private Path stateDirectory;
+
+    /**
+     * 验证相同 chainId/signer 的第二个进程视图无法同时取得 writer 所有权。
+     */
+    @Test
+    void shouldRejectSecondWriterForSameChainAndSigner() {
+        BsnBesuFileNonceStateStore first = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        BsnBesuFileNonceStateStore second = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        first.initialize();
+        try {
+            assertThatThrownBy(second::initialize)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("另一个 writer");
+        } finally {
+            second.close();
+            first.close();
+        }
+    }
+
+    /**
+     * 验证独立 JVM 已持有相同 chainId/signer 文件锁时，当前 JVM 的 writer 启动失败。
+     */
+    @Test
+    void shouldRejectWriterOwnedByForkedJvm() throws Exception {
+        Path readyFile = stateDirectory.resolve("forked-writer.ready");
+        Path processLog = stateDirectory.resolve("forked-writer.log");
+        Process child = startWriterProcess(readyFile, processLog);
+        BsnBesuFileNonceStateStore competingStore =
+                newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        try {
+            awaitWriterReady(child, readyFile, processLog, Duration.ofSeconds(10));
+
+            assertThatThrownBy(competingStore::initialize)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("另一个 writer");
+
+            child.getOutputStream().close();
+            assertThat(child.waitFor(5, TimeUnit.SECONDS))
+                    .as("forked writer should exit after stdin closes; log=%s", readProcessLog(processLog))
+                    .isTrue();
+            assertThat(child.exitValue())
+                    .as("forked writer exit code; log=%s", readProcessLog(processLog))
+                    .isZero();
+        } finally {
+            competingStore.close();
+            terminateProcess(child);
+        }
+    }
+
+    /**
+     * 验证旧 writer 释放锁后冷备可接管并恢复 durable high watermark。
+     */
+    @Test
+    void shouldRestoreStateAfterControlledWriterTakeover() throws Exception {
+        BsnBesuFileNonceStateStore first = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        first.initialize();
+        String signer = FIRST_CREDENTIALS.getAddress();
+        BsnBesuNonceStateStore.PersistedState expected = new BsnBesuNonceStateStore.PersistedState(
+                BigInteger.valueOf(18),
+                BigInteger.valueOf(17),
+                BsnBesuNonceStateStore.Outcome.UNKNOWN,
+                "0x" + "a".repeat(64),
+                null
+        );
+        first.save(signer, expected);
+        first.close();
+
+        BsnBesuFileNonceStateStore takeover = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        try {
+            takeover.initialize();
+            assertThat(takeover.load(signer)).isEqualTo(expected);
+        } finally {
+            takeover.close();
+        }
+    }
+
+    /**
+     * 验证 UNKNOWN 广播跨进程重启后仍由真实文件状态阻止 nonce 重用。
+     */
+    @Test
+    void shouldBlockUnknownNonceReuseAfterProcessRestart() throws Exception {
+        BsnBesuFileNonceStateStore firstStore = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        firstStore.initialize();
+        BsnBesuNonceCoordinator firstCoordinator = new BsnBesuNonceCoordinator(firstStore);
+        assertThatThrownBy(() -> firstCoordinator.send(
+                FIRST_CREDENTIALS.getAddress(),
+                () -> BigInteger.valueOf(25),
+                nonce -> "0x25",
+                raw -> {
+                    throw new IOException("broadcast timeout");
+                }
+        )).isInstanceOf(IOException.class);
+        firstStore.close();
+
+        BsnBesuFileNonceStateStore restartedStore = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        try {
+            restartedStore.initialize();
+            BsnBesuNonceCoordinator restartedCoordinator =
+                    new BsnBesuNonceCoordinator(restartedStore);
+            assertThatThrownBy(() -> restartedCoordinator.send(
+                    FIRST_CREDENTIALS.getAddress(),
+                    () -> BigInteger.valueOf(25),
+                    nonce -> "0x26",
+                    BsnBesuFileNonceStateStoreTest::accepted
+            )).isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("unresolved broadcast");
+        } finally {
+            restartedStore.close();
+        }
+    }
+
+    /**
+     * 验证不同 signer 在同一持久目录中使用独立锁和状态文件。
+     */
+    @Test
+    void shouldAllowDifferentSignersToOwnIndependentLocks() {
+        BsnBesuFileNonceStateStore first = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        BsnBesuFileNonceStateStore second = newStore(CHAIN_ID, SECOND_CREDENTIALS);
+        try {
+            first.initialize();
+            assertThatCode(second::initialize).doesNotThrowAnyException();
+        } finally {
+            second.close();
+            first.close();
+        }
+    }
+
+    /**
+     * 验证相同 signer 在不同 chainId 下不会共享 writer 锁或 nonce 状态。
+     */
+    @Test
+    void shouldIsolateSameSignerAcrossChains() {
+        BsnBesuFileNonceStateStore first = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+        BsnBesuFileNonceStateStore second = newStore(CHAIN_ID + 1, FIRST_CREDENTIALS);
+        try {
+            first.initialize();
+            assertThatCode(second::initialize).doesNotThrowAnyException();
+        } finally {
+            second.close();
+            first.close();
+        }
+    }
+
+    /**
+     * 验证损坏的 durable state 会阻止 writer 启动而不是静默清空高水位。
+     */
+    @Test
+    void shouldFailClosedForCorruptedStateFile() throws Exception {
+        Path stateFile = stateDirectory.resolve(
+                "chain-" + CHAIN_ID + "-signer-"
+                        + FIRST_CREDENTIALS.getAddress().substring(2)
+                        + ".state"
+        );
+        Files.writeString(
+                stateFile,
+                "schema=" + BsnBesuFileNonceStateStore.SCHEMA_VERSION + "\nnextNonce=broken\n",
+                StandardCharsets.UTF_8
+        );
+        BsnBesuFileNonceStateStore store = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+
+        try {
+            assertThatThrownBy(store::initialize)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("字段不完整");
+        } finally {
+            store.close();
+        }
+    }
+
+    /**
+     * 验证字段完整但 ACCEPTED 高水位未推进的语义损坏状态会阻止 writer 启动。
+     */
+    @Test
+    void shouldFailClosedForAcceptedStateWithoutAdvancedHighWatermark() throws Exception {
+        Path stateFile = stateDirectory.resolve(
+                "chain-" + CHAIN_ID + "-signer-"
+                        + FIRST_CREDENTIALS.getAddress().substring(2)
+                        + ".state"
+        );
+        Files.writeString(
+                stateFile,
+                "schema=" + BsnBesuFileNonceStateStore.SCHEMA_VERSION + "\n"
+                        + "chainId=" + CHAIN_ID + "\n"
+                        + "signer=" + FIRST_CREDENTIALS.getAddress().toLowerCase() + "\n"
+                        + "nextNonce=31\n"
+                        + "lastNonce=31\n"
+                        + "outcome=ACCEPTED\n"
+                        + "localTransactionHash=0x" + "a".repeat(64) + "\n"
+                        + "remoteTransactionHash=0x" + "a".repeat(64) + "\n"
+                        + "updatedAt=" + Instant.parse("2026-07-17T00:00:00Z") + "\n",
+                StandardCharsets.UTF_8
+        );
+        BsnBesuFileNonceStateStore store = newStore(CHAIN_ID, FIRST_CREDENTIALS);
+
+        try {
+            assertThatThrownBy(store::initialize)
+                    .isInstanceOf(IllegalStateException.class);
+        } finally {
+            store.close();
+        }
+    }
+
+    /**
+     * 验证 BSN Besu 模式缺少持久状态目录时启动失败关闭。
+     */
+    @Test
+    void shouldRequireNonceStateDirectory() {
+        BsnBesuConfig config = new BsnBesuConfig();
+        config.setChainId(CHAIN_ID);
+        BsnBesuFileNonceStateStore store =
+                new BsnBesuFileNonceStateStore(config, FIRST_CREDENTIALS);
+
+        assertThatThrownBy(store::initialize)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("state directory 未配置");
+    }
+
+    /**
+     * 创建绑定到临时状态目录的文件存储实例。
+     */
+    private BsnBesuFileNonceStateStore newStore(long chainId, Credentials credentials) {
+        BsnBesuConfig config = new BsnBesuConfig();
+        config.setChainId(chainId);
+        config.getNonce().setStateDirectory(stateDirectory.toString());
+        return new BsnBesuFileNonceStateStore(config, credentials);
+    }
+
+    /**
+     * 启动独立 JVM，并把输出重定向到测试专用日志文件。
+     */
+    private Process startWriterProcess(Path readyFile, Path processLog) throws IOException {
+        String classPath = System.getProperty("surefire.test.class.path");
+        if (classPath == null || classPath.isBlank()) {
+            classPath = System.getProperty("java.class.path");
+        }
+        if (classPath == null || classPath.isBlank()) {
+            throw new IllegalStateException("Forked JVM classpath is unavailable");
+        }
+
+        Path javaExecutable = Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                isWindows() ? "java.exe" : "java"
+        );
+        List<String> command = new ArrayList<>();
+        command.add(javaExecutable.toString());
+        command.add("-cp");
+        command.add(classPath);
+        command.add(BsnBesuWriterLockProcess.class.getName());
+        command.add(stateDirectory.toString());
+        command.add(String.valueOf(CHAIN_ID));
+        command.add(FIRST_PRIVATE_KEY);
+        command.add(readyFile.toString());
+
+        return new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .redirectOutput(processLog.toFile())
+                .start();
+    }
+
+    /**
+     * 在有界时间内等待子进程确认锁已获取，并在提前退出时附带日志失败。
+     */
+    private void awaitWriterReady(
+            Process child,
+            Path readyFile,
+            Path processLog,
+            Duration timeout
+    ) throws Exception {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (Files.isRegularFile(readyFile)) {
+                return;
+            }
+            if (!child.isAlive()) {
+                throw new AssertionError(
+                        "Forked writer exited before acquiring lock, exit="
+                                + child.exitValue() + ", log=" + readProcessLog(processLog)
+                );
+            }
+            Thread.sleep(25);
+        }
+        throw new AssertionError(
+                "Timed out waiting for forked writer lock; log=" + readProcessLog(processLog)
+        );
+    }
+
+    /**
+     * 先请求子进程正常退出，超时后逐级终止并确保不遗留进程。
+     */
+    private void terminateProcess(Process child) throws Exception {
+        if (child == null || !child.isAlive()) {
+            return;
+        }
+        child.getOutputStream().close();
+        if (child.waitFor(2, TimeUnit.SECONDS)) {
+            return;
+        }
+        child.destroy();
+        if (child.waitFor(2, TimeUnit.SECONDS)) {
+            return;
+        }
+        child.destroyForcibly();
+        assertThat(child.waitFor(5, TimeUnit.SECONDS))
+                .as("forked writer must terminate during test cleanup")
+                .isTrue();
+    }
+
+    /**
+     * 读取子进程日志，日志尚未创建时返回稳定占位文本。
+     */
+    private String readProcessLog(Path processLog) {
+        try {
+            return Files.exists(processLog)
+                    ? Files.readString(processLog, StandardCharsets.UTF_8)
+                    : "<log-not-created>";
+        } catch (IOException exception) {
+            return "<log-unreadable:" + exception.getClass().getSimpleName() + ">";
+        }
+    }
+
+    /**
+     * 判断当前 JVM 是否运行在 Windows，以解析 java 可执行文件名。
+     */
+    private boolean isWindows() {
+        return System.getProperty("os.name", "")
+                .toLowerCase()
+                .contains("win");
+    }
+
+    /**
+     * 创建与签名 payload 本地哈希一致的成功广播响应。
+     */
+    private static EthSendTransaction accepted(String signedRawTransaction) {
+        EthSendTransaction response = new EthSendTransaction();
+        response.setResult(Hash.sha3(signedRawTransaction));
+        return response;
+    }
+}

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuNonceCoordinatorTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuNonceCoordinatorTest.java
@@ -1,0 +1,446 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Hash;
+import org.web3j.protocol.core.Response;
+import org.web3j.protocol.core.methods.response.EthSendTransaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BsnBesuNonceCoordinatorTest {
+
+    private static final String SIGNER = "0x1111111111111111111111111111111111111111";
+    private static final String OTHER_SIGNER =
+            "0x2222222222222222222222222222222222222222";
+
+    /**
+     * 验证广播前本地构造失败不会推进 nonce，后续请求可安全复用。
+     */
+    @Test
+    void shouldReuseNonceAfterLocalSigningFailure() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(7),
+                nonce -> {
+                    throw new IOException("local signing failed");
+                },
+                raw -> accepted(raw)
+        )).isInstanceOf(IOException.class)
+                .hasMessage("local signing failed");
+
+        AtomicReference<BigInteger> reusedNonce = new AtomicReference<>();
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(7),
+                nonce -> {
+                    reusedNonce.set(nonce);
+                    return "0x01";
+                },
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        assertThat(reusedNonce).hasValue(BigInteger.valueOf(7));
+        assertThat(stateStore.load(SIGNER).outcome())
+                .isEqualTo(BsnBesuNonceStateStore.Outcome.ACCEPTED);
+    }
+
+    /**
+     * 验证调用网络广播器前已经持久化 BROADCASTING 安全高水位。
+     */
+    @Test
+    void shouldPersistBroadcastingBeforeCallingNetwork() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+        AtomicReference<BsnBesuNonceStateStore.Outcome> observedOutcome =
+                new AtomicReference<>();
+
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(8),
+                nonce -> "0x0102",
+                raw -> {
+                    observedOutcome.set(stateStore.load(SIGNER).outcome());
+                    return accepted(raw);
+                }
+        );
+
+        assertThat(observedOutcome)
+                .hasValue(BsnBesuNonceStateStore.Outcome.BROADCASTING);
+        assertThat(stateStore.load(SIGNER).outcome())
+                .isEqualTo(BsnBesuNonceStateStore.Outcome.ACCEPTED);
+    }
+
+    /**
+     * 验证 durable reservation 落盘失败时绝不进入网络广播阶段。
+     */
+    @Test
+    void shouldNotBroadcastWhenDurableReservationFails() {
+        AtomicBoolean broadcasterCalled = new AtomicBoolean();
+        BsnBesuNonceStateStore failingStore = new BsnBesuNonceStateStore() {
+            @Override
+            public PersistedState load(String canonicalSigner) {
+                return null;
+            }
+
+            @Override
+            public void save(String canonicalSigner, PersistedState state) throws IOException {
+                throw new IOException("durable reservation failed");
+            }
+        };
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(failingStore);
+
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(8),
+                nonce -> "0x0103",
+                raw -> {
+                    broadcasterCalled.set(true);
+                    return accepted(raw);
+                }
+        )).isInstanceOf(IOException.class)
+                .hasMessage("durable reservation failed");
+        assertThat(broadcasterCalled).isFalse();
+    }
+
+    /**
+     * 验证标准 JSON-RPC 参数拒绝可在重新读取 PENDING 后复用原 nonce。
+     */
+    @Test
+    void shouldReuseNonceAfterDefiniteReject() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+
+        EthSendTransaction rejected = new EthSendTransaction();
+        rejected.setError(new Response.Error(-32602, "invalid params"));
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(9),
+                nonce -> "0x02",
+                raw -> rejected
+        );
+
+        AtomicReference<BigInteger> reusedNonce = new AtomicReference<>();
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(9),
+                nonce -> {
+                    reusedNonce.set(nonce);
+                    return "0x03";
+                },
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        assertThat(reusedNonce).hasValue(BigInteger.valueOf(9));
+    }
+
+    /**
+     * 验证广播 IOException 被持久化为 UNKNOWN，并在 PENDING 未前进时失败关闭。
+     */
+    @Test
+    void shouldBlockReuseUntilPendingPassesUnknownNonce() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(11),
+                nonce -> "0x04",
+                raw -> {
+                    throw new IOException("connection reset");
+                }
+        )).isInstanceOf(IOException.class)
+                .hasMessage("connection reset");
+
+        assertThat(stateStore.load(SIGNER).outcome())
+                .isEqualTo(BsnBesuNonceStateStore.Outcome.UNKNOWN);
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(11),
+                nonce -> "0x05",
+                BsnBesuNonceCoordinatorTest::accepted
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("manual reconciliation");
+
+        AtomicReference<BigInteger> nextNonce = new AtomicReference<>();
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(12),
+                nonce -> {
+                    nextNonce.set(nonce);
+                    return "0x06";
+                },
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        assertThat(nextNonce).hasValue(BigInteger.valueOf(12));
+    }
+
+    /**
+     * 验证 already known 不会被误判为可回滚的明确拒绝。
+     */
+    @Test
+    void shouldTreatAlreadyKnownAsUnresolvedBroadcast() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+        EthSendTransaction alreadyKnown = new EthSendTransaction();
+        alreadyKnown.setError(new Response.Error(-32000, "already known"));
+
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(13),
+                nonce -> "0x07",
+                raw -> alreadyKnown
+        );
+
+        assertThat(stateStore.load(SIGNER).outcome())
+                .isEqualTo(BsnBesuNonceStateStore.Outcome.UNKNOWN);
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(13),
+                nonce -> "0x08",
+                BsnBesuNonceCoordinatorTest::accepted
+        )).isInstanceOf(IllegalStateException.class);
+    }
+
+    /**
+     * 验证同时包含 error 与 result 的冲突响应不能被当作可回滚的明确拒绝。
+     */
+    @Test
+    void shouldTreatConflictingErrorAndResultAsUnknown() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+        String signedRawTransaction = "0x0711";
+        EthSendTransaction conflicting = responseWithHash(Hash.sha3(signedRawTransaction));
+        conflicting.setError(new Response.Error(-32602, "invalid params"));
+
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(14),
+                nonce -> signedRawTransaction,
+                raw -> conflicting
+        );
+
+        BsnBesuNonceStateStore.PersistedState state = stateStore.load(SIGNER);
+        assertThat(state.outcome()).isEqualTo(BsnBesuNonceStateStore.Outcome.UNKNOWN);
+        assertThat(state.nextNonce()).isEqualTo(BigInteger.valueOf(15));
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(14),
+                nonce -> "0x0712",
+                BsnBesuNonceCoordinatorTest::accepted
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("manual reconciliation");
+    }
+
+    /**
+     * 验证节点返回与本地签名 payload 不匹配的 hash 时按 UNKNOWN 处理。
+     */
+    @Test
+    void shouldRejectMismatchedTransactionHashWithoutRollback() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+
+        assertThatThrownBy(() -> coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(15),
+                nonce -> "0x09",
+                raw -> responseWithHash("0x" + "a".repeat(64))
+        )).isInstanceOf(IOException.class)
+                .hasMessageContaining("invalid transaction response");
+
+        BsnBesuNonceStateStore.PersistedState state = stateStore.load(SIGNER);
+        assertThat(state.outcome()).isEqualTo(BsnBesuNonceStateStore.Outcome.UNKNOWN);
+        assertThat(state.nextNonce()).isEqualTo(BigInteger.valueOf(16));
+    }
+
+    /**
+     * 验证节点 PENDING 超过本地高水位时选择节点值继续发送。
+     */
+    @Test
+    void shouldAdvanceToNodePendingWhenNodeMovesAhead() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(3),
+                nonce -> "0x0a",
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        AtomicReference<BigInteger> selectedNonce = new AtomicReference<>();
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(20),
+                nonce -> {
+                    selectedNonce.set(nonce);
+                    return "0x0b";
+                },
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        assertThat(selectedNonce).hasValue(BigInteger.valueOf(20));
+    }
+
+    /**
+     * 验证同一 signer 的大小写形式共享同一 nonce 状态。
+     */
+    @Test
+    void shouldCanonicalizeSignerAddress() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+        coordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(30),
+                nonce -> "0x0c",
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        AtomicReference<BigInteger> selectedNonce = new AtomicReference<>();
+        coordinator.send(
+                SIGNER.toUpperCase(),
+                () -> BigInteger.valueOf(30),
+                nonce -> {
+                    selectedNonce.set(nonce);
+                    return "0x0d";
+                },
+                BsnBesuNonceCoordinatorTest::accepted
+        );
+
+        assertThat(selectedNonce).hasValue(BigInteger.valueOf(31));
+    }
+
+    /**
+     * 验证不同 signer 的广播临界区可并行进入，不受全局锁串行化。
+     */
+    @Test
+    void shouldCoordinateDifferentSignersInParallel() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator coordinator = new BsnBesuNonceCoordinator(stateStore);
+        CyclicBarrier broadcastBarrier = new CyclicBarrier(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<EthSendTransaction> first = executor.submit(() -> coordinator.send(
+                    SIGNER,
+                    () -> BigInteger.ZERO,
+                    nonce -> "0x0e",
+                    raw -> awaitAndAccept(broadcastBarrier, raw)
+            ));
+            Future<EthSendTransaction> second = executor.submit(() -> coordinator.send(
+                    OTHER_SIGNER,
+                    () -> BigInteger.ZERO,
+                    nonce -> "0x0f",
+                    raw -> awaitAndAccept(broadcastBarrier, raw)
+            ));
+
+            assertThat(first.get(5, TimeUnit.SECONDS).getTransactionHash()).isNotBlank();
+            assertThat(second.get(5, TimeUnit.SECONDS).getTransactionHash()).isNotBlank();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * 验证新 coordinator 进程视图会恢复 UNKNOWN 高水位并阻止 nonce 重用。
+     */
+    @Test
+    void shouldRestoreUnknownStateAcrossCoordinatorRestart() throws Exception {
+        InMemoryStateStore stateStore = new InMemoryStateStore();
+        BsnBesuNonceCoordinator firstCoordinator = new BsnBesuNonceCoordinator(stateStore);
+        assertThatThrownBy(() -> firstCoordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(40),
+                nonce -> "0x10",
+                raw -> {
+                    throw new IOException("timeout");
+                }
+        )).isInstanceOf(IOException.class);
+
+        BsnBesuNonceCoordinator restartedCoordinator = new BsnBesuNonceCoordinator(stateStore);
+        assertThatThrownBy(() -> restartedCoordinator.send(
+                SIGNER,
+                () -> BigInteger.valueOf(40),
+                nonce -> "0x11",
+                BsnBesuNonceCoordinatorTest::accepted
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("unresolved broadcast");
+    }
+
+    /**
+     * 验证 ACCEPTED 状态必须保存完全一致的本地与远端交易哈希。
+     */
+    @Test
+    void shouldRejectAcceptedStateWithMismatchedHashes() {
+        assertThatThrownBy(() -> new BsnBesuNonceStateStore.PersistedState(
+                BigInteger.valueOf(51),
+                BigInteger.valueOf(50),
+                BsnBesuNonceStateStore.Outcome.ACCEPTED,
+                "0x" + "a".repeat(64),
+                "0x" + "b".repeat(64)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("inconsistent with outcome ACCEPTED");
+    }
+
+    /**
+     * 在 barrier 中等待另一个 signer 后返回与本地 payload 匹配的成功响应。
+     */
+    private static EthSendTransaction awaitAndAccept(CyclicBarrier barrier, String raw)
+            throws Exception {
+        barrier.await(3, TimeUnit.SECONDS);
+        return accepted(raw);
+    }
+
+    /**
+     * 创建交易哈希与本地签名 payload 一致的成功响应。
+     */
+    private static EthSendTransaction accepted(String signedRawTransaction) {
+        return responseWithHash(Hash.sha3(signedRawTransaction));
+    }
+
+    /**
+     * 创建指定交易哈希的 Web3j 广播响应。
+     */
+    private static EthSendTransaction responseWithHash(String transactionHash) {
+        EthSendTransaction response = new EthSendTransaction();
+        response.setResult(transactionHash);
+        return response;
+    }
+
+    /**
+     * 为 coordinator 状态机测试提供线程安全的 durable store 替身。
+     */
+    private static final class InMemoryStateStore implements BsnBesuNonceStateStore {
+        private final Map<String, PersistedState> states = new ConcurrentHashMap<>();
+
+        /**
+         * 按规范化 signer 读取测试状态。
+         */
+        @Override
+        public PersistedState load(String canonicalSigner) {
+            return states.get(canonicalSigner.toLowerCase());
+        }
+
+        /**
+         * 按规范化 signer 保存测试状态。
+         */
+        @Override
+        public void save(String canonicalSigner, PersistedState state) {
+            states.put(canonicalSigner.toLowerCase(), state);
+        }
+    }
+}

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuWriterLockProcess.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/BsnBesuWriterLockProcess.java
@@ -1,0 +1,56 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import cn.flying.fisco_bcos.config.BsnBesuConfig;
+import org.web3j.crypto.Credentials;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * 在独立 JVM 中持有 BSN Besu signer 文件锁，供跨进程门禁测试使用。
+ */
+public final class BsnBesuWriterLockProcess {
+
+    private BsnBesuWriterLockProcess() {
+    }
+
+    /**
+     * 获取指定 signer 的 writer 锁，写入 ready 文件后等待父进程关闭标准输入。
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 4) {
+            throw new IllegalArgumentException(
+                    "Expected arguments: <stateDirectory> <chainId> <privateKey> <readyFile>"
+            );
+        }
+
+        Path stateDirectory = Path.of(args[0]);
+        long chainId = Long.parseLong(args[1]);
+        Credentials credentials = Credentials.create(args[2]);
+        Path readyFile = Path.of(args[3]);
+
+        BsnBesuConfig config = new BsnBesuConfig();
+        config.setChainId(chainId);
+        config.getNonce().setStateDirectory(stateDirectory.toString());
+
+        BsnBesuFileNonceStateStore store =
+                new BsnBesuFileNonceStateStore(config, credentials);
+        try {
+            store.initialize();
+            Files.writeString(
+                    readyFile,
+                    "locked\n",
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW,
+                    StandardOpenOption.WRITE
+            );
+            while (System.in.read() != -1) {
+                // 父进程保持标准输入打开期间持续持有 signer 锁。
+            }
+        } finally {
+            store.close();
+        }
+    }
+}


### PR DESCRIPTION
## 背景

P1 阶段综合代码审查发现：BSN Besu 的所有链写在发送前读取 `LATEST` nonce，并发执行 batch 与普通写时可能为不同 payload 分配同一 nonce。该缺陷不是 `ROADMAP_new.md` 的独立条目，但会破坏 P1 链写稳定性，必须在后续 TenantFilter 子任务前按依赖闭环。

关联 Trellis 子任务：`roadmap-p1-bsn-besu-nonce-coordination`  
父任务：`07-13-roadmap-p1-proof-productization`  
基线：`origin/main@38fa7fa71f8ec12e61b57efe60727c587a586a1d`

## 变更范围

- 为每个规范化 signer 增加 nonce coordinator：
  - 使用节点 `PENDING` nonce 与本地 durable high watermark 安全选取 nonce；
  - 同 signer 的查询、构造/签名、BROADCASTING 预写、同步广播分类和状态推进处于同一临界区；
  - receipt 轮询位于锁外，不造成确认期串行；
  - 不同 signer 使用独立锁，可并行发送。
- 将本地失败、明确拒绝、BROADCASTING、ACCEPTED、UNKNOWN 分开建模：
  - 网络超时、断连、`already known`、nonce 冲突、错误/result 冲突、无效或不匹配 hash 均保守视为未决，不回退 nonce；
  - 只有节点 `PENDING > lastNonce` 才自动解除未决门禁。
- 增加原子持久状态和单 writer/signer 门禁：
  - 同目录临时文件、文件 fsync、原子替换、目录 fsync；
  - `(chainId, signer)` 生命周期文件锁；
  - 状态文件不保存私钥或 signed raw transaction。
- 所有五类 Besu 写入口统一经过 coordinator：
  `storeFile`、`storeAttestationBatch`、`deleteFiles`、`shareFiles`、`cancelShare`。
- 补充非 root Docker 目录、具名持久卷及 CI 两容器写入/持久性 smoke test。
- 同步中英文配置、Compose、生产部署、故障恢复和回滚文档；移除完整 RPC URL 日志。

## 验收与测试证据

- `platform-fisco`: 158 tests passed；其中新增 28 个 nonce 聚焦测试，覆盖：
  - batch + 普通写、batch + batch barrier 并发与真实 raw transaction 解码；
  - 五类写入口统一路由；
  - 本地失败、明确拒绝、广播未知、冲突响应、hash 不匹配；
  - 重启恢复、持久化失败禁止广播、receipt 锁外等待；
  - 不同 signer 并行、同 signer/chain 跨 JVM 单 writer 与冷备接管。
- `platform-backend` 单元测试：common 241、service 932、web 355，全部通过；package 通过。
- `platform-storage`: 169 tests passed；`platform-verifier`: SDK 119、CLI 10、Web 28 tests passed；各模块 package 通过。
- 前端：Prettier、ESLint、Svelte check、464/464 tests、coverage、生产构建、OpenAPI generated types drift check 全部通过。
- 合同/文档：59/59 Python contract tests、artifact fingerprint verify/临时 refresh 一致性、routes/env/roadmap/versions、VitePress build、中英文 Compose YAML/20 项环境变量一致性、shell syntax 全部通过。
- 静态与安全：`actionlint`、`git diff --check`、生产 raw-send 路径核对通过；本地 Trivy CRITICAL/HIGH vulnerability、secret、misconfiguration 均为 0。
- 完整人工审查已执行；发现的一处未决广播恢复文档偏差已修复并复审关闭，无剩余高置信缺陷。

本机没有 Docker，因此 `-Pit` 的 Testcontainers 集成测试无法在本地启动：44 个容器用例由 Testcontainers 跳过，`ProofStatusTimestampMigrationIT` 在容器初始化阶段失败，没有业务断言失败。未删除、屏蔽或跳过任何门禁；本 PR 必须等待 GitHub CI 在真实 Docker 环境执行全部 IT、FISCO 镜像构建及非 root 具名卷 smoke 后才能合并。

Security PoC 将在此功能分支上单独触发并审阅 Semgrep、Trivy 与 SBOM 产物。

## 影响与风险

- BSN Besu 模式现在强制要求 `BSN_BESU_NONCE_STATE_DIRECTORY`；目录必须持久化并支持可靠文件锁、原子替换与目录 fsync。
- 同一 signer 不支持独立主机上的无协调 active-active；必须使用单 writer、冷备 fencing、不同 signer 或另行审查的分布式协调器。
- UNKNOWN/BROADCASTING 会失败关闭；如果 provider 的 PENDING 未推进，必须人工对账，避免用同 nonce 发送不同 payload。
- 不改变既有合约 ABI、chainId 签名格式、业务接口、批次状态机或 receipt 处理语义。

## 回滚

1. 合并回滚本提交；
2. 停止并 fence 所有持有该 signer 的 writer；
3. 保留并归档 nonce 状态目录，按 `lastNonce`、本地 hash、provider pending/latest 完成对账；
4. 只有确认未接受且服务完全停止时，才按文档移出状态文件；不得通过删除状态或重启来盲目复用 nonce。

合并条件：代码审查通过、全部 CI 与 Security PoC 结果审阅通过、无未解决意见、无冲突、验收标准全部满足。