### PR TITLE
fix: harden SSE tenant trust boundary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,6 +225,35 @@ jobs:
                   )
           PY
 
+      - name: Require SSE Audit Tenant Isolation IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.controller.SseAuditTenantIsolationIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          expected_counts = {
+              "tests": 4,
+              "skipped": 0,
+              "failures": 0,
+              "errors": 0,
+          }
+          for name, expected in expected_counts.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"SseAuditTenantIsolationIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Run FISCO Tests
         run: mvn -f platform-fisco/pom.xml test
 

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -84,7 +84,7 @@ POST /api/v1/auth/login
 - `GET /api/v1/shares/{shareCode}/info` - Get share basic info (public)
 - `GET /api/v1/public/proofs/{proofId}/status` - Resolve current signed-proof status
 - `GET /api/v1/public/proof-keys/{keyId}/versions/{keyVersion}` - Resolve a versioned proof verification key
-- `GET /api/v1/sse/connect?token=...` - SSE connect entry (short-lived token required)
+- `GET /api/v1/sse/connect?token=...&x-tenant-id=...` - SSE connect entry (short-lived token required; tenant value is an untrusted Redis namespace hint)
 
 `POST /api/v1/auth/logout` is also handled by Spring Security (non-controller endpoint) and requires authenticated context.
 
@@ -2493,10 +2493,12 @@ Server-Sent Events for real-time push notifications.
 Establish SSE connection for real-time updates.
 
 ```
-GET /api/v1/sse/connect
+GET /api/v1/sse/connect?token=<sseToken>&x-tenant-id=<tenantHint>
 ```
 
 **Authentication**: Short-lived SSE token in query param (`token`), obtained via `POST /api/v1/auth/tokens/sse` with Bearer JWT.
+
+`X-Tenant-ID` header, `x-tenant-id` query (or legacy `tenantId` query) only locate the existing tenant-scoped Redis token key. The atomically consumed token supplies the trusted tenant, user, and role; a mismatch, replay, expiry, damaged payload, or Redis failure creates no emitter. Raw one-time tokens are not persisted in operation audit parameters.
 
 **Response**: `text/event-stream`
 
@@ -3937,7 +3939,7 @@ GET /api/v1/admin/attestation-batches/production/status
 SSE short-lived token flow:
 
 1. `POST /api/v1/auth/tokens/sse` with JWT
-2. `GET /api/v1/sse/connect?token=<sseToken>&connectionId=<optional>`
+2. `GET /api/v1/sse/connect?token=<sseToken>&x-tenant-id=<tenantHint>`
 
 Current event types include:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@
 |------|--------|----------|
 | REST 控制器 | 30 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 134 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 153 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 154 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 33（V1.0.0 ~ V1.15.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | CI 流水线（核心） | 5 | `.github/workflows/test.yml`, `perf-smoke.yml`, `docs.yml`, `security-poc.yml`, `docs-consistency.yml` |
 

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -46,7 +46,7 @@ Based on `SecurityConfiguration`:
 ### 3) SSE dual-token flow
 
 - `POST /api/v1/auth/tokens/sse`: requires standard JWT
-- `GET /api/v1/sse/connect?token=...`: public route, but short-lived one-time token is mandatory
+- `GET /api/v1/sse/connect?token=...&x-tenant-id=...`: public route, but a short-lived one-time token is mandatory. The tenant query value is only a Redis namespace hint; the consumed token is the authority for tenant, user, and role.
 
 ## Endpoints by Module
 
@@ -321,8 +321,10 @@ Recommended flow:
 
 ```text
 1) POST /api/v1/auth/tokens/sse   (Authorization: Bearer <jwt>)
-2) GET  /api/v1/sse/connect?token=<sseToken>&connectionId=<optional>
+2) GET  /api/v1/sse/connect?token=<sseToken>&x-tenant-id=<tenantHint>
 ```
+
+Clients capable of custom headers may use `X-Tenant-ID`; `tenantId` remains accepted as a legacy query alias for `x-tenant-id`. A missing or mismatched hint, an invalid/expired/consumed token, or a damaged token payload fails before an emitter is created. The raw one-time token is omitted from operation logs and persisted audit parameters.
 
 Typical event types:
 

--- a/docs/en/architecture/security.md
+++ b/docs/en/architecture/security.md
@@ -25,8 +25,10 @@ EventSource doesn't support custom headers, so SSE uses URL token:
 
 ```
 1. POST /api/v1/auth/tokens/sse → Get short-lived token (30s, single-use)
-2. GET /api/v1/sse/connect?token=<token> → Establish SSE connection
+2. GET /api/v1/sse/connect?token=<token>&x-tenant-id=<tenantHint> → Establish SSE connection
 ```
+
+The `X-Tenant-ID` header, `x-tenant-id` query value, and legacy `tenantId` query value are untrusted namespace hints only. `TenantContext`, request audit attributes, and MDC identity are established only after Redis atomically consumes the token and its tenant matches the hint. Invalid, expired, replayed, damaged, mismatched, or Redis-failed handshakes create no emitter. Anonymous failures are audited under system tenant `0`, and raw one-time tokens are excluded from text logs and persisted request parameters.
 
 ## Authorization (RBAC)
 

--- a/docs/en/architecture/system-overview.md
+++ b/docs/en/architecture/system-overview.md
@@ -507,9 +507,9 @@ flowchart LR
 SSE connections use a short-lived one-time token:
 
 1. Call `POST /api/v1/auth/tokens/sse` with regular JWT auth
-2. Connect via `GET /api/v1/sse/connect?token={sseToken}&connectionId={optional}`
+2. Connect via `GET /api/v1/sse/connect?token={sseToken}&x-tenant-id={tenantHint}`
 
-> `GET /api/v1/sse/connect` is publicly exposed in Spring Security but still requires valid short-lived token authentication.
+> `GET /api/v1/sse/connect` is publicly exposed in Spring Security but still requires valid short-lived token authentication. The tenant value is only a Redis namespace hint; validated token tenant/user/role data is authoritative.
 
 ### Monitoring Capacity Semantics
 

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -46,7 +46,7 @@ Authorization: Bearer <token>
 ### 3) SSE 双令牌模式
 
 - `POST /api/v1/auth/tokens/sse`：需要常规 JWT（登录态）
-- `GET /api/v1/sse/connect?token=...`：公开路由，但必须携带有效一次性短期令牌
+- `GET /api/v1/sse/connect?token=...&x-tenant-id=...`：公开路由，但必须携带有效一次性短期令牌。租户 query 值只用于定位 Redis namespace，连接的租户、用户和角色以消费后的短令牌为准。
 
 ## API 端点（按模块）
 
@@ -321,8 +321,10 @@ Authorization: Bearer <token>
 
 ```text
 1) POST /api/v1/auth/tokens/sse   (Authorization: Bearer <jwt>)
-2) GET  /api/v1/sse/connect?token=<sseToken>&connectionId=<optional>
+2) GET  /api/v1/sse/connect?token=<sseToken>&x-tenant-id=<tenantHint>
 ```
+
+可设置自定义请求头的客户端也可使用 `X-Tenant-ID`；旧 `tenantId` query 参数继续作为 `x-tenant-id` 的兼容别名。提示缺失或与令牌租户不一致、令牌无效/过期/已消费、载荷损坏时，服务端会在创建 emitter 前失败关闭；一次性 token 原文不会写入操作日志或数据库审计参数。
 
 常见事件类型：
 

