### PR TITLE
fix: harden tenant filter boundaries

### DIFF
--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
@@ -20,6 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Enumeration;
 import java.util.Set;
 import java.util.UUID;
 
@@ -34,6 +35,7 @@ public class TenantFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(TenantFilter.class);
     private static final String TENANT_HEADER = "X-Tenant-ID";
+    private static final String SSE_CONNECT_PATH = "/api/v1/sse/connect";
 
     /**
      * 全局公开 proof 路径不依赖租户查询，必须忽略匿名调用者提供的租户头。
@@ -89,33 +91,33 @@ public class TenantFilter extends OncePerRequestFilter {
                 requestPath = requestUri;
             }
 
-            // 检查是否在白名单中
-            if (isWhitelisted(requestPath)) {
-                // 公开 proof 必须忽略租户头；其他白名单路径仍可使用租户头完成租户隔离查询
-                if (!shouldIgnoreTenantHeader(requestPath)) {
-                    String tenantIdHeader = request.getHeader(TENANT_HEADER);
-                    if (tenantIdHeader != null && !tenantIdHeader.isEmpty()) {
-                        try {
-                            Long tenantId = Long.parseLong(tenantIdHeader);
-                            TenantContext.setTenantId(tenantId);
-                            request.setAttribute(Const.ATTR_TENANT_ID, tenantId);
-                        } catch (NumberFormatException e) {
-                            log.warn("租户ID格式错误: {}", tenantIdHeader);
-                            sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
-                            return;
-                        }
-                    }
-                }
+            boolean whitelisted = isWhitelisted(requestPath);
+
+            // 公开 proof 必须完整忽略调用者租户头，包括重复或畸形值
+            if (whitelisted && shouldIgnoreTenantHeader(requestPath)) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            // 从请求头获取租户ID
+            // 租户身份头必须唯一，避免代理与 Servlet 对重复头采用不同解释
+            if (hasMultipleTenantHeaders(request)) {
+                log.warn("请求包含重复的租户ID头: {} {}", request.getMethod(), requestUri);
+                sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
+                return;
+            }
+
             String tenantIdHeader = request.getHeader(TENANT_HEADER);
 
-            if (tenantIdHeader == null || tenantIdHeader.isEmpty()) {
+            // 显式空头属于畸形租户身份，不能降级成“未提供”或让 SSE query 覆盖
+            if (tenantIdHeader != null && tenantIdHeader.isEmpty()) {
+                log.warn("租户ID头为空: {} {}", request.getMethod(), requestUri);
+                sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
+                return;
+            }
+
+            if (tenantIdHeader == null) {
                 // 仅对 SSE 连接接口允许从参数中获取租户ID，因为 EventSource 不支持自定义 Header
-                if (requestPath.contains("/sse/connect")) {
+                if (SSE_CONNECT_PATH.equals(requestPath)) {
                     tenantIdHeader = request.getParameter("x-tenant-id");
                     if (tenantIdHeader == null || tenantIdHeader.isEmpty()) {
                         tenantIdHeader = request.getParameter("tenantId");
@@ -124,25 +126,33 @@ public class TenantFilter extends OncePerRequestFilter {
             }
 
             if (tenantIdHeader == null || tenantIdHeader.isEmpty()) {
+                if (whitelisted) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
                 log.warn("请求缺少租户ID: {} {}", request.getMethod(), requestUri);
                 sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "缺少租户标识 (X-Tenant-ID)");
                 return;
             }
 
+            Long tenantId;
             try {
-                Long tenantId = Long.parseLong(tenantIdHeader);
-                // 设置租户上下文（会被 MyBatis-Plus 租户拦截器使用）
-                TenantContext.setTenantId(tenantId);
-                // 存储到请求属性，供 JWT 过滤器之后使用
-                request.setAttribute(Const.ATTR_TENANT_ID, tenantId);
-
-                log.debug("租户上下文已设置: tenantId={}, uri={}", tenantId, requestUri);
-
-                filterChain.doFilter(request, response);
+                tenantId = Long.parseLong(tenantIdHeader);
             } catch (NumberFormatException e) {
                 log.warn("租户ID格式错误: {}", tenantIdHeader);
                 sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
+                return;
             }
+
+            // 设置租户上下文（会被 MyBatis-Plus 租户拦截器使用）
+            TenantContext.setTenantId(tenantId);
+            // 存储到请求属性，供 JWT 过滤器之后使用
+            request.setAttribute(Const.ATTR_TENANT_ID, tenantId);
+
+            log.debug("租户上下文已设置: tenantId={}, uri={}", tenantId, requestUri);
+
+            // 解析异常捕获必须止于租户头，避免吞掉下游业务抛出的 NumberFormatException
+            filterChain.doFilter(request, response);
             // 注意：正常路径不在这里清理 TenantContext，由 JwtAuthenticationFilter 统一清理
         } finally {
             TenantContext.clear();
@@ -159,24 +169,40 @@ public class TenantFilter extends OncePerRequestFilter {
         if (uri == null) {
             return false;
         }
-        if (uri.startsWith("/api/v1/shares/") && uri.endsWith("/info")) {
+        if (uri.matches("^/api/v1/shares/[^/]+/info/?$")) {
             return true;
         }
         if (uri.matches("^/api/v1/shares/[^/]+/files/?$")) {
             return true;
         }
-        return WHITELIST_PATHS.stream().anyMatch(uri::startsWith);
+        return WHITELIST_PATHS.stream().anyMatch(prefix -> matchesPathOrDescendant(uri, prefix));
     }
 
     /**
      * 判断白名单路径是否必须忽略请求租户头，并使用路径段边界避免相似前缀误匹配。
      */
     private boolean shouldIgnoreTenantHeader(String uri) {
-        if (uri == null) {
+        return TENANT_HEADER_IGNORED_PATHS.stream()
+                .anyMatch(prefix -> matchesPathOrDescendant(uri, prefix));
+    }
+
+    /**
+     * 检查请求是否包含多个租户身份头；重复值同样视为有歧义并拒绝。
+     */
+    private boolean hasMultipleTenantHeaders(HttpServletRequest request) {
+        Enumeration<String> values = request.getHeaders(TENANT_HEADER);
+        if (values == null || !values.hasMoreElements()) {
             return false;
         }
-        return TENANT_HEADER_IGNORED_PATHS.stream()
-                .anyMatch(prefix -> uri.equals(prefix) || uri.startsWith(prefix + "/"));
+        values.nextElement();
+        return values.hasMoreElements();
+    }
+
+    /**
+     * 按完整路径段匹配白名单族，避免相似字符串前缀被误认为公开路径。
+     */
+    private boolean matchesPathOrDescendant(String path, String prefix) {
+        return path.equals(prefix) || path.startsWith(prefix + "/");
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
@@ -148,6 +148,30 @@ class TenantFilterTest {
     }
 
     /**
+     * 公开 proof 路径必须完整忽略重复租户头，避免新校验改变匿名 proof 合同。
+     */
+    @Test
+    @DisplayName("should ignore duplicate tenant headers for public proof endpoints")
+    void shouldIgnoreDuplicateTenantHeadersForPublicProofEndpoints() throws ServletException, IOException {
+        for (String path : new String[]{
+                "/api/v1/public/proofs/rp-proof-abc/status",
+                "/api/v1/public/proof-keys/key-main/versions/1"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+            request.setServletPath(path);
+            request.addHeader("X-Tenant-ID", "12");
+            request.addHeader("X-Tenant-ID", "13");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
+        }
+
+        verify(filterChain, times(2)).doFilter(any(), any());
+    }
+
+    /**
      * 与公开 proof 前缀相似但不在该路径族内的请求不得误用忽略规则。
      */
     @Test
@@ -197,6 +221,118 @@ class TenantFilterTest {
         assertEquals(12L, capturedTenantId.get());
         assertEquals(12L, request.getAttribute(Const.ATTR_TENANT_ID));
         assertNull(TenantContext.getTenantId());
+    }
+
+    /**
+     * 非 proof 白名单路径携带畸形租户头时应返回 400，且不得污染请求属性或线程租户上下文。
+     */
+    @Test
+    @DisplayName("should reject invalid tenant header for non-proof whitelisted path")
+    void shouldRejectInvalidTenantHeaderForNonProofWhitelistedPath() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/shares/abc/info");
+        request.setServletPath("/api/v1/shares/abc/info");
+        request.addHeader("X-Tenant-ID", "invalid-tenant");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        TenantContext.setTenantId(999L);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain, never()).doFilter(request, response);
+        assertEquals(400, response.getStatus());
+        assertTrue(response.getContentAsString().contains(String.valueOf(ResultEnum.PARAM_IS_INVALID.getCode())));
+        assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+        assertNull(TenantContext.getTenantId());
+    }
+
+    /**
+     * 显式空租户头必须按畸形输入拒绝；SSE 也不得用 query 参数覆盖调用方已提供的空头。
+     */
+    @Test
+    @DisplayName("should reject a single empty tenant header outside public proof endpoints")
+    void shouldRejectSingleEmptyTenantHeaderOutsidePublicProofEndpoints() throws ServletException, IOException {
+        for (String path : new String[]{"/api/v1/shares/abc/info", "/api/v1/sse/connect"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+            request.setServletPath(path);
+            request.addHeader("X-Tenant-ID", "");
+            request.addParameter("x-tenant-id", "7");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            TenantContext.setTenantId(999L);
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(400, response.getStatus());
+            assertTrue(response.getContentAsString()
+                    .contains(String.valueOf(ResultEnum.PARAM_IS_INVALID.getCode())));
+            assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
+        }
+
+        verifyNoInteractions(filterChain);
+    }
+
+    /**
+     * 非 proof 白名单和受保护路径都必须拒绝重复租户头，避免有歧义的租户身份被静默采用。
+     */
+    @Test
+    @DisplayName("should reject duplicate tenant headers outside public proof endpoints")
+    void shouldRejectDuplicateTenantHeadersOutsidePublicProofEndpoints() throws ServletException, IOException {
+        String[] paths = {"/api/v1/shares/abc/info", "/api/v1/files"};
+        String[][] duplicateValues = {
+                {"12", "12"},
+                {"12", "13"},
+                {"", "12"},
+                {"12", ""}
+        };
+
+        for (String path : paths) {
+            for (String[] values : duplicateValues) {
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+                request.setServletPath(path);
+                request.addHeader("X-Tenant-ID", values[0]);
+                request.addHeader("X-Tenant-ID", values[1]);
+                MockHttpServletResponse response = new MockHttpServletResponse();
+
+                TenantContext.setTenantId(999L);
+
+                filter.doFilterInternal(request, response, filterChain);
+
+                assertEquals(400, response.getStatus());
+                assertTrue(response.getContentAsString()
+                        .contains(String.valueOf(ResultEnum.PARAM_IS_INVALID.getCode())));
+                assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+                assertNull(TenantContext.getTenantId());
+            }
+        }
+
+        verifyNoInteractions(filterChain);
+    }
+
+    /**
+     * 与白名单相似但缺少路径段边界的请求必须按受保护路径处理。
+     */
+    @Test
+    @DisplayName("should reject paths with whitelisted prefix but no segment boundary")
+    void shouldRejectPathsWithWhitelistedPrefixButNoSegmentBoundary() throws ServletException, IOException {
+        for (String path : new String[]{
+                "/api/v1/public/proofs-admin",
+                "/actuator/healthcheck",
+                "/swagger-ui-admin",
+                "/api/v1/images/download-private",
+                "/api/v1/shares/abc/extra/info"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+            request.setServletPath(path);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(400, response.getStatus());
+            assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
+        }
+
+        verifyNoInteractions(filterChain);
     }
 
     /**
@@ -288,6 +424,29 @@ class TenantFilterTest {
     }
 
     /**
+     * 下游抛出的 NumberFormatException 必须原样传播，不能被误写成租户头格式错误。
+     */
+    @Test
+    @DisplayName("should propagate number format exception from downstream filter")
+    void shouldPropagateNumberFormatExceptionFromDownstreamFilter() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/files");
+        request.setServletPath("/api/v1/files");
+        request.addHeader("X-Tenant-ID", "12");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        NumberFormatException downstreamFailure = new NumberFormatException("downstream failure");
+        doThrow(downstreamFailure).when(filterChain).doFilter(request, response);
+
+        NumberFormatException actual = assertThrows(NumberFormatException.class,
+                () -> filter.doFilterInternal(request, response, filterChain));
+
+        assertSame(downstreamFailure, actual);
+        assertEquals(200, response.getStatus());
+        assertEquals("", response.getContentAsString());
+        assertEquals(12L, request.getAttribute(Const.ATTR_TENANT_ID));
+        assertNull(TenantContext.getTenantId());
+    }
+
+    /**
      * SSE 连接端点允许从 query 参数读取租户 ID（EventSource 不支持自定义 Header）。
      */
     @Test
@@ -314,5 +473,30 @@ class TenantFilterTest {
         assertEquals(7L, request.getAttribute(Const.ATTR_TENANT_ID));
         // 过滤器完成后 TenantContext 应被清理
         assertNull(TenantContext.getTenantId());
+    }
+
+    /**
+     * 只有精确 SSE connect 路径允许 query 租户参数，相似路径仍必须提供租户头。
+     */
+    @Test
+    @DisplayName("should only use query tenant for exact SSE connect path")
+    void shouldOnlyUseQueryTenantForExactSseConnectPath() throws ServletException, IOException {
+        for (String path : new String[]{
+                "/api/v1/sse/connectivity",
+                "/api/v1/admin/sse/connect",
+                "/api/v1/sse/connect/extra"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+            request.setServletPath(path);
+            request.addParameter("tenantId", "7");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(400, response.getStatus());
+            assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
+        }
+
+        verifyNoInteractions(filterChain);
     }
 }


### PR DESCRIPTION
## 关联任务

- 父任务：`07-13-roadmap-p1-proof-productization`
- 当前子任务：`07-16-roadmap-p1-tenant-filter-negative-coverage`
- 前置基线：`origin/main@f1730b8a590f9a6f6399c3e6b0a053a9582c87ed`（PR #300 已合并并完成 exact-main 验证）

## 问题背景

PR #292 的历史 Codecov patch 失败暴露出 TenantFilter 可达负向路径覆盖不足。进一步人工审查确认：重复租户头、相似白名单前缀、伪 SSE 路径、显式空租户头以及过宽的 `NumberFormatException` 捕获均可能造成歧义、失败开放或错误响应被误写。

## 修改范围

- public proof 路径继续在任何租户头读取或校验前放行，兼容数字、畸形、空值和重复租户头。
- 非 public-proof 请求拒绝重复及单个显式空 `X-Tenant-ID`；SSE query 不得覆盖显式空头。
- 将租户 ID 的 `NumberFormatException` 捕获范围收窄到 `Long.parseLong`，下游同类异常原样传播。
- 静态白名单仅按精确路径或路径段后代匹配；动态 share info/files 路径仅允许单个 shareCode 段。
- SSE query 租户回退仅允许精确 `/api/v1/sse/connect`。
- 删除真实过滤链不可达的 private null 分支，不添加反射或实现细节测试。
- 仅修改 `TenantFilter.java` 与 `TenantFilterTest.java`；无 API、数据库、配置或依赖变更。

## 测试证据

- TenantFilter 目标测试：19/19 通过。
- 后端 `clean verify`：backend-web 362 项通过，JaCoCo 全模块门禁通过；21 项 Docker 依赖测试在本机无 Docker 时按条件跳过。
- API：7 项通过；Verifier SDK/CLI/Web：119/10/28 项通过；FISCO：158 项通过；Storage：169 项通过。
- 前端：format、lint、Svelte check（0 errors/0 warnings）、464 项覆盖率测试和生产构建全部通过。
- 合同测试：59/59；指纹 2 项；routes/env/roadmap/versions 四项文档一致性；OpenAPI `generated.ts` 字节级无漂移；VitePress 构建通过。
- `actionlint`、`git diff --check` 通过。
- Trivy `CRITICAL,HIGH` 依赖漏洞：0；secret/misconfiguration：0。
- TenantFilter 最终覆盖：76/78 行、38/48 分支；生产 patch 可执行行 30/30 命中，估算 patch 分支 25/26 命中。
- 本机缺少 Docker，`-Pit` 的 44 项容器测试无法形成有效本地通过证据，且 `ProofStatusTimestampMigrationIT` 在容器初始化处失败；必须由本 PR CI 的真实容器环境完成验收，不做跳过或降级。

## 审查与验收

- 已人工检查租户隔离、重复/空 header 歧义、白名单路径边界、SSE 兼容、ThreadLocal/MDC 清理、下游异常传播、接口兼容与性能影响。
- 独立终审首次发现单空头绕过后已修复；修复后复审无高置信阻塞项。
- 未使用 security 插件；本 PR 将另外触发仓库原生 Security PoC，并与 exact-main 基线归一化比对 Semgrep、Trivy 与 SBOM 制品。
- 合并前要求全部必需 CI、CodeQL/Codecov、Security Scan、合同/构建门禁通过，无未解决审查意见、无冲突。

## 风险评估

- 低到中风险：畸形、重复或相似前缀请求会由历史上的宽松处理改为 HTTP 400，这是预期的失败关闭。
- public proof、合法普通白名单租户头、合法受保护路径及缺少自定义 header 的标准 SSE query 合同均有回归覆盖。
- 新增 header 枚举和少量路径匹配仅发生于单次请求过滤，未引入外部 I/O 或共享状态。

## 回滚方式

回滚本 PR 的单个提交即可；无数据库迁移、配置变更、缓存键变更或数据修复步骤。