--- a/docs/zh/architecture/security.md
+++ b/docs/zh/architecture/security.md
@@ -25,8 +25,10 @@ EventSource 不支持自定义 Header，因此 SSE 使用 URL Token：
 
 ```
 1. POST /api/v1/auth/tokens/sse → 获取短期 Token（30 秒，一次性）
-2. GET /api/v1/sse/connect?token=<token> → 建立 SSE 连接
+2. GET /api/v1/sse/connect?token=<token>&x-tenant-id=<tenantHint> → 建立 SSE 连接
 ```
+
+`X-Tenant-ID` 请求头、`x-tenant-id` query 和旧 `tenantId` query 都只是不可信的 namespace 提示。只有 Redis 原子消费短令牌且令牌 tenant 与提示一致后，服务端才会建立 `TenantContext`、请求审计属性和 MDC 身份。无效、过期、重放、损坏、租户不匹配或 Redis 异常的握手均不会创建 emitter；匿名失败审计固定落在 system tenant `0`，一次性 token 原文不会进入文本日志和数据库请求参数。
 
 ## 授权 (RBAC)
 

--- a/docs/zh/architecture/system-overview.md
+++ b/docs/zh/architecture/system-overview.md
@@ -507,9 +507,9 @@ flowchart LR
 SSE 连接采用短期一次性令牌：
 
 1. 登录态下调用 `POST /api/v1/auth/tokens/sse` 获取短期令牌（需常规 JWT）
-2. 使用 `GET /api/v1/sse/connect?token={sseToken}&connectionId={optional}` 建立连接
+2. 使用 `GET /api/v1/sse/connect?token={sseToken}&x-tenant-id={tenantHint}` 建立连接
 
-> `GET /api/v1/sse/connect` 为公开端点，但依赖短期令牌完成认证；不是匿名开放连接。
+> `GET /api/v1/sse/connect` 为公开端点，但依赖短期令牌完成认证；不是匿名开放连接。租户值仅用于定位 Redis namespace，可信租户、用户和角色均来自验证后的短令牌。
 
 ### 监控容量口径
 

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/Const.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/Const.java
@@ -28,6 +28,7 @@ public final class Const {
     public final static String ATTR_USER_ID = "userId";
     public final static String ATTR_USER_ROLE = "userRole";
     public final static String ATTR_TENANT_ID = "tenantId";
+    public final static String ATTR_SSE_TENANT_HINT = "sseTenantHint";
     public final static String ATTR_REQ_ID = "reqId";
     public final static String ATTR_LOGIN_USERNAME = "loginUsername";
     //分布式追踪

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/JwtUtils.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/JwtUtils.java
@@ -403,7 +403,7 @@ public class JwtUtils {
         String value = userId + ":" + tenantId + ":" + role;
         template.opsForValue().set(key, value, Const.SSE_TOKEN_TTL, TimeUnit.SECONDS);
 
-        log.debug("SSE token created for user {}: {}", userId, token);
+        log.debug("SSE token created: userId={}, tenantId={}", userId, tenantId);
         return token;
     }
 
@@ -424,17 +424,17 @@ public class JwtUtils {
         // 原子性地获取并删除（防止并发消费）
         String value = template.opsForValue().getAndDelete(key);
         if (value == null) {
-            log.debug("SSE token not found or already consumed: {}", token);
+            log.debug("SSE token not found or already consumed");
             return null;
         }
 
-        String[] parts = value.split(":");
+        String[] parts = value.split(":", -1);
         if (parts.length != 3) {
-            log.warn("Invalid SSE token format: {}", token);
+            log.warn("Invalid SSE token payload format");
             return null;
         }
 
-        log.debug("SSE token consumed for user {}: {}", parts[0], token);
+        log.debug("SSE token consumed");
         return parts;
     }
 }

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/JwtUtilsTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/JwtUtilsTest.java
@@ -1,6 +1,10 @@
 package cn.flying.common.util;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -12,6 +16,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -510,6 +515,42 @@ class JwtUtilsTest {
             String[] result = jwtUtils.validateAndConsumeSseToken("malformed-token");
 
             assertThat(result).isNull();
+        }
+
+        /**
+         * 验证创建、未命中和损坏载荷日志都不会包含一次性短令牌原文。
+         */
+        @Test
+        @DisplayName("should never log raw SSE tokens")
+        void sseTokenOperations_neverLogRawTokens() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.getAndDelete(anyString()))
+                    .thenReturn(null, "invalid-format");
+
+            Logger jwtLogger = (Logger) LoggerFactory.getLogger(JwtUtils.class);
+            Level previousLevel = jwtLogger.getLevel();
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            jwtLogger.setLevel(Level.DEBUG);
+            jwtLogger.addAppender(appender);
+            List<String> sensitiveTokens = new java.util.ArrayList<>();
+            try {
+                sensitiveTokens.add(jwtUtils.createSseToken(123L, 456L, "user"));
+                sensitiveTokens.add("missing-sensitive-sse-token");
+                sensitiveTokens.add("malformed-sensitive-sse-token");
+                assertThat(jwtUtils.validateAndConsumeSseToken(sensitiveTokens.get(1))).isNull();
+                assertThat(jwtUtils.validateAndConsumeSseToken(sensitiveTokens.get(2))).isNull();
+            } finally {
+                jwtLogger.detachAppender(appender);
+                jwtLogger.setLevel(previousLevel);
+                appender.stop();
+            }
+
+            List<String> messages = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .toList();
+            assertThat(messages).allSatisfy(message ->
+                    assertThat(sensitiveTokens).noneMatch(message::contains));
         }
     }
 

--- a/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
@@ -17,6 +17,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.slf4j.MDC;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
@@ -142,14 +143,14 @@ public class OperationLogAspect {
                 authorities = user.getAuthorities().toString();
             }
             
-            // 获取请求参数
-            String requestParams = getRequestParams(request, joinPoint);
-            
             // 获取操作注解信息
             OperationLog operationLogAnnotation = getOperationLogAnnotation(joinPoint);
             String module = operationLogAnnotation != null ? operationLogAnnotation.module() : "";
             String operationType = operationLogAnnotation != null ? operationLogAnnotation.operationType() : "";
             String description = operationLogAnnotation != null ? operationLogAnnotation.description() : "";
+            String requestParams = operationLogAnnotation != null && !operationLogAnnotation.saveRequestData()
+                    ? "<omitted>"
+                    : getRequestParams(request, joinPoint);
             
             // 记录请求开始的日志
             log.info("操作日志 - 开始 | 模块: {} | 类型: {} | 描述: {} | URL: \"{}\" ({}) | IP: {} | 用户: {} | 角色: {} | 参数: {}",
@@ -243,14 +244,16 @@ public class OperationLogAspect {
                         : SensitiveDataMasker.maskAndSerialize(result));
             }
             
-            // 设置操作状态和时间
-            operationLog.setStatus(e == null ? 0 : 1);
+            // 设置操作状态和时间，ResponseEntity 4xx/5xx 也属于失败
+            String failureMessage = resolveFailureMessage(result, e);
+            boolean failed = failureMessage != null;
+            operationLog.setStatus(failed ? 1 : 0);
             operationLog.setOperationTime(LocalDateTime.now());
             operationLog.setExecutionTime(executionTime);
             
             // 设置异常信息
-            if (e != null) {
-                operationLog.setErrorMsg(e.getMessage());
+            if (failed) {
+                operationLog.setErrorMsg(failureMessage);
             }
             
             // 保存操作日志
@@ -260,7 +263,7 @@ public class OperationLogAspect {
             log.info("操作日志 - 结束 | 模块: {} | 类型: {} | 描述: {} | 用户ID: {} | 用户名: {} | 耗时: {}ms | 状态: {}",
                     operationLog.getModule(), operationLog.getOperationType(), operationLog.getDescription(),
                     operationLog.getUserId(), operationLog.getUsername(),
-                    executionTime, e == null ? "成功" : "失败(" + e.getMessage() + ")");
+                    executionTime, failed ? "失败(" + failureMessage + ")" : "成功");
             
         } catch (Exception ex) {
             log.error("记录操作日志异常", ex);
@@ -277,6 +280,26 @@ public class OperationLogAspect {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
         return method.getAnnotation(OperationLog.class);
+    }
+
+    /**
+     * 将异常或 HTTP 错误响应归一化为审计失败原因。
+     *
+     * @param result 控制器返回结果
+     * @param exception 控制器抛出的异常
+     * @return 失败原因；成功时返回 null
+     */
+    private String resolveFailureMessage(Object result, Exception exception) {
+        if (exception != null) {
+            return exception.getMessage() != null
+                    ? exception.getMessage()
+                    : exception.getClass().getSimpleName();
+        }
+        if (result instanceof ResponseEntity<?> responseEntity
+                && responseEntity.getStatusCode().isError()) {
+            return "HTTP " + responseEntity.getStatusCode().value();
+        }
+        return null;
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/SseController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/SseController.java
@@ -121,8 +121,8 @@ public class SseController {
             return null;
         }
         try {
-            Long userId = Long.parseLong(userInfo[0]);
-            Long tenantId = Long.parseLong(userInfo[1]);
+            long userId = Long.parseLong(userInfo[0]);
+            long tenantId = Long.parseLong(userInfo[1]);
             UserRole role = UserRole.getRole(userInfo[2]);
             if (userId <= 0 || tenantId <= 0 || role == UserRole.ROLE_NOOP) {
                 return null;

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/SseController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/SseController.java
@@ -2,13 +2,21 @@ package cn.flying.controller;
 
 import cn.flying.common.annotation.OperationLog;
 import cn.flying.common.constant.Result;
+import cn.flying.common.constant.UserRole;
+import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.JwtUtils;
 import cn.flying.service.sse.SseEmitterManager;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -35,34 +43,116 @@ public class SseController {
      * 建立 SSE 连接（使用短期令牌）
      * 该端点使用一次性短期令牌进行认证，不使用常规 JWT
      * 支持同一用户多个连接（多设备/多标签页），连接 ID 由服务端生成
+     *
+     * @param sseToken 一次性 SSE 短令牌
+     * @param tenantHint TenantFilter 解析的不可信 Redis namespace 提示
+     * @param request 当前 HTTP 请求，用于在令牌验证后写入可信审计属性
+     * @return SSE emitter 或失败状态
      */
-    @OperationLog(module = "实时推送", operationType = "新增", description = "建立SSE连接")
+    @OperationLog(module = "实时推送", operationType = "新增", description = "建立SSE连接", saveRequestData = false)
     @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    @Operation(summary = "建立SSE连接", description = "使用短期SSE令牌建立长连接，接收实时消息推送。支持多设备/多标签页连接。")
-    public ResponseEntity<SseEmitter> connect(@RequestParam("token") String sseToken) {
-        // 验证并消费 SSE 短期令牌
-        String[] userInfo = jwtUtils.validateAndConsumeSseToken(sseToken);
-        if (userInfo == null || userInfo.length < 2) {
+    @Operation(
+            summary = "建立SSE连接",
+            description = "使用一次性短期SSE令牌建立长连接。X-Tenant-ID请求头、x-tenant-id query"
+                    + "（旧客户端可使用tenantId）"
+                    + "仅用于Redis namespace查找，连接与审计身份以短令牌中的tenant/user/role为准。")
+    @Parameters({
+            @Parameter(
+                    name = "X-Tenant-ID",
+                    in = ParameterIn.HEADER,
+                    description = "可设置自定义请求头的客户端使用的Redis namespace提示，不作为可信租户身份",
+                    schema = @Schema(type = "integer", format = "int64", minimum = "1")),
+            @Parameter(
+                    name = "x-tenant-id",
+                    in = ParameterIn.QUERY,
+                    description = "Redis namespace提示；与旧tenantId参数二选一，不作为可信租户身份",
+                    schema = @Schema(type = "integer", format = "int64", minimum = "1")),
+            @Parameter(
+                    name = "tenantId",
+                    in = ParameterIn.QUERY,
+                    description = "旧客户端兼容的Redis namespace提示；建议改用x-tenant-id",
+                    deprecated = true,
+                    schema = @Schema(type = "integer", format = "int64", minimum = "1"))
+    })
+    public ResponseEntity<SseEmitter> connect(
+            @RequestParam("token") String sseToken,
+            @RequestAttribute(Const.ATTR_SSE_TENANT_HINT) Long tenantHint,
+            HttpServletRequest request) {
+        String[] userInfo;
+        try {
+            // hint 只在既有 Redis namespace 查找期间临时生效，返回后立即恢复为空
+            userInfo = TenantContext.callWithTenant(
+                    tenantHint,
+                    () -> jwtUtils.validateAndConsumeSseToken(sseToken));
+        } catch (RuntimeException e) {
+            log.error("SSE 连接失败: 短令牌存储不可用, exceptionType={}", e.getClass().getSimpleName());
+            return ResponseEntity.status(503).build();
+        }
+
+        SseIdentity identity = parseSseIdentity(userInfo);
+        if (identity == null) {
             log.warn("SSE 连接失败: 无效或已过期的 SSE 令牌");
             return ResponseEntity.status(401).build();
         }
 
-        // 解析用户信息，处理潜在的格式异常
-        Long userId;
-        Long tenantId;
-        try {
-            userId = Long.parseLong(userInfo[0]);
-            tenantId = Long.parseLong(userInfo[1]);
-        } catch (NumberFormatException e) {
-            log.error("SSE 连接失败: 令牌中的用户ID或租户ID格式无效, userInfo={}", (Object) userInfo);
+        if (!tenantHint.equals(identity.tenantId())) {
+            log.warn("SSE 连接失败: 租户提示与短令牌身份不一致");
             return ResponseEntity.status(401).build();
         }
 
+        establishTrustedIdentity(request, identity);
         String connectionId = UUID.randomUUID().toString().replace("-", "");
 
-        log.info("SSE 连接请求: tenantId={}, userId={}, connectionId={}", tenantId, userId, connectionId);
-        SseEmitter emitter = sseEmitterManager.createConnection(tenantId, userId, connectionId);
+        log.info("SSE 连接请求: tenantId={}, userId={}, connectionId={}",
+                identity.tenantId(), identity.userId(), connectionId);
+        SseEmitter emitter = sseEmitterManager.createConnection(
+                identity.tenantId(), identity.userId(), connectionId);
         return ResponseEntity.ok(emitter);
+    }
+
+    /**
+     * 解析并校验 Redis 中的一次性短令牌身份载荷。
+     *
+     * @param userInfo 短令牌载荷 [userId, tenantId, role]
+     * @return 完整且受支持的身份；载荷损坏时返回 null
+     */
+    private SseIdentity parseSseIdentity(String[] userInfo) {
+        if (userInfo == null || userInfo.length != 3) {
+            return null;
+        }
+        try {
+            Long userId = Long.parseLong(userInfo[0]);
+            Long tenantId = Long.parseLong(userInfo[1]);
+            UserRole role = UserRole.getRole(userInfo[2]);
+            if (userId <= 0 || tenantId <= 0 || role == UserRole.ROLE_NOOP) {
+                return null;
+            }
+            return new SseIdentity(userId, tenantId, role.getRole());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 在短令牌验证完成后建立本次握手的可信租户、用户、角色与 MDC 身份。
+     *
+     * @param request 当前 HTTP 请求
+     * @param identity 已验证且与 namespace 提示一致的短令牌身份
+     */
+    private void establishTrustedIdentity(HttpServletRequest request, SseIdentity identity) {
+        TenantContext.setTenantId(identity.tenantId());
+        request.setAttribute(Const.ATTR_TENANT_ID, identity.tenantId());
+        request.setAttribute(Const.ATTR_USER_ID, identity.userId());
+        request.setAttribute(Const.ATTR_USER_ROLE, identity.role());
+        MDC.put(Const.ATTR_TENANT_ID, identity.tenantId().toString());
+        MDC.put(Const.ATTR_USER_ID, identity.userId().toString());
+        MDC.put(Const.ATTR_USER_ROLE, identity.role());
+    }
+
+    /**
+     * 短令牌中经校验的 SSE 身份。
+     */
+    private record SseIdentity(Long userId, Long tenantId, String role) {
     }
 
     @OperationLog(module = "实时推送", operationType = "删除", description = "断开SSE连接")

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
@@ -115,9 +115,10 @@ public class TenantFilter extends OncePerRequestFilter {
                 return;
             }
 
+            boolean sseConnectRequest = SSE_CONNECT_PATH.equals(requestPath);
             if (tenantIdHeader == null) {
-                // 仅对 SSE 连接接口允许从参数中获取租户ID，因为 EventSource 不支持自定义 Header
-                if (SSE_CONNECT_PATH.equals(requestPath)) {
+                // 仅对 SSE 连接接口允许从参数中获取租户提示，因为 EventSource 不支持自定义 Header
+                if (sseConnectRequest) {
                     tenantIdHeader = request.getParameter("x-tenant-id");
                     if (tenantIdHeader == null || tenantIdHeader.isEmpty()) {
                         tenantIdHeader = request.getParameter("tenantId");
@@ -141,6 +142,14 @@ public class TenantFilter extends OncePerRequestFilter {
             } catch (NumberFormatException e) {
                 log.warn("租户ID格式错误: {}", tenantIdHeader);
                 sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
+                return;
+            }
+
+            if (sseConnectRequest) {
+                // SSE 匿名握手只能获得 Redis namespace 提示，短令牌消费成功前不能建立权威租户上下文
+                request.setAttribute(Const.ATTR_SSE_TENANT_HINT, tenantId);
+                log.debug("SSE 租户提示已解析: uri={}", requestUri);
+                filterChain.doFilter(request, response);
                 return;
             }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -267,6 +268,48 @@ class OperationLogAspectTest {
     }
 
     /**
+     * 验证 saveRequestData=false 同时约束开始日志和落库参数，并把 HTTP 401 记为失败。
+     */
+    @Test
+    @DisplayName("Should omit sensitive request data and classify HTTP errors")
+    void shouldOmitSensitiveRequestDataAndClassifyHttpErrors() throws Throwable {
+        String secretToken = "sse-secret-token-that-must-never-be-logged";
+        SysOperationLogService operationLogService = mock(SysOperationLogService.class);
+        OperationLogAspect aspect = new OperationLogAspect(operationLogService, newResolver(""));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/sse/connect");
+        request.setServletPath("/api/v1/sse/connect");
+        request.setRemoteAddr("198.51.100.31");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ProceedingJoinPoint joinPoint = sensitiveAuditedJoinPoint(
+                secretToken,
+                ResponseEntity.status(401).build());
+        Logger aspectLogger = (Logger) LoggerFactory.getLogger(OperationLogAspect.class);
+        Level previousLevel = aspectLogger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        aspectLogger.setLevel(Level.INFO);
+        aspectLogger.addAppender(appender);
+        try {
+            assertThat(aspect.doAround(joinPoint)).isInstanceOf(ResponseEntity.class);
+        } finally {
+            aspectLogger.detachAppender(appender);
+            aspectLogger.setLevel(previousLevel);
+            appender.stop();
+        }
+
+        var captor = org.mockito.ArgumentCaptor.forClass(SysOperationLog.class);
+        verify(operationLogService).saveOperationLog(captor.capture());
+        assertThat(captor.getValue().getRequestParam()).isNull();
+        assertThat(captor.getValue().getStatus()).isEqualTo(1);
+        assertThat(captor.getValue().getErrorMsg()).isEqualTo("HTTP 401");
+
+        List<String> messages = appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+        assertThat(messages).anyMatch(message -> message.contains("参数: <omitted>"));
+        assertThat(messages).noneMatch(message -> message.contains(secretToken));
+    }
+
+    /**
      * 验证无 HTTP 请求上下文时仍执行目标方法且不会尝试持久化操作日志。
      */
     @Test
@@ -322,6 +365,24 @@ class OperationLogAspectTest {
         return joinPoint;
     }
 
+    /**
+     * 构造携带敏感参数并返回指定 HTTP 响应的测试连接点。
+     */
+    private ProceedingJoinPoint sensitiveAuditedJoinPoint(
+            String token,
+            ResponseEntity<Void> response) throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        Method method = AuditedFixture.class.getDeclaredMethod("executeSensitive", String.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{token});
+        when(joinPoint.proceed()).thenReturn(response);
+        when(signature.getMethod()).thenReturn(method);
+        when(signature.getDeclaringTypeName()).thenReturn(AuditedFixture.class.getName());
+        when(signature.getName()).thenReturn(method.getName());
+        return joinPoint;
+    }
+
     private static final class AuditedFixture {
 
         /**
@@ -330,6 +391,18 @@ class OperationLogAspectTest {
         @OperationLog(module = "test", operationType = "query", description = "test audit")
         private String execute() {
             return "ok";
+        }
+
+        /**
+         * 提供禁止保存敏感请求参数的测试目标方法。
+         */
+        @OperationLog(
+                module = "sse",
+                operationType = "connect",
+                description = "sensitive audit",
+                saveRequestData = false)
+        private ResponseEntity<Void> executeSensitive(String token) {
+            return ResponseEntity.ok().build();
         }
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -402,6 +402,7 @@ class OperationLogAspectTest {
                 description = "sensitive audit",
                 saveRequestData = false)
         private ResponseEntity<Void> executeSensitive(String token) {
+            assertThat(token).isNotNull();
             return ResponseEntity.ok().build();
         }
     }

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseAuditTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseAuditTenantIsolationIT.java
@@ -1,0 +1,272 @@
+package cn.flying.controller;
+
+import cn.flying.common.tenant.TenantContext;
+import cn.flying.common.util.Const;
+import cn.flying.common.util.JwtUtils;
+import cn.flying.common.util.TenantKeyUtils;
+import cn.flying.service.sse.SseEmitterManager;
+import cn.flying.test.support.BaseControllerIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SSE 匿名握手的真实 MySQL/Redis 租户与审计隔离集成测试。
+ */
+@Transactional
+@DisplayName("SSE trusted tenant and audit integration tests")
+class SseAuditTenantIsolationIT extends BaseControllerIntegrationTest {
+
+    private static final String CONNECT_PATH = "/api/v1/sse/connect";
+    private static final String CONNECT_METHOD = "cn.flying.controller.SseController.connect";
+    private static final long TRUSTED_TENANT_ID = 7_101L;
+    private static final long FORGED_TENANT_ID = 7_102L;
+    private static final long OTHER_TENANT_ID = 7_103L;
+    private static final long SSE_USER_ID = 8_101L;
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private SseEmitterManager sseEmitterManager;
+
+    private final Set<String> redisKeys = new LinkedHashSet<>();
+
+    /**
+     * 为每个场景提供可控 emitter，并隔离当前测试的审计数据。
+     */
+    @BeforeEach
+    void setUpSseAuditTest() {
+        when(sseEmitterManager.createConnection(anyLong(), anyLong(), anyString()))
+                .thenReturn(new SseEmitter(60_000L));
+        jdbcTemplate.update("DELETE FROM sys_operation_log WHERE method = ?", CONNECT_METHOD);
+    }
+
+    /**
+     * 清理 Redis 测试 key 与线程上下文，避免容器复用污染后续测试。
+     */
+    @AfterEach
+    void cleanUpSseAuditTest() {
+        if (!redisKeys.isEmpty()) {
+            redisTemplate.delete(redisKeys);
+        }
+        TenantContext.clear();
+        MDC.clear();
+    }
+
+    /**
+     * 验证调用者选择的租户不能接收无效 token 的失败审计。
+     */
+    @Test
+    @DisplayName("invalid token should not pollute a forged tenant audit")
+    void invalidTokenShouldNotPolluteForgedTenantAudit() throws Exception {
+        String invalidToken = "invalid-" + UUID.randomUUID().toString().replace("-", "");
+        String requestIp = "198.51.100.41";
+
+        performConnect(invalidToken, FORGED_TENANT_ID, requestIp)
+                .andExpect(status().isUnauthorized());
+
+        assertFailureAuditIsSystemTenant(requestIp, invalidToken);
+    }
+
+    /**
+     * 验证 namespace 中的载荷 tenant 与提示不一致时 token 被消费但身份不被信任。
+     */
+    @Test
+    @DisplayName("embedded tenant mismatch should consume the token and fail closed")
+    void embeddedTenantMismatchShouldConsumeTokenAndFailClosed() throws Exception {
+        String mismatchedToken = "mismatch-" + UUID.randomUUID().toString().replace("-", "");
+        String redisKey = sseRedisKey(FORGED_TENANT_ID, mismatchedToken);
+        redisTemplate.opsForValue().set(
+                redisKey,
+                SSE_USER_ID + ":" + OTHER_TENANT_ID + ":user",
+                Const.SSE_TOKEN_TTL,
+                TimeUnit.SECONDS);
+        String requestIp = "198.51.100.42";
+
+        performConnect(mismatchedToken, FORGED_TENANT_ID, requestIp)
+                .andExpect(status().isUnauthorized());
+
+        assertThat(redisTemplate.hasKey(redisKey)).isFalse();
+        assertFailureAuditIsSystemTenant(requestIp, mismatchedToken);
+    }
+
+    /**
+     * 验证合法 token 的 emitter、请求用户和数据库 tenant 均来自 token。
+     *
+     */
+    @Test
+    @DisplayName("valid token should establish trusted emitter and audit identity")
+    void validTokenShouldEstablishTrustedEmitterAndAuditIdentity() throws Exception {
+        String validToken = createValidToken();
+        String requestIp = "198.51.100.43";
+
+        performConnect(validToken, TRUSTED_TENANT_ID, requestIp)
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted())
+                .andExpect(request().attribute(Const.ATTR_TENANT_ID, TRUSTED_TENANT_ID))
+                .andExpect(request().attribute(Const.ATTR_USER_ID, SSE_USER_ID))
+                .andExpect(request().attribute(Const.ATTR_USER_ROLE, "user"));
+
+        AuditRow row = findSingleAudit(requestIp);
+        assertThat(row.tenantId()).isEqualTo(TRUSTED_TENANT_ID);
+        assertThat(row.status()).isZero();
+        assertThat(row.userId()).isEqualTo(String.valueOf(SSE_USER_ID));
+        assertThat(row.requestParam()).isNull();
+        assertAuditDoesNotContain(row, validToken);
+        verify(sseEmitterManager, times(1))
+                .createConnection(TRUSTED_TENANT_ID, SSE_USER_ID, org.mockito.ArgumentMatchers.anyString());
+    }
+
+    /**
+     * 验证一次性 token 再次使用时失败且只产生 system tenant 审计。
+     */
+    @Test
+    @DisplayName("consumed token should not be replayed")
+    void consumedTokenShouldNotBeReplayed() throws Exception {
+        String validToken = createValidToken();
+        performConnect(validToken, TRUSTED_TENANT_ID, "198.51.100.43")
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted());
+        String requestIp = "198.51.100.44";
+
+        performConnect(validToken, TRUSTED_TENANT_ID, requestIp)
+                .andExpect(status().isUnauthorized());
+
+        assertFailureAuditIsSystemTenant(requestIp, validToken);
+        verify(sseEmitterManager, times(1))
+                .createConnection(TRUSTED_TENANT_ID, SSE_USER_ID, org.mockito.ArgumentMatchers.anyString());
+    }
+
+    /**
+     * 创建一个生产兼容的 tenant-scoped 一次性 SSE token。
+     */
+    private String createValidToken() {
+        String validToken = TenantContext.callWithTenant(
+                TRUSTED_TENANT_ID,
+                () -> jwtUtils.createSseToken(SSE_USER_ID, TRUSTED_TENANT_ID, "user"));
+        sseRedisKey(TRUSTED_TENANT_ID, validToken);
+        return validToken;
+    }
+
+    /**
+     * 发起不带普通 JWT 的 SSE 短令牌握手请求。
+     */
+    private org.springframework.test.web.servlet.ResultActions performConnect(
+            String token,
+            long tenantHint,
+            String requestIp) throws Exception {
+        return mockMvc.perform(get(CONNECT_PATH)
+                .param("token", token)
+                .param("tenantId", String.valueOf(tenantHint))
+                .with(remoteAddress(requestIp))
+                .accept(MediaType.TEXT_EVENT_STREAM_VALUE));
+    }
+
+    /**
+     * 验证失败审计固定落在 system tenant、标记失败且不包含短 token。
+     */
+    private void assertFailureAuditIsSystemTenant(String requestIp, String token) {
+        AuditRow row = findSingleAudit(requestIp);
+        assertThat(row.tenantId()).isZero();
+        assertThat(row.status()).isEqualTo(1);
+        assertThat(row.userId()).isNull();
+        assertThat(row.requestParam()).isNull();
+        assertThat(row.errorMsg()).startsWith("HTTP ");
+        assertAuditDoesNotContain(row, token);
+    }
+
+    /**
+     * 查询一个请求 IP 对应的唯一 SSE connect 审计行。
+     */
+    private AuditRow findSingleAudit(String requestIp) {
+        List<AuditRow> rows = jdbcTemplate.query(
+                """
+                SELECT tenant_id, status, user_id, request_param, error_msg, response_result
+                FROM sys_operation_log
+                WHERE method = ? AND request_ip = ?
+                """,
+                (resultSet, rowNumber) -> new AuditRow(
+                        resultSet.getLong("tenant_id"),
+                        resultSet.getInt("status"),
+                        resultSet.getString("user_id"),
+                        resultSet.getString("request_param"),
+                        resultSet.getString("error_msg"),
+                        resultSet.getString("response_result")),
+                CONNECT_METHOD,
+                requestIp);
+        assertThat(rows).hasSize(1);
+        return rows.getFirst();
+    }
+
+    /**
+     * 验证所有可持久化审计文本均不包含一次性 token 原文。
+     */
+    private void assertAuditDoesNotContain(AuditRow row, String token) {
+        List<String> persistedText = java.util.stream.Stream.of(
+                        row.requestParam(), row.errorMsg(), row.responseResult())
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        assertThat(persistedText).noneMatch(value -> value.contains(token));
+    }
+
+    /**
+     * 构造并登记与生产兼容的 tenant-scoped SSE Redis key。
+     */
+    private String sseRedisKey(long tenantId, String token) {
+        String key = TenantKeyUtils.tenantKey(Const.SSE_TOKEN_PREFIX + token, tenantId);
+        redisKeys.add(key);
+        return key;
+    }
+
+    /**
+     * 设置 MockMvc 请求的直接 socket 对端地址。
+     */
+    private RequestPostProcessor remoteAddress(String peer) {
+        return request -> {
+            request.setRemoteAddr(peer);
+            return request;
+        };
+    }
+
+    private record AuditRow(
+            long tenantId,
+            int status,
+            String userId,
+            String requestParam,
+            String errorMsg,
+            String responseResult) {
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseAuditTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseAuditTenantIsolationIT.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -147,7 +148,7 @@ class SseAuditTenantIsolationIT extends BaseControllerIntegrationTest {
         assertThat(row.requestParam()).isNull();
         assertAuditDoesNotContain(row, validToken);
         verify(sseEmitterManager, times(1))
-                .createConnection(TRUSTED_TENANT_ID, SSE_USER_ID, org.mockito.ArgumentMatchers.anyString());
+                .createConnection(eq(TRUSTED_TENANT_ID), eq(SSE_USER_ID), anyString());
     }
 
     /**
@@ -167,7 +168,7 @@ class SseAuditTenantIsolationIT extends BaseControllerIntegrationTest {
 
         assertFailureAuditIsSystemTenant(requestIp, validToken);
         verify(sseEmitterManager, times(1))
-                .createConnection(TRUSTED_TENANT_ID, SSE_USER_ID, org.mockito.ArgumentMatchers.anyString());
+                .createConnection(eq(TRUSTED_TENANT_ID), eq(SSE_USER_ID), anyString());
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerIntegrationTest.java
@@ -53,7 +53,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should establish SSE connection with valid token")
         void connect_shouldEstablishConnectionWithValidToken() throws Exception {
             String validSseToken = "valid_sse_token";
-            doReturn(new String[]{"100", "1"})
+            doReturn(new String[]{"100", "1", "user"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -71,7 +71,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         void connect_shouldIgnoreClientSuppliedConnectionId() throws Exception {
             String validSseToken = "valid_sse_token";
             String connectionId = "custom_connection_123";
-            doReturn(new String[]{"100", "1"})
+            doReturn(new String[]{"100", "1", "user"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -119,7 +119,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should return 401 for malformed user ID in token")
         void connect_shouldReturn401ForMalformedUserId() throws Exception {
             String malformedToken = "malformed_token";
-            doReturn(new String[]{"invalid_user_id", "1"})
+            doReturn(new String[]{"invalid_user_id", "1", "user"})
                     .when(jwtUtils).validateAndConsumeSseToken(malformedToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -133,7 +133,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should generate connectionId if not provided")
         void connect_shouldGenerateConnectionIdIfNotProvided() throws Exception {
             String validSseToken = "valid_sse_token";
-            doReturn(new String[]{"100", "1"})
+            doReturn(new String[]{"100", "1", "user"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -145,6 +145,25 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
             verify(sseEmitterManager).createConnection(eq(1L), eq(100L), argThat(id -> 
                     id != null && !id.isBlank() && id.length() == 32
             ));
+        }
+
+        /**
+         * 验证伪造的 namespace 租户提示不能覆盖短令牌中的可信租户。
+         */
+        @Test
+        @DisplayName("GET /connect - Should reject tenant hint mismatch")
+        void connect_shouldRejectTenantHintMismatch() throws Exception {
+            String mismatchedToken = "mismatched_token";
+            doReturn(new String[]{"100", "2", "user"})
+                    .when(jwtUtils).validateAndConsumeSseToken(mismatchedToken);
+
+            mockMvc.perform(get(BASE_URL + "/connect")
+                            .param("token", mismatchedToken)
+                            .param("tenantId", String.valueOf(testTenantId))
+                            .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+                    .andExpect(status().isUnauthorized());
+
+            verify(sseEmitterManager, never()).createConnection(anyLong(), anyLong(), anyString());
         }
     }
 
@@ -233,9 +252,9 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         void shouldSupportMultipleConnectionsForSameUser() throws Exception {
             String validSseToken1 = "valid_sse_token_1";
             String validSseToken2 = "valid_sse_token_2";
-            doReturn(new String[]{"100", "1"})
+            doReturn(new String[]{"100", "1", "user"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken1);
-            doReturn(new String[]{"100", "1"})
+            doReturn(new String[]{"100", "1", "user"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken2);
 
             mockMvc.perform(get(BASE_URL + "/connect")

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerTest.java
@@ -1,7 +1,10 @@
 package cn.flying.controller;
 
+import cn.flying.common.tenant.TenantContext;
+import cn.flying.common.util.Const;
 import cn.flying.common.util.JwtUtils;
 import cn.flying.service.sse.SseEmitterManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,10 +13,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.slf4j.MDC;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,17 +45,33 @@ class SseControllerTest {
     @BeforeEach
     void setUp() {
         controller = new SseController(sseEmitterManager, jwtUtils);
-        when(sseEmitterManager.createConnection(eq(1L), eq(100L), org.mockito.ArgumentMatchers.anyString()))
-                .thenReturn(new SseEmitter(60000L));
     }
 
+    /**
+     * 清理直接调用控制器后留下的可信身份上下文。
+     */
+    @AfterEach
+    void tearDown() {
+        TenantContext.clear();
+        MDC.clear();
+    }
+
+    /**
+     * 验证合法短令牌使用服务端连接 ID，并把令牌身份写入可信请求上下文。
+     */
     @Test
     @DisplayName("connect should use server generated connection id")
     void connectShouldUseServerGeneratedConnectionId() {
         when(jwtUtils.validateAndConsumeSseToken("valid-token"))
-                .thenReturn(new String[]{"100", "1"});
+                .thenAnswer(invocation -> {
+                    assertThat(TenantContext.getTenantId()).isEqualTo(1L);
+                    return new String[]{"100", "1", "user"};
+                });
+        when(sseEmitterManager.createConnection(eq(1L), eq(100L), anyString()))
+                .thenReturn(new SseEmitter(60000L));
+        MockHttpServletRequest request = new MockHttpServletRequest();
 
-        ResponseEntity<SseEmitter> response = controller.connect("valid-token");
+        ResponseEntity<SseEmitter> response = controller.connect("valid-token", 1L, request);
 
         ArgumentCaptor<String> connectionIdCaptor = ArgumentCaptor.forClass(String.class);
         verify(sseEmitterManager).createConnection(eq(1L), eq(100L), connectionIdCaptor.capture());
@@ -55,5 +79,83 @@ class SseControllerTest {
         assertThat(connectionIdCaptor.getValue())
                 .isNotBlank()
                 .hasSize(32);
+        assertThat(request.getAttribute(Const.ATTR_TENANT_ID)).isEqualTo(1L);
+        assertThat(request.getAttribute(Const.ATTR_USER_ID)).isEqualTo(100L);
+        assertThat(request.getAttribute(Const.ATTR_USER_ROLE)).isEqualTo("user");
+        assertThat(TenantContext.getTenantId()).isEqualTo(1L);
+        assertThat(MDC.get(Const.ATTR_TENANT_ID)).isEqualTo("1");
+        assertThat(MDC.get(Const.ATTR_USER_ID)).isEqualTo("100");
+        assertThat(MDC.get(Const.ATTR_USER_ROLE)).isEqualTo("user");
+    }
+
+    /**
+     * 验证 namespace 提示与短令牌租户不一致时失败关闭且不建立连接。
+     */
+    @Test
+    @DisplayName("connect should reject a token tenant that differs from the hint")
+    void connectShouldRejectTokenTenantMismatch() {
+        when(jwtUtils.validateAndConsumeSseToken("mismatched-token"))
+                .thenReturn(new String[]{"100", "2", "user"});
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        ResponseEntity<SseEmitter> response = controller.connect("mismatched-token", 1L, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+        verify(sseEmitterManager, never()).createConnection(anyLong(), anyLong(), anyString());
+        assertThat(request.getAttribute(Const.ATTR_TENANT_ID)).isNull();
+        assertThat(request.getAttribute(Const.ATTR_USER_ID)).isNull();
+        assertThat(request.getAttribute(Const.ATTR_USER_ROLE)).isNull();
+        assertThat(TenantContext.getTenantId()).isNull();
+        assertThat(MDC.get(Const.ATTR_TENANT_ID)).isNull();
+        assertThat(MDC.get(Const.ATTR_USER_ID)).isNull();
+        assertThat(MDC.get(Const.ATTR_USER_ROLE)).isNull();
+    }
+
+    /**
+     * 验证损坏角色载荷不会被当成可信身份。
+     */
+    @Test
+    @DisplayName("connect should reject a corrupted token role")
+    void connectShouldRejectCorruptedTokenRole() {
+        when(jwtUtils.validateAndConsumeSseToken("corrupted-token"))
+                .thenReturn(new String[]{"100", "1", "owner"});
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        ResponseEntity<SseEmitter> response = controller.connect(
+                "corrupted-token", 1L, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+        verify(sseEmitterManager, never()).createConnection(anyLong(), anyLong(), anyString());
+        assertThat(request.getAttribute(Const.ATTR_TENANT_ID)).isNull();
+        assertThat(request.getAttribute(Const.ATTR_USER_ID)).isNull();
+        assertThat(request.getAttribute(Const.ATTR_USER_ROLE)).isNull();
+        assertThat(TenantContext.getTenantId()).isNull();
+        assertThat(MDC.get(Const.ATTR_TENANT_ID)).isNull();
+        assertThat(MDC.get(Const.ATTR_USER_ID)).isNull();
+        assertThat(MDC.get(Const.ATTR_USER_ROLE)).isNull();
+    }
+
+    /**
+     * 验证 Redis 异常返回服务不可用且不泄漏临时 hint 上下文。
+     */
+    @Test
+    @DisplayName("connect should fail closed when the token store is unavailable")
+    void connectShouldFailClosedWhenTokenStoreUnavailable() {
+        when(jwtUtils.validateAndConsumeSseToken("redis-failure-token"))
+                .thenThrow(new IllegalStateException("redis key contains sensitive data"));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        ResponseEntity<SseEmitter> response = controller.connect(
+                "redis-failure-token", 1L, request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+        verify(sseEmitterManager, never()).createConnection(anyLong(), anyLong(), anyString());
+        assertThat(request.getAttribute(Const.ATTR_TENANT_ID)).isNull();
+        assertThat(request.getAttribute(Const.ATTR_USER_ID)).isNull();
+        assertThat(request.getAttribute(Const.ATTR_USER_ROLE)).isNull();
+        assertThat(TenantContext.getTenantId()).isNull();
+        assertThat(MDC.get(Const.ATTR_TENANT_ID)).isNull();
+        assertThat(MDC.get(Const.ATTR_USER_ID)).isNull();
+        assertThat(MDC.get(Const.ATTR_USER_ROLE)).isNull();
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
@@ -447,17 +447,16 @@ class TenantFilterTest {
     }
 
     /**
-     * SSE 连接端点允许从 query 参数读取租户 ID（EventSource 不支持自定义 Header）。
+     * SSE 连接端点只能把 query 租户 ID 保存为不可信提示，不能提前建立权威租户上下文。
      */
     @Test
-    @DisplayName("should read tenant id from query params for SSE connect")
-    void shouldReadTenantIdFromQueryParamsForSseConnect() throws ServletException, IOException {
+    @DisplayName("should keep SSE query tenant as an untrusted hint")
+    void shouldKeepSseQueryTenantAsUntrustedHint() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/sse/connect");
         request.setServletPath("/api/v1/sse/connect");
         request.addParameter("x-tenant-id", "7");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        // 使用 AtomicLong 在过滤链执行期间捕获 TenantContext
         AtomicLong capturedTenantId = new AtomicLong(-1);
         doAnswer(invocation -> {
             capturedTenantId.set(TenantContext.getTenantId() != null ? TenantContext.getTenantId() : -1);
@@ -467,11 +466,53 @@ class TenantFilterTest {
         filter.doFilterInternal(request, response, filterChain);
 
         verify(filterChain).doFilter(request, response);
-        // 在过滤链执行期间 TenantContext 应已设置
-        assertEquals(7L, capturedTenantId.get());
-        // 请求属性应被设置
-        assertEquals(7L, request.getAttribute(Const.ATTR_TENANT_ID));
-        // 过滤器完成后 TenantContext 应被清理
+        assertEquals(-1L, capturedTenantId.get());
+        assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+        assertEquals(7L, request.getAttribute(Const.ATTR_SSE_TENANT_HINT));
+        assertNull(TenantContext.getTenantId());
+    }
+
+    /**
+     * SSE 连接头中的租户 ID 也只能作为 namespace 提示，不能建立权威上下文。
+     */
+    @Test
+    @DisplayName("should keep SSE header tenant as an untrusted hint")
+    void shouldKeepSseHeaderTenantAsUntrustedHint() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/sse/connect");
+        request.setServletPath("/api/v1/sse/connect");
+        request.addHeader("X-Tenant-ID", "8");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AtomicLong capturedTenantId = new AtomicLong(-1);
+        doAnswer(invocation -> {
+            capturedTenantId.set(TenantContext.getTenantId() != null ? TenantContext.getTenantId() : -1);
+            return null;
+        }).when(filterChain).doFilter(any(), any());
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        assertEquals(-1L, capturedTenantId.get());
+        assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+        assertEquals(8L, request.getAttribute(Const.ATTR_SSE_TENANT_HINT));
+        assertNull(TenantContext.getTenantId());
+    }
+
+    /**
+     * 旧 tenantId query 参数继续兼容，但仍只能产生不可信提示。
+     */
+    @Test
+    @DisplayName("should keep legacy SSE tenantId query as an untrusted hint")
+    void shouldKeepLegacySseTenantIdAsUntrustedHint() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/sse/connect");
+        request.setServletPath("/api/v1/sse/connect");
+        request.addParameter("tenantId", "9");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+        assertEquals(9L, request.getAttribute(Const.ATTR_SSE_TENANT_HINT));
         assertNull(TenantContext.getTenantId());
     }
 

--- a/platform-frontend/src/lib/api/endpoints/sse.test.ts
+++ b/platform-frontend/src/lib/api/endpoints/sse.test.ts
@@ -96,6 +96,7 @@ describe("sse endpoints", () => {
     const es = getLatestEventSource();
     expect(es.url).toContain("/sse/connect?");
     expect(es.url).toContain("token=short-token");
+    expect(es.url).toContain("x-tenant-id=1");
     expect(es.url).not.toContain("connectionId=");
 
     es.emitOpen();

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -1702,7 +1702,7 @@ export interface paths {
         };
         /**
          * 建立SSE连接
-         * @description 使用短期SSE令牌建立长连接，接收实时消息推送。支持多设备/多标签页连接。
+         * @description 使用一次性短期SSE令牌建立长连接。X-Tenant-ID请求头、x-tenant-id query（旧客户端可使用tenantId）仅用于Redis namespace查找，连接与审计身份以短令牌中的tenant/user/role为准。
          */
         get: operations["connect"];
         put?: never;
@@ -8624,9 +8624,19 @@ export interface operations {
     connect: {
         parameters: {
             query: {
+                /**
+                 * @deprecated
+                 * @description 旧客户端兼容的Redis namespace提示；建议改用x-tenant-id
+                 */
+                tenantId?: number;
                 token: string;
+                /** @description Redis namespace提示；与旧tenantId参数二选一，不作为可信租户身份 */
+                "x-tenant-id"?: number;
             };
-            header?: never;
+            header?: {
+                /** @description 可设置自定义请求头的客户端使用的Redis namespace提示，不作为可信租户身份 */
+                "X-Tenant-ID"?: number;
+            };
             path?: never;
             cookie?: never;
         };


### PR DESCRIPTION
## 关联任务

- Trellis 子任务：roadmap-p1-sse-trusted-tenant-source
- 父阶段：roadmap-p1-proof-productization
- 基线：main@91de456b6d23c7edbd1fb8ae4d92167e3fb99ffc

## 问题背景

SSE connect 是 permitAll 的一次性短令牌入口。此前 X-Tenant-ID、x-tenant-id 或旧 tenantId query 会在短令牌消费前建立 TenantContext，使匿名调用者能够选择失败审计的 tenant；同时 401 ResponseEntity 会被记录为成功，短令牌也可能进入开始日志或 JwtUtils debug 日志。

## 修改内容

- TenantFilter 对 connect 路径只写入不可信 sseTenantHint，不提前建立 TenantContext、可信 request attribute 或 MDC。
- SseController 仅在 tenant-scoped Redis GETDEL 成功、三字段载荷合法且 token tenant 与 hint 一致后建立可信 tenant/user/role，并据此创建 emitter。
- 无效、损坏、过期、重放、租户不匹配和 Redis 异常全部在 emitter 创建前失败关闭。
- 保持 permitAll、Redis key schema、30 秒 TTL、GETDEL 一次性消费、前端 x-tenant-id 和旧 tenantId query 合同不变。
- OperationLogAspect 让 saveRequestData=false 同时约束开始日志与数据库参数，并将 ResponseEntity 4xx/5xx 记录为失败。
- JwtUtils 移除一次性 token 原文日志。
- 新增真实 MySQL/Redis 的 SseAuditTenantIsolationIT，并在 CI 中要求 4 tests / 0 skipped / 0 failures / 0 errors。
- 同步 OpenAPI、生成的前端类型、中英文 API/安全/系统架构文档和 ROADMAP 测试文件基线。

## 影响范围

- backend-common：SSE token 常量属性、Redis token 日志与解析。
- backend-web：tenant filter、SSE controller、operation audit 与相关测试。
- frontend：保留 EventSource 的 x-tenant-id query，并同步 OpenAPI 生成类型。
- docs/CI：SSE 信任边界合同、真实集成测试执行门禁。

## 测试与验收证据

本地通过：

- 目标后端单测：68 tests，0 failures/errors/skips。
- OpenAPI 合同导出：2 tests；types:gen:check 幂等通过。
- platform-api：7 tests；public verifier：157 tests；FISCO：158 tests；storage：169 tests。
- 后端 common/service/web 单元测试与 JaCoCo 门禁通过；各 Maven 模块 clean package -DskipTests 通过。
- 前端 format:check、lint、svelte-check、test:coverage（464 tests）和 production build 通过。
- contract fixtures：59 tests；contract fingerprint、docs consistency、VitePress build、actionlint 全部通过。
- 本地 Trivy fs CRITICAL/HIGH 阻断扫描：0 findings。
- git diff/cached diff whitespace 检查通过；人工审查未发现未解决缺陷。

本机没有 Docker daemon，因此完整 -Pit 容器阶段无法本地执行：新 SseAuditTenantIsolationIT 的 Failsafe 报告为 4 tests / 4 skipped（disabledWithoutDocker），另有既有 ProofStatusTimestampMigrationIT 因 Docker socket 不可用报错。PR CI 必须实际运行全部容器 IT；新增硬门禁禁止该 SSE IT 缺失或跳过，CI 未全绿前不得合并。

## 人工审查结论

- hint 只在 Redis namespace 查找期间临时进入 TenantContext，finally 后恢复为空。
- emitter、request attributes、MDC 和租户化审计只接受短令牌中的 tenant/user/role。
- tenant mismatch 会在 GETDEL 后失败，确保同一 token 不能转用或重放。
- 请求 URL 审计不含 query；开始日志和持久化参数均省略 token；Redis 异常只记录异常类型。
- JwtAuthenticationFilter 与 TenantFilter 的 finally 会清理 SSE 成功路径建立的 MDC/TenantContext，不会污染复用线程。
- 通用 ResponseEntity 4xx/5xx 现在按 HTTP 语义记为失败；接口响应体和状态码不变。

## 风险评估

- 中等：合法连接现在要求 namespace hint 与 token tenant 严格一致；现有前端和 legacy tenantId 均已保留并覆盖测试。
- 低：OperationLogAspect 对所有 ResponseEntity 4xx/5xx 的审计状态改为失败，这是预期的审计语义修正，不改变 API 响应。
- 无 Redis 迁移风险：key、value 三字段格式、TTL 和 GETDEL 语义保持不变。

## 回滚方式

- 回滚提交 0852b70d8a08b28a260f93b0e0327e9e95126ff2。
- 无数据库迁移或数据回填需要回滚。
- 如果生产环境已发生短令牌日志泄漏，回滚代码不足以消除已写日志，应同步限制日志访问、审计泄漏窗口并清理相关日志留存。
