### PR TITLE
fix: harden public share tenant boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,9 @@ PROOF_SIGNING_KEY_STATUS=DISABLED
 PROOF_SIGNING_PRIVATE_KEY_PKCS8=
 PROOF_SIGNING_PUBLIC_KEY_SPKI=
 PUBLIC_REGISTRATION_TENANT_ID=0
-# 公共 proof 限流的可信代理数字 IP/CIDR，逗号分隔；直连或未知拓扑保持为空。
+# 公共 proof、匿名公开分享限流与审计共用的可信代理数字 IP/CIDR，逗号分隔；直连或未知拓扑保持为空。
 # 禁止 /0、hostname、URL、端口或通配符；代理必须覆盖/清洗调用者提供的转发头。
+# Redis key 使用 rate:limit:public:proof-verification:v2:ip: 与 rate:limit:public:share-access:v2:ip: namespace；不要把 tenant 放入共享桶。
 RATE_LIMIT_TRUSTED_PROXY_CIDRS=
 # 后端调用 FISCO Dubbo provider 的共享令牌，backend 与 fisco 必须保持一致
 BLOCKCHAIN_RPC_TOKEN=replace_with_strong_blockchain_rpc_token

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,64 @@ jobs:
       - name: Run Backend Tests
         run: mvn -f platform-backend/pom.xml clean verify -pl backend-common,backend-service,backend-web -am -Pit
 
+      - name: Require Public Share Rate Limit IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.aspect.PublicShareRateLimitIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          expected_counts = {
+              "tests": 1,
+              "skipped": 0,
+              "failures": 0,
+              "errors": 0,
+          }
+          for name, expected in expected_counts.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"PublicShareRateLimitIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
+      - name: Require Public Share Audit Tenant Isolation IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.controller.PublicShareAuditTenantIsolationIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          expected_counts = {
+              "tests": 6,
+              "skipped": 0,
+              "failures": 0,
+              "errors": 0,
+          }
+          for name, expected in expected_counts.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"PublicShareAuditTenantIsolationIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Require Attestation Batch Consistency IT Execution
         run: |
           python3 - <<'PY'

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -86,6 +86,8 @@ POST /api/v1/auth/login
 - `GET /api/v1/public/proof-keys/{keyId}/versions/{keyVersion}` - Resolve a versioned proof verification key
 - `GET /api/v1/sse/connect?token=...&x-tenant-id=...` - SSE connect entry (short-lived token required; tenant value is an untrusted Redis namespace hint)
 
+The anonymous public-share allowlist is exactly `GET /api/v1/shares/{shareCode}/info`, `GET /api/v1/shares/{shareCode}/files`, `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks`, and `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`. No other share route is public by implication. These four routes require neither JWT nor `X-Tenant-ID`; a supplied tenant header is ignored. Share writes, saving shared files, and the authenticated share download/decrypt routes still require a Bearer token.
+
 `POST /api/v1/auth/logout` is also handled by Spring Security (non-controller endpoint) and requires authenticated context.
 
 ---
@@ -284,7 +286,7 @@ POST /api/v1/auth/login
 
 **Authentication**: None
 
-**Query Parameters**:
+**Path Parameters**:
 
 | Parameter | Type   | Required | Description |
 | --------- | ------ | -------- | ----------- |
@@ -1207,7 +1209,7 @@ POST /api/v1/shares
 
 ### 4.9 Get Shared Files
 
-Get files by sharing code.
+Get files by sharing code under the anonymous public-share tenant boundary.
 
 ```
 GET /api/v1/shares/{shareCode}/files
@@ -1215,11 +1217,26 @@ GET /api/v1/shares/{shareCode}/files
 
 **Authentication**: None
 
-**Query Parameters**:
+`X-Tenant-ID` is not an authorization or data-selection input on this route. The backend resolves the owner tenant from the matching `shareCode` metadata, limits cross-tenant access to that metadata lookup, and performs every applicable subsequent file, key-envelope, access-count, and share-access-audit operation inside the owner tenant.
+
+**Path Parameters**:
 
 | Parameter   | Type   | Required | Description  |
 | ----------- | ------ | -------- | ------------ |
-| sharingCode | string | Yes      | Sharing code |
+| shareCode   | string | Yes      | Sharing code |
+
+#### Anonymous Public-Share Contract
+
+| Method | Endpoint | Rate Limit |
+| ------ | -------- | ---------- |
+| GET | `/api/v1/shares/{shareCode}/info` | Not part of the 30/60 transfer bucket |
+| GET | `/api/v1/shares/{shareCode}/files` | Not part of the 30/60 transfer bucket |
+| GET | `/api/v1/public/shares/{shareCode}/files/{fileHash}/chunks` | Shared canonical-IP bucket, 30/60 seconds |
+| GET | `/api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info` | Shared canonical-IP bucket, 30/60 seconds |
+
+All four routes ignore caller-supplied `X-Tenant-ID`, including `0`, another tenant, or malformed values. The server derives the owner tenant from `shareCode`; public/private, active/cancelled/expired, unknown type/status, and included-file checks remain fail closed. The current model has no share-password field; password-protected shares require a separate end-to-end feature. Anonymous `sys_operation_log` rows use system tenant `0`, while emitted `share_access_log` rows use the owner tenant. Both audit paths use the same canonical trusted-client IP used by public-share rate limiting.
+
+The public chunk and decrypt-info routes share `rate:limit:public:share-access:v2:ip:<canonical-ip>`. The key contains no tenant, JWT role, endpoint method, or raw forwarding-header value. Unless the direct peer matches the configured numeric trusted-proxy allowlist, `X-Forwarded-For` and `X-Real-IP` are ignored. The first 30 combined requests may enter the controller; the current 31st request remains HTTP 200 with business code `70005`.
 
 ---
 
@@ -3900,6 +3917,7 @@ GET /api/v1/admin/attestation-batches/production/status
 - `GET /api/v1/upload-sessions/{clientId}/progress`
 - `POST /api/v1/shares`
 - `PATCH /api/v1/shares/{shareCode}`
+- `GET /api/v1/shares/{shareCode}/info`
 - `GET /api/v1/shares/{shareCode}/files`
 - `POST /api/v1/shares/{shareCode}/files/save`
 - `DELETE /api/v1/files/share/{shareCode}`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@
 |------|--------|----------|
 | REST 控制器 | 30 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 134 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 154 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 156 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 33（V1.0.0 ~ V1.15.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | CI 流水线（核心） | 5 | `.github/workflows/test.yml`, `perf-smoke.yml`, `docs.yml`, `security-poc.yml`, `docs-consistency.yml` |
 

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -34,14 +34,16 @@ Based on `SecurityConfiguration`:
 - `POST /api/v1/auth/register`
 - `POST /api/v1/auth/password-resets/confirm`
 - `PUT /api/v1/auth/password-resets`
+- `GET /api/v1/shares/{shareCode}/info`
 - `GET /api/v1/shares/{shareCode}/files`
 - `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks`
 - `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`
 - `GET /api/v1/images/download/images/**`
-- `GET /api/v1/shares/**`
 - `GET /api/v1/public/proofs/{proofId}/status`
 - `GET /api/v1/public/proof-keys/{keyId}/versions/{keyVersion}`
 - `GET /api/v1/sse/connect` (still requires short-lived token)
+
+The anonymous public-share surface is limited to the four exact `GET` routes above. No other share route is implicitly public.
 
 ### 3) SSE dual-token flow
 
@@ -124,6 +126,10 @@ Based on `SecurityConfiguration`:
 | POST | `/api/v1/files/download-batches/report` | Report batch download quality metrics |
 | GET | `/api/v1/files/{id}/versions` | List version chain for a file |
 | POST | `/api/v1/files/{id}/versions` | Mark file as parent for a new version upload |
+
+The exact anonymous public-share contract consists of `GET /api/v1/shares/{shareCode}/info`, `GET /api/v1/shares/{shareCode}/files`, `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks`, and `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`. These routes require neither Bearer authentication nor a tenant header. Any supplied `X-Tenant-ID`, including `0`, another tenant, or a malformed value, is ignored for authorization and data selection. The backend resolves the owner tenant from the matching `shareCode` metadata; the cross-tenant scope is restricted to that metadata lookup, and subsequent file, key-envelope, access-count, and share-access-audit work runs in the owner tenant. Anonymous `sys_operation_log` rows use system tenant `0`; any `share_access_log` row uses the owner tenant. Both audit paths use the same canonical trusted-client IP.
+
+The public chunk and decrypt-info routes share one tenant-independent 30-request/60-second bucket, `rate:limit:public:share-access:v2:ip:<canonical-ip>`. Changing `X-Tenant-ID`, JWT role, endpoint, `X-Forwarded-For`, or `X-Real-IP` cannot split the bucket unless the direct peer is in the configured trusted-proxy allowlist and supplies a valid chain. The first 30 combined requests may enter the controller; the current 31st-request contract remains HTTP 200 with business code `70005`. Share visibility, active/expiry state, unknown type/status, and included-file checks remain fail closed. The current model has no share-password field; password-protected shares require a separate end-to-end feature. Share writes, saving a share into a user account, and the authenticated `/api/v1/shares/{shareCode}/files/{fileHash}/chunks` and `/decrypt-info` routes still require a Bearer token.
 
 The `.zip` routes are the canonical contract: exactly eight root entries with fixed order/timestamp/STORED metadata, a canonical `manifest.json` that hashes six evidence entries, and an `issuer-signature.jws` compact JWS over the exact manifest bytes using a dedicated Ed25519 key. Export revalidates tenant/owner authorization, original-byte `contentHash`, active manifest, storage HEAD records, the `MANIFEST_HASH` Merkle path, completed batch, and immutable contract registry. A completed batch is accepted only for `CHAIN_WRITE` with a valid 32-byte transaction hash or one of the two chain-query recovery sources with no transaction hash; its 32-byte chain root must equal the Merkle root. `contentHash`, `chainRecordId`, `manifestHash`, `cipherHash`, `merkleRoot`, and `abiFingerprint` are never interchangeable. Each entry is capped at 1 MiB and the logical payload total at 4 MiB; additional entries, nested names, and traversal paths fail closed.
 

--- a/docs/en/architecture/security.md
+++ b/docs/en/architecture/security.md
@@ -30,6 +30,19 @@ EventSource doesn't support custom headers, so SSE uses URL token:
 
 The `X-Tenant-ID` header, `x-tenant-id` query value, and legacy `tenantId` query value are untrusted namespace hints only. `TenantContext`, request audit attributes, and MDC identity are established only after Redis atomically consumes the token and its tenant matches the hint. Invalid, expired, replayed, damaged, mismatched, or Redis-failed handshakes create no emitter. Anonymous failures are audited under system tenant `0`, and raw one-time tokens are excluded from text logs and persisted request parameters.
 
+## Anonymous Public-Share Tenant Boundary
+
+Only these four exact routes are anonymous:
+
+- `GET /api/v1/shares/{shareCode}/info`
+- `GET /api/v1/shares/{shareCode}/files`
+- `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks`
+- `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`
+
+They require neither JWT nor a tenant header. Caller-controlled `X-Tenant-ID` values are ignored rather than becoming an authoritative `TenantContext`. The service uses the matching `shareCode` metadata to resolve the owner tenant; only that share-metadata lookup crosses tenant isolation. File metadata, key envelopes, access-count changes, and share-access auditing then execute inside the owner tenant. Checks for public visibility, active/cancelled/expired or unknown state, supported share type, and file membership remain fail closed. The current model has no share-password field; password protection is outside this change.
+
+Anonymous system operation audit is always attributed to system tenant `0`. A `share_access_log` row is attributed to the resolved owner tenant, never to a caller header. System audit, share audit, and public-share rate limiting consume the same canonical trusted-client IP. Share creation/update/cancellation, saving shared files, and the authenticated share download/decrypt routes remain protected by Bearer authentication.
+
 ## Authorization (RBAC)
 
 ### Role Definitions
@@ -105,6 +118,10 @@ public Result<File> getFile(@PathVariable Long id) { ... }
 
 The public proof status and historical-key endpoints explicitly opt into a tenant-independent trusted-client-IP mode. They share `rate:limit:public:proof-verification:v2:ip:<canonical-ip>` at a fixed 120 requests per 60 seconds, even when a request carries a valid user/admin/monitor JWT. The key contains no tenant, user, endpoint method, or raw header; all other `@RateLimit` callers retain their legacy tenant, role, and forwarding-header behavior. By default the identity is the canonical direct socket peer and all forwarding headers are ignored. A numeric trusted-proxy allowlist is optional, empty by default, bounded to 4096 characters/64 ranges at startup, and parses one 1024-character/16-hop XFF chain right-to-left only after the immediate peer is trusted. Redis results other than `1`, including `null`, `0`, or dependency exceptions, never execute the controller.
 
+### Public Share Shared Bucket
+
+The public chunk and decrypt-info endpoints share `rate:limit:public:share-access:v2:ip:<canonical-ip>` at a fixed 30 requests per 60 seconds. The key contains no tenant, JWT role, endpoint method, or caller-supplied header value, so changing `X-Tenant-ID` or alternating between the two endpoints cannot split the bucket. The trusted-proxy boundary is the same one described above: forwarding headers are ignored unless the immediate peer matches the configured numeric allowlist. The first 30 combined requests may enter the controller; the current 31st request is denied through the existing response wrapper as HTTP 200 with business code `70005`. A Redis result other than `1`, including an exception, fails closed before the controller executes.
+
 ### Distributed Rate Limiter
 
 Redis Lua script-based sliding window:
@@ -115,7 +132,7 @@ RATE_LIMITED → Window exceeded
 BLOCKED → In block list
 ```
 
-**Generic utility fallback**: The reusable distributed limiter allows requests if Redis is unavailable. This fallback does not apply to the public proof annotation bucket, which fails closed.
+**Generic utility fallback**: The reusable distributed limiter allows requests if Redis is unavailable. This fallback does not apply to the public proof or public-share annotation buckets, which fail closed.
 
 ## ID Obfuscation
 

--- a/docs/en/deployment/production.md
+++ b/docs/en/deployment/production.md
@@ -143,13 +143,13 @@ storage:
 
 > For complete configuration options, see [Nacos Config Template](/nacos-config-template.yaml)
 
-## Trusted Client IP for Public Proof Rate Limiting
+## Trusted Client IP for Public Rate Limiting and Audit
 
-The two public proof status/key endpoints share one fixed 120-request/60-second Redis bucket per canonical trusted client IP. The bucket is global: it does not include a tenant, endpoint method, user, or JWT role.
+The two public proof status/key endpoints share one fixed 120-request/60-second Redis bucket per canonical trusted client IP. Public-share chunk/decrypt endpoints separately share one fixed 30-request/60-second bucket per canonical IP. Neither bucket contains a tenant, endpoint method, user, or JWT role. Anonymous public-share system audit and share-access audit use the same resolver output as the share bucket.
 
 ### Direct deployment
 
-Keep `RATE_LIMIT_TRUSTED_PROXY_CIDRS=` empty. The backend uses the direct socket peer and ignores every forwarding header. This is also the safe setting whenever the production proxy topology or header-cleaning behavior has not been verified. If an unconfigured reverse proxy is the immediate peer, all clients safely share that proxy's 120/60 bucket and may be rejected earlier; configure a verified allowlist or enforce an equivalent edge limit before production traffic.
+Keep `RATE_LIMIT_TRUSTED_PROXY_CIDRS=` empty. The backend uses the direct socket peer and ignores every forwarding header. This is also the safe setting whenever the production proxy topology or header-cleaning behavior has not been verified. If an unconfigured reverse proxy is the immediate peer, all clients safely share that proxy's proof 120/60 and public-share 30/60 buckets and may be rejected earlier; configure a verified allowlist or enforce equivalent edge limits before production traffic.
 
 ### Controlled reverse proxy
 
@@ -163,7 +163,15 @@ Only a matching immediate peer can activate header parsing. The backend accepts 
 
 `server.forward-headers-strategy` is fixed to `none` so Spring/Tomcat cannot rewrite `request.getRemoteAddr()` before this resolver. Startup also rejects `server.tomcat.remoteip.remote-ip-header` and `server.tomcat.remoteip.protocol-header`, because either can install a `RemoteIpValve` independently. Do not configure a `ForwardedHeaderFilter`, external `RemoteIpValve`, ingress sidecar, or servlet-container equivalent that rewrites the remote address. Because framework forwarding inference is disabled, proxy TLS termination and absolute URL/scheme handling must be configured and verified independently; do not re-enable forwarded-header processing to solve those concerns.
 
-Before production rollout, verify both public endpoints alternately: requests 1–120 from one client must succeed, request 121 must be rejected, a second client must have an independent bucket, and the Redis TTL must be within 60 seconds. The new key namespace is `rate:limit:public:proof-verification:v2:ip:<canonical-ip>`. No old counters are copied; deploy and rollback can each reset one 60-second window. Roll out at low traffic with edge limiting retained. Rollback restores the old forwarding-header bypass, so enable an edge direct-source limit of 120/60 or stricter before reverting.
+### Production verification and rollback
+
+Before production rollout, verify the public proof endpoints alternately: requests 1–120 from one client must succeed, request 121 must be rejected, a second client must have an independent bucket, and the Redis TTL must be within 60 seconds. The proof namespace is `rate:limit:public:proof-verification:v2:ip:<canonical-ip>`.
+
+For a public share owned by a non-system tenant, call all four exact anonymous `GET` routes with no `X-Tenant-ID`, `0`, another tenant, and a malformed value; each header variant must produce the same authorized result. Confirm that anonymous share writes and the authenticated share download/decrypt routes still reject requests without Bearer authentication. Alternate the public chunk and decrypt-info routes from one canonical client: combined requests 1–30 must succeed, and request 31 must keep the current HTTP 200 response with business code `70005`. A second client must receive an independent bucket. Redis must contain only `rate:limit:public:share-access:v2:ip:<canonical-ip>` for that first client, with a TTL no greater than 60 seconds; tenant-header changes and untrusted forwarding headers must not create extra keys. For a configured trusted proxy, repeat with a valid chain and confirm that the expected canonical client address is used.
+
+Query the resulting audit rows before admitting traffic: anonymous `sys_operation_log.tenant_id` must be `0`, `share_access_log.tenant_id` must be the resolved owner tenant, and both IP columns must equal the canonical IP used in the Redis key. Monitor rate-limit code `70005`, unexpected tenant attribution, and public-share authorization failures.
+
+No old counters are copied, so deployment and rollback can each reset one 60-second window. Roll out at low traffic with edge direct-source limits retained (120/60 for public proof and 30/60 for public-share chunk/decrypt). Revert the public-share tenant, service, audit, and rate-limit changes as one unit; a partial revert can break non-system-tenant shares or reopen cross-tenant attribution. Before reverting, keep the 30/60 edge limit and temporarily restrict the four anonymous share routes if the old tenant/audit boundary would otherwise be exposed. Do not delete or rewrite historical suspicious audit rows during rollback; assess them read-only.
 
 ## SSL/TLS Configuration
 

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -34,14 +34,16 @@ Authorization: Bearer <token>
 - `POST /api/v1/auth/register`
 - `POST /api/v1/auth/password-resets/confirm`
 - `PUT /api/v1/auth/password-resets`
+- `GET /api/v1/shares/{shareCode}/info`
 - `GET /api/v1/shares/{shareCode}/files`
 - `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks`
 - `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`
 - `GET /api/v1/images/download/images/**`
-- `GET /api/v1/shares/**`
 - `GET /api/v1/public/proofs/{proofId}/status`
 - `GET /api/v1/public/proof-keys/{keyId}/versions/{keyVersion}`
 - `GET /api/v1/sse/connect`（需短期令牌，见下文）
+
+匿名公开分享面仅限上面的四条精确 `GET` 路由；其他分享路由不会因此隐式公开。
 
 ### 3) SSE 双令牌模式
 
@@ -124,6 +126,10 @@ Authorization: Bearer <token>
 | POST | `/api/v1/files/download-batches/report` | 上报批量下载质量指标 |
 | GET | `/api/v1/files/{id}/versions` | 查询文件版本链列表 |
 | POST | `/api/v1/files/{id}/versions` | 将文件标记为新版本的父版本 |
+
+精确的匿名公开分享合同仅包含 `GET /api/v1/shares/{shareCode}/info`、`GET /api/v1/shares/{shareCode}/files`、`GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks` 和 `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`。这些路由既不需要 Bearer，也不需要租户头。调用者即使提供 `X-Tenant-ID=0`、其他租户或畸形值，该值也会在授权和数据选择中被忽略。后端只从匹配的 `shareCode` 元数据解析 owner tenant；跨租户范围仅覆盖这次元数据查询，后续文件、key envelope、访问计数和分享访问审计都在 owner tenant 内完成。匿名 `sys_operation_log` 固定使用 system tenant `0`；产生的 `share_access_log` 使用 owner tenant。两类审计使用同一个规范化可信客户端 IP。
+
+公开 chunks 与 decrypt-info 路由按 `rate:limit:public:share-access:v2:ip:<canonical-ip>` 共享一个无租户的固定 30 次/60 秒桶。除非 direct peer 命中已配置的 trusted-proxy allowlist 且提供合法代理链，否则修改 `X-Tenant-ID`、JWT 角色、端点、`X-Forwarded-For` 或 `X-Real-IP` 都不能拆分该桶。前 30 次合计请求可以进入 controller；当前第 31 次仍保持 HTTP 200，并返回业务码 `70005`。分享公开性、有效/过期状态、未知类型/状态和 included-file 校验继续失败关闭。当前模型没有分享密码字段；密码分享需要另建端到端功能任务。分享写入、保存分享文件到当前用户空间，以及登录态 `/api/v1/shares/{shareCode}/files/{fileHash}/chunks` 和 `/decrypt-info` 路由仍必须携带 Bearer。
 
 `.zip` 是当前规范合同：固定八个根条目、固定顺序/时间戳/STORED metadata，canonical `manifest.json` 摘要绑定六个证据条目，`issuer-signature.jws` 使用专用 Ed25519 key 对 manifest 字节做 compact JWS 签名。导出前重新校验租户/owner、原文件 `contentHash`、active manifest、存储 HEAD、`MANIFEST_HASH` Merkle 路径、已完成 batch 和不可变 contract registry。完成批次只接受携带合法 32-byte 交易哈希的 `CHAIN_WRITE`，或交易哈希为空的两种链查询恢复来源；32-byte 链根必须等于 Merkle 根。`contentHash`、`chainRecordId`、`manifestHash`、`cipherHash`、`merkleRoot`、`abiFingerprint` 不允许互换。单条目上限 1 MiB，总逻辑 payload 上限 4 MiB，额外条目、嵌套路径和路径穿越均失败关闭。
 

--- a/docs/zh/architecture/security.md
+++ b/docs/zh/architecture/security.md
@@ -30,6 +30,19 @@ EventSource 不支持自定义 Header，因此 SSE 使用 URL Token：
 
 `X-Tenant-ID` 请求头、`x-tenant-id` query 和旧 `tenantId` query 都只是不可信的 namespace 提示。只有 Redis 原子消费短令牌且令牌 tenant 与提示一致后，服务端才会建立 `TenantContext`、请求审计属性和 MDC 身份。无效、过期、重放、损坏、租户不匹配或 Redis 异常的握手均不会创建 emitter；匿名失败审计固定落在 system tenant `0`，一次性 token 原文不会进入文本日志和数据库请求参数。
 
+## 匿名公开分享租户边界
+
+匿名面仅包含以下四条精确路由：
+
+- `GET /api/v1/shares/{shareCode}/info`
+- `GET /api/v1/shares/{shareCode}/files`
+- `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/chunks`
+- `GET /api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info`
+
+它们既不需要 JWT，也不需要租户头。调用者控制的 `X-Tenant-ID` 会被忽略，不会成为权威 `TenantContext`。服务端通过匹配的 `shareCode` 元数据解析 owner tenant；只有这次分享元数据查询跨越租户隔离。文件元数据、key envelope、访问计数变更和分享访问审计随后都在 owner tenant 内执行。公开性、有效/取消/过期或未知状态、合法分享类型和文件归属校验继续失败关闭。当前模型没有分享密码字段；密码保护不属于本次变更。
+
+匿名系统操作审计始终归 system tenant `0`；`share_access_log` 归解析出的 owner tenant，绝不采用调用者头。系统审计、分享审计与公开分享限流使用同一个规范化可信客户端 IP。分享创建/更新/取消、保存分享文件，以及登录态分享下载/解密路由仍受 Bearer 认证保护。
+
 ## 授权 (RBAC)
 
 ### 角色定义
@@ -105,6 +118,10 @@ public Result<File> getFile(@PathVariable Long id) { ... }
 
 公共 proof 状态与历史公钥端点显式选择无租户的可信客户端 IP 模式。二者按 `rate:limit:public:proof-verification:v2:ip:<canonical-ip>` 共享固定 120 次/60 秒额度，即使请求携带有效的普通用户、管理员或监控员 JWT 也不会改变阈值。key 不包含 tenant、user、端点方法或原始 header；其他 `@RateLimit` 调用方继续保留 legacy tenant、角色和转发头行为。默认身份是规范化 direct socket peer，全部转发头都被忽略；可选的数字 trusted-proxy allowlist 默认空，启动时限制为 4096 字符/64 个网段，且仅在立即 peer 可信后从右向左解析一条 1024 字符/16 hops 的 XFF 链。Redis 结果不是 `1` 时（包括 `null`、`0` 或依赖异常）都不会执行 controller。
 
+### 公开分享共享桶
+
+公开 chunks 与 decrypt-info 端点按 `rate:limit:public:share-access:v2:ip:<canonical-ip>` 共享固定 30 次/60 秒额度。key 不包含 tenant、JWT 角色、端点方法或调用者提供的 header 值，因此修改 `X-Tenant-ID` 或在两个端点间交替都不能拆桶。可信代理边界与上文一致：只有立即 peer 命中已配置的数字 allowlist 时才处理转发头。前 30 次合计请求可以进入 controller；当前第 31 次通过现有响应包装保持 HTTP 200，并返回业务码 `70005`。Redis 结果不是 `1`（包括依赖异常）时会在 controller 执行前失败关闭。
+
 ### 分布式限流器
 
 基于 Redis Lua 脚本的滑动窗口：
@@ -115,7 +132,7 @@ RATE_LIMITED → 超过窗口限制
 BLOCKED → 在封禁列表中
 ```
 
-**通用工具容错**：可复用的分布式限流器在 Redis 不可用时允许请求；该策略不适用于 fail closed 的公共 proof 注解桶。
+**通用工具容错**：可复用的分布式限流器在 Redis 不可用时允许请求；该策略不适用于 fail closed 的公共 proof 或公开分享注解桶。
 
 ## ID 混淆
 

--- a/docs/zh/deployment/production.md
+++ b/docs/zh/deployment/production.md
@@ -143,13 +143,13 @@ storage:
 
 > 完整配置项请参阅 [Nacos 配置模板](/nacos-config-template.yaml)
 
-## 公共 proof 限流的可信客户端 IP
+## 公共限流与审计的可信客户端 IP
 
-公共 proof 状态/历史公钥两个端点按规范化可信客户端 IP 共享一个固定 120 次/60 秒 Redis 桶。该桶是全局桶，不包含租户、端点方法、用户或 JWT 角色。
+公共 proof 状态/历史公钥两个端点按规范化可信客户端 IP 共享一个固定 120 次/60 秒 Redis 桶。公开分享 chunks/decrypt 两个端点另行按规范化 IP 共享固定 30 次/60 秒桶。两个桶都不包含租户、端点方法、用户或 JWT 角色。匿名公开分享的系统审计与分享访问审计使用和分享桶相同的 resolver 输出。
 
 ### 直连部署
 
-保持 `RATE_LIMIT_TRUSTED_PROXY_CIDRS=` 为空。后端只使用直接 socket peer，并忽略全部转发头。只要生产代理拓扑或 header 清洗行为尚未核验，也必须使用这个安全设置。如果立即 peer 是未配置的反向代理，所有客户端会安全地共享该代理的 120/60 桶并可能更早被拒绝；生产流量接入前应配置已核验 allowlist，或在边缘实施等效限流。
+保持 `RATE_LIMIT_TRUSTED_PROXY_CIDRS=` 为空。后端只使用直接 socket peer，并忽略全部转发头。只要生产代理拓扑或 header 清洗行为尚未核验，也必须使用这个安全设置。如果立即 peer 是未配置的反向代理，所有客户端会安全地共享该代理的 proof 120/60 桶和公开分享 30/60 桶，并可能更早被拒绝；生产流量接入前应配置已核验 allowlist，或在边缘实施等效限流。
 
 ### 受控反向代理
 
@@ -163,7 +163,15 @@ RATE_LIMIT_TRUSTED_PROXY_CIDRS=10.20.0.0/16,2001:db8:20::/48
 
 `server.forward-headers-strategy` 固定为 `none`，避免 Spring/Tomcat 在 resolver 前改写 `request.getRemoteAddr()`。应用还会拒绝 `server.tomcat.remoteip.remote-ip-header` 和 `server.tomcat.remoteip.protocol-header`，因为任一属性都可能独立安装 `RemoteIpValve`。不得配置会改写 remote address 的 `ForwardedHeaderFilter`、外部 `RemoteIpValve`、ingress sidecar 或 servlet-container 等价能力。由于框架不会推导转发后的 scheme/host，代理 TLS 终止以及绝对 URL/scheme 必须独立配置和验证；不能为解决这些问题重新启用转发头处理。
 
-生产发布前，交替请求两个公开端点并验证：同一客户端第 1–120 次成功、第 121 次拒绝，第二个客户端使用独立桶，Redis TTL 不超过 60 秒。新 key namespace 为 `rate:limit:public:proof-verification:v2:ip:<canonical-ip>`。旧计数不复制，发布和回滚都会产生一次最长 60 秒的窗口重置；应低峰发布并保留边缘限流。回滚会恢复旧转发头绕过，因此回滚前必须在边缘启用不弱于 120/60 的 direct-source 限流。
+### 生产验证与回滚
+
+生产发布前，先交替请求两个公共 proof 端点：同一客户端第 1–120 次必须成功，第 121 次必须拒绝，第二个客户端必须使用独立桶，Redis TTL 不超过 60 秒。proof namespace 为 `rate:limit:public:proof-verification:v2:ip:<canonical-ip>`。
+
+为非 system tenant 创建公开分享，分别用无 `X-Tenant-ID`、`0`、其他租户和畸形值调用四条精确匿名 `GET`；所有 header 变体必须得到相同的合法结果。同时确认匿名分享写入和登录态分享下载/解密在没有 Bearer 时仍被拒绝。用同一规范化客户端交替调用公开 chunks 与 decrypt-info：合计第 1–30 次必须成功，第 31 次保持当前 HTTP 200 并返回业务码 `70005`；第二个客户端必须使用独立桶。第一个客户端在 Redis 中只能产生 `rate:limit:public:share-access:v2:ip:<canonical-ip>`，TTL 不超过 60 秒；修改租户头或不可信转发头不得产生额外 key。配置可信代理时，用合法代理链重复验证，并确认使用预期的规范化客户端地址。
+
+放量前查询审计结果：匿名 `sys_operation_log.tenant_id` 必须为 `0`，`share_access_log.tenant_id` 必须为解析出的 owner tenant，两个 IP 字段都必须等于 Redis key 中的规范化 IP。监控限流业务码 `70005`、异常租户归属和公开分享授权失败。
+
+旧计数不会复制，因此发布和回滚都可能重置一次最长 60 秒的窗口。应低峰发布并保留边缘 direct-source 限流（公共 proof 120/60，公开分享 chunks/decrypt 30/60）。公开分享的租户、服务、审计和限流改动必须整组回滚；部分回滚可能破坏非 system tenant 分享，或重新打开跨租户归属问题。回滚前保留边缘 30/60 限流；如果旧租户/审计边界会重新暴露，应临时限制四条匿名分享路由。回滚期间不得删除或改写历史可疑审计行，只做只读评估。
 
 ## SSL/TLS 配置
 

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/tenant/TenantContext.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/tenant/TenantContext.java
@@ -126,6 +126,64 @@ public final class TenantContext {
         }
     }
 
+    /**
+     * 在指定租户内执行操作，并在执行期间强制启用租户隔离。
+     * 适用于从窄全局元数据查询恢复 owner tenant 后的完整数据访问。
+     */
+    public static void runWithTenantIsolation(Long tenantId, Runnable action) {
+        Long previousTenantId = getTenantId();
+        boolean previousIgnoreIsolation = isIgnoreIsolation();
+        try {
+            TENANT_HOLDER.set(requireIsolationTenantId(tenantId));
+            IGNORE_ISOLATION.set(false);
+            action.run();
+        } finally {
+            restoreContext(previousTenantId, previousIgnoreIsolation);
+        }
+    }
+
+    /**
+     * 在指定租户内执行有返回值的操作，并在执行期间强制启用租户隔离。
+     * 结束时完整恢复调用前的租户与跨租户标志。
+     */
+    public static <T> T callWithTenantIsolation(Long tenantId, Supplier<T> action) {
+        Long previousTenantId = getTenantId();
+        boolean previousIgnoreIsolation = isIgnoreIsolation();
+        try {
+            TENANT_HOLDER.set(requireIsolationTenantId(tenantId));
+            IGNORE_ISOLATION.set(false);
+            return action.get();
+        } finally {
+            restoreContext(previousTenantId, previousIgnoreIsolation);
+        }
+    }
+
+    /**
+     * 校验隔离执行必须具备明确租户，防止空值沿用调用方上下文。
+     */
+    private static Long requireIsolationTenantId(Long tenantId) {
+        if (tenantId == null) {
+            throw new IllegalArgumentException("tenantId must not be null for isolated execution");
+        }
+        return tenantId;
+    }
+
+    /**
+     * 恢复隔离执行前的完整线程上下文。
+     */
+    private static void restoreContext(Long previousTenantId, boolean previousIgnoreIsolation) {
+        if (previousTenantId == null) {
+            TENANT_HOLDER.remove();
+        } else {
+            TENANT_HOLDER.set(previousTenantId);
+        }
+        if (previousIgnoreIsolation) {
+            IGNORE_ISOLATION.set(true);
+        } else {
+            IGNORE_ISOLATION.remove();
+        }
+    }
+
     // ========== Cross-Tenant Operation Support ==========
 
     /**

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/SensitiveDataMasker.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/SensitiveDataMasker.java
@@ -3,7 +3,9 @@ package cn.flying.common.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.server.PathContainer;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -182,41 +184,127 @@ public final class SensitiveDataMasker {
 
         PathParts pathParts = splitPath(path);
         String[] segments = pathParts.path().split("/", -1);
-        for (int i = 0; i < segments.length; i++) {
-            String segment = segments[i].toLowerCase(Locale.ROOT);
-            if (("shares".equals(segment) || "share".equals(segment) || "transactions".equals(segment))
-                    && hasMaskableNextSegment(segments, i)) {
-                segments[++i] = PATH_MASKED_VALUE;
-                continue;
-            }
-
-            if ("upload-sessions".equals(segment) && hasMaskableNextSegment(segments, i)) {
-                segments[++i] = PATH_MASKED_VALUE;
-                continue;
-            }
-
-            if ("hash".equals(segment) && hasMaskableNextSegment(segments, i)) {
-                segments[++i] = PATH_MASKED_VALUE;
-                continue;
-            }
-
-            if ("files".equals(segment)
-                    && hasMaskableNextSegment(segments, i)
-                    && isSensitiveFilePathVariable(segments[i + 1])) {
-                segments[++i] = PATH_MASKED_VALUE;
-            }
-        }
+        RouteSegments rawRouteSegments = collectRouteSegments(segments, false);
+        RouteSegments canonicalRouteSegments = collectRouteSegments(segments, true);
+        maskSensitiveRouteTargets(segments, rawRouteSegments);
+        maskSensitiveRouteTargets(segments, canonicalRouteSegments);
         return String.join("/", segments) + pathParts.suffix();
     }
 
     /**
-     * 判断指定位置后是否存在可脱敏路径段。
+     * 按 Spring 路由语义规范化路径，仅供内存中的路由分类使用，返回值禁止直接写入日志。
+     *
+     * @param path 原始请求路径
+     * @return 逐段解码并移除矩阵参数后的路径，不包含查询参数或 fragment
      */
-    private static boolean hasMaskableNextSegment(String[] segments, int currentIndex) {
-        return currentIndex + 1 < segments.length
-                && segments[currentIndex + 1] != null
-                && !segments[currentIndex + 1].isBlank()
-                && !PATH_MASKED_VALUE.equals(segments[currentIndex + 1]);
+    public static String normalizePathForRouteMatching(String path) {
+        if (path == null || path.isBlank()) {
+            return path;
+        }
+
+        String rawPath = splitPath(path).path();
+        String[] segments = rawPath.split("/", -1);
+        RouteSegments canonicalRouteSegments = collectRouteSegments(segments, true);
+        String normalizedPath = String.join("/", canonicalRouteSegments.values());
+        if (rawPath.startsWith("/")) {
+            normalizedPath = "/" + normalizedPath;
+        }
+        if (hasCanonicalTrailingSeparator(rawPath, segments)
+                && !normalizedPath.isEmpty()
+                && !normalizedPath.endsWith("/")) {
+            normalizedPath += "/";
+        }
+        return normalizedPath;
+    }
+
+    /**
+     * 按原始顺序或容器规范化顺序收集参与路由匹配的路径段。
+     */
+    private static RouteSegments collectRouteSegments(String[] segments, boolean resolveParentSegments) {
+        List<Integer> rawIndexes = new ArrayList<>(segments.length);
+        List<String> values = new ArrayList<>(segments.length);
+        for (int i = 0; i < segments.length; i++) {
+            String value = pathSegmentValueToMatch(segments[i]);
+            if (value == null || value.isEmpty() || ".".equals(value)) {
+                continue;
+            }
+            if ("..".equals(value) && resolveParentSegments) {
+                if (!values.isEmpty()) {
+                    int lastIndex = values.size() - 1;
+                    values.remove(lastIndex);
+                    rawIndexes.remove(lastIndex);
+                }
+                continue;
+            }
+            rawIndexes.add(i);
+            values.add(value);
+        }
+        return new RouteSegments(rawIndexes, values);
+    }
+
+    /**
+     * 按给定的路由视图定位并替换敏感路径变量。
+     */
+    private static void maskSensitiveRouteTargets(String[] rawSegments, RouteSegments routeSegments) {
+        for (int i = 0; i < routeSegments.values().size(); i++) {
+            String segment = routeSegments.values().get(i).toLowerCase(Locale.ROOT);
+            if (("shares".equals(segment) || "share".equals(segment) || "transactions".equals(segment))
+                    && hasMaskableRouteTarget(routeSegments, i)) {
+                maskRouteTarget(rawSegments, routeSegments, ++i);
+                continue;
+            }
+
+            if ("upload-sessions".equals(segment) && hasMaskableRouteTarget(routeSegments, i)) {
+                maskRouteTarget(rawSegments, routeSegments, ++i);
+                continue;
+            }
+
+            if ("hash".equals(segment) && hasMaskableRouteTarget(routeSegments, i)) {
+                maskRouteTarget(rawSegments, routeSegments, ++i);
+                continue;
+            }
+
+            if ("files".equals(segment)
+                    && hasMaskableRouteTarget(routeSegments, i)
+                    && isSensitiveFilePathVariable(routeSegments.values().get(i + 1))) {
+                maskRouteTarget(rawSegments, routeSegments, ++i);
+            }
+        }
+    }
+
+    /**
+     * 判断路由字面量后是否存在非导航路径变量。
+     */
+    private static boolean hasMaskableRouteTarget(RouteSegments routeSegments, int currentIndex) {
+        if (currentIndex + 1 >= routeSegments.values().size()) {
+            return false;
+        }
+        String targetValue = routeSegments.values().get(currentIndex + 1);
+        return targetValue != null && !targetValue.isBlank() && !"..".equals(targetValue);
+    }
+
+    /**
+     * 将路由视图中的路径变量映射回原始 URI 段并整体替换。
+     */
+    private static void maskRouteTarget(String[] rawSegments, RouteSegments routeSegments, int routeIndex) {
+        rawSegments[routeSegments.rawIndexes().get(routeIndex)] = PATH_MASKED_VALUE;
+    }
+
+    /**
+     * 判断容器规范化后的路径是否仍保留尾部分隔符。
+     */
+    private static boolean hasCanonicalTrailingSeparator(String rawPath, String[] segments) {
+        if (rawPath.endsWith("/")) {
+            return true;
+        }
+        for (int i = segments.length - 1; i >= 0; i--) {
+            String value = pathSegmentValueToMatch(segments[i]);
+            if (value == null || value.isEmpty()) {
+                continue;
+            }
+            return ".".equals(value) || "..".equals(value);
+        }
+        return false;
     }
 
     /**
@@ -226,7 +314,46 @@ public final class SensitiveDataMasker {
         if (segment == null || segment.isBlank()) {
             return false;
         }
-        return !FILE_ROUTE_LITERALS.contains(segment.toLowerCase(Locale.ROOT));
+        return !FILE_ROUTE_LITERALS.contains(pathSegmentValueToMatch(segment).toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * 按 Spring 路由匹配语义解码单个路径段并移除矩阵参数，避免编码形式绕过脱敏。
+     */
+    private static String pathSegmentValueToMatch(String segment) {
+        if (segment == null || segment.isEmpty()) {
+            return segment;
+        }
+        if (segment.indexOf('%') < 0 && segment.indexOf(';') < 0) {
+            return segment;
+        }
+        try {
+            return parsePathSegmentValueToMatch(segment);
+        } catch (IllegalArgumentException exception) {
+            int matrixParameterIndex = segment.indexOf(';');
+            if (matrixParameterIndex < 0) {
+                return segment;
+            }
+
+            String segmentWithoutMatrixParameters = segment.substring(0, matrixParameterIndex);
+            try {
+                return parsePathSegmentValueToMatch(segmentWithoutMatrixParameters);
+            } catch (IllegalArgumentException ignored) {
+                return segmentWithoutMatrixParameters;
+            }
+        }
+    }
+
+    /**
+     * 解析单个路径段，返回 Spring 路由匹配实际使用的解码值。
+     */
+    private static String parsePathSegmentValueToMatch(String segment) {
+        return PathContainer.parsePath(segment).elements().stream()
+                .filter(PathContainer.PathSegment.class::isInstance)
+                .map(PathContainer.PathSegment.class::cast)
+                .map(PathContainer.PathSegment::valueToMatch)
+                .findFirst()
+                .orElse(segment);
     }
 
     /**
@@ -347,5 +474,11 @@ public final class SensitiveDataMasker {
     }
 
     private record PathParts(String path, String suffix) {
+    }
+
+    /**
+     * 保存规范路由段及其在原始 URI 中的索引映射。
+     */
+    private record RouteSegments(List<Integer> rawIndexes, List<String> values) {
     }
 }

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/tenant/TenantContextTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/tenant/TenantContextTest.java
@@ -218,6 +218,75 @@ class TenantContextTest {
     }
 
     @Nested
+    @DisplayName("Context Switching - isolated tenant")
+    class IsolatedTenantTests {
+
+        /**
+         * 验证隔离执行会覆盖上游跨租户标志，并在成功后完整恢复原上下文。
+         */
+        @Test
+        @DisplayName("should force isolation and restore previous context after success")
+        void shouldForceIsolationAndRestorePreviousContextAfterSuccess() {
+            TenantContext.setTenantId(100L);
+            TenantContext.setIgnoreIsolation(true);
+
+            String result = TenantContext.callWithTenantIsolation(600L, () -> {
+                assertThat(TenantContext.getTenantId()).isEqualTo(600L);
+                assertThat(TenantContext.isIgnoreIsolation()).isFalse();
+                return "isolated";
+            });
+
+            assertThat(result).isEqualTo("isolated");
+            assertThat(TenantContext.getTenantId()).isEqualTo(100L);
+            assertThat(TenantContext.isIgnoreIsolation()).isTrue();
+        }
+
+        /**
+         * 验证隔离执行抛出异常时仍恢复原租户与跨租户标志。
+         */
+        @Test
+        @DisplayName("should restore previous context after isolated action fails")
+        void shouldRestorePreviousContextAfterIsolatedActionFails() {
+            TenantContext.setTenantId(100L);
+            TenantContext.setIgnoreIsolation(true);
+
+            assertThatThrownBy(() -> TenantContext.runWithTenantIsolation(700L, () -> {
+                assertThat(TenantContext.getTenantId()).isEqualTo(700L);
+                assertThat(TenantContext.isIgnoreIsolation()).isFalse();
+                throw new IllegalStateException("expected");
+            })).isInstanceOf(IllegalStateException.class);
+
+            assertThat(TenantContext.getTenantId()).isEqualTo(100L);
+            assertThat(TenantContext.isIgnoreIsolation()).isTrue();
+        }
+
+        /**
+         * 验证无原租户时隔离执行结束后不会残留线程上下文。
+         */
+        @Test
+        @DisplayName("should clear isolated context when no previous tenant exists")
+        void shouldClearIsolatedContextWhenNoPreviousTenantExists() {
+            TenantContext.runWithTenantIsolation(800L, () -> {
+                assertThat(TenantContext.getTenantId()).isEqualTo(800L);
+                assertThat(TenantContext.isIgnoreIsolation()).isFalse();
+            });
+
+            assertThat(TenantContext.getTenantId()).isNull();
+            assertThat(TenantContext.isIgnoreIsolation()).isFalse();
+        }
+
+        /**
+         * 验证隔离执行拒绝空租户，避免意外沿用调用方租户。
+         */
+        @Test
+        @DisplayName("should reject null tenant for isolated execution")
+        void shouldRejectNullTenantForIsolatedExecution() {
+            assertThatThrownBy(() -> TenantContext.callWithTenantIsolation(null, () -> "unexpected"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
     @DisplayName("Cross-Tenant Operations - runWithoutIsolation")
     class RunWithoutIsolationTests {
 

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
@@ -238,6 +238,57 @@ class SensitiveDataMaskerTest {
         );
     }
 
+    /**
+     * 验证路由规范化对空输入、相对路径和容器尾部分隔符语义保持稳定。
+     */
+    @Test
+    @DisplayName("路由匹配路径应稳定处理空输入和尾部分隔符")
+    void normalizePathForRouteMatching_shouldHandleEmptyAndTrailingSegments() {
+        assertNull(SensitiveDataMasker.normalizePathForRouteMatching(null));
+        assertEquals("   ", SensitiveDataMasker.normalizePathForRouteMatching("   "));
+        assertEquals("api/v1/shares", SensitiveDataMasker.normalizePathForRouteMatching("api/v1/shares"));
+        assertEquals("", SensitiveDataMasker.normalizePathForRouteMatching("."));
+        assertEquals("/", SensitiveDataMasker.normalizePathForRouteMatching("/"));
+        assertEquals("/api/", SensitiveDataMasker.normalizePathForRouteMatching("/api/"));
+        assertEquals("/", SensitiveDataMasker.normalizePathForRouteMatching("/api/.."));
+        assertEquals("/api", SensitiveDataMasker.normalizePathForRouteMatching("/../api"));
+        assertEquals("/api", SensitiveDataMasker.normalizePathForRouteMatching("/api/;x=1"));
+        assertEquals("/", SensitiveDataMasker.normalizePathForRouteMatching("/;x=1"));
+        assertEquals("/api", SensitiveDataMasker.normalizePathForRouteMatching("/api"));
+    }
+
+    /**
+     * 验证终止路由、导航段和非法编码均不会绕过或误触发敏感路径变量脱敏。
+     */
+    @Test
+    @DisplayName("异常路由目标应按实际路径变量语义脱敏")
+    void maskSensitivePathSegments_shouldHandleTerminalNavigationAndInvalidTargets() {
+        assertEquals(
+                "/api/v1/upload-sessions",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/upload-sessions")
+        );
+        assertEquals(
+                "/api/v1/hash",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/hash")
+        );
+        assertEquals(
+                "/api/v1/files",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/files")
+        );
+        assertEquals(
+                "/api/v1/shares/../public",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/shares/../public")
+        );
+        assertEquals(
+                "/api/v1/shares/***",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/shares/%ZZ")
+        );
+        assertEquals(
+                "/api/v1/shares/***",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/shares/%ZZ;bad=%ZZ")
+        );
+    }
+
     @Test
     @DisplayName("日志路径脱敏不应误替换静态文件路由段")
     void maskSensitivePathSegments_shouldKeepStaticFileRouteSegments() {

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
@@ -139,6 +139,105 @@ class SensitiveDataMaskerTest {
         );
     }
 
+    /**
+     * 验证脱敏字面量与 Spring 路由的逐段解码和矩阵参数语义保持一致。
+     */
+    @Test
+    @DisplayName("编码或矩阵参数路径中的分享凭据应被脱敏")
+    void maskSensitivePathSegments_shouldMaskEncodedAndMatrixParameterizedRoutes() {
+        assertEquals(
+                "/api/v1/public/sh%61res/***/f%69les/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/sh%61res/share-secret/f%69les/hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares;x=1/***/files;v=2/***/decrypt-info",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares;x=1/share-secret;probe=1/files;v=2/hash-secret;probe=2/decrypt-info")
+        );
+        assertEquals(
+                "/api/v1/public/shares;bad=%ZZ/***",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares;bad=%ZZ/share-secret")
+        );
+        assertEquals(
+                "/api/v1/public/sh%61res;bad=%ZZ/***/f%69les;bad=%ZZ/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/sh%61res;bad=%ZZ/share-secret/f%69les;bad=%ZZ/file-hash-secret/chunks")
+        );
+    }
+
+    /**
+     * 验证容器折叠空段、点段和父段后，实际参与路由的分享凭据仍会被脱敏。
+     */
+    @Test
+    @DisplayName("容器规范化路径中的实际分享凭据应被脱敏")
+    void maskSensitivePathSegments_shouldMaskContainerNormalizedRoutes() {
+        assertEquals(
+                "/api/v1/public/shares/./***/files/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares/./share-secret/files/file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares//***/files/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares//share-secret/files/file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares/%2E/***/files/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares/%2E/share-secret/files/file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares/***/../***/files/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares/decoy-secret/../share-secret/files/file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares/***/%2e%2E/***/files/***/chunks",
+                SensitiveDataMasker.maskSensitivePathSegments(
+                        "/api/v1/public/shares/encoded-decoy/%2e%2E/share-secret/files/file-hash-secret/chunks")
+        );
+    }
+
+    /**
+     * 验证路由分类使用的规范路径会逐段解码、移除矩阵参数并忽略非路径后缀。
+     */
+    @Test
+    @DisplayName("路由匹配路径应遵循 Spring 的逐段解码语义")
+    void normalizePathForRouteMatching_shouldDecodeSegmentsAndRemoveMatrixParameters() {
+        assertEquals(
+                "/api/v1/public/shares/share-secret/files/hash-secret/chunks",
+                SensitiveDataMasker.normalizePathForRouteMatching(
+                        "/api/v1/public/sh%61res;x=1/share-secret/f%69les;v=2/hash-secret/chunks?download=true")
+        );
+        assertEquals(
+                "/api/v1/public/sh/ares/share-secret",
+                SensitiveDataMasker.normalizePathForRouteMatching(
+                        "/api/v1/public/sh%2Fares/share-secret")
+        );
+        assertEquals(
+                "/api/v1/public/shares/share-secret/files/file-hash-secret/chunks",
+                SensitiveDataMasker.normalizePathForRouteMatching(
+                        "/api/v1/public/sh%61res;bad=%ZZ/share-secret/f%69les;bad=%ZZ/file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares/share-secret/files/file-hash-secret/chunks",
+                SensitiveDataMasker.normalizePathForRouteMatching(
+                        "/api//v1/public/shares/%2E/decoy-secret/../share-secret/files//file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares/share-secret/files/file-hash-secret/chunks",
+                SensitiveDataMasker.normalizePathForRouteMatching(
+                        "/api/v1/public/shares/encoded-decoy/%2e%2E/share-secret/files/file-hash-secret/chunks")
+        );
+        assertEquals(
+                "/api/v1/public/shares/share-secret/",
+                SensitiveDataMasker.normalizePathForRouteMatching(
+                        "/api/v1/public/shares/share-secret/.")
+        );
+    }
+
     @Test
     @DisplayName("日志路径脱敏不应误替换静态文件路由段")
     void maskSensitivePathSegments_shouldKeepStaticFileRouteSegments() {
@@ -153,6 +252,10 @@ class SensitiveDataMaskerTest {
         assertEquals(
                 "/api/v1/shares/***/files/save",
                 SensitiveDataMasker.maskSensitivePathSegments("/api/v1/shares/ABC123/files/save")
+        );
+        assertEquals(
+                "/api/v1/f%69les;x=1/st%61ts;view=summary",
+                SensitiveDataMasker.maskSensitivePathSegments("/api/v1/f%69les;x=1/st%61ts;view=summary")
         );
     }
 

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/FileShareMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/FileShareMapper.java
@@ -1,6 +1,7 @@
 package cn.flying.dao.mapper;
 
 import cn.flying.dao.dto.FileShare;
+import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -17,6 +18,16 @@ import java.util.List;
  */
 @Mapper
 public interface FileShareMapper extends BaseMapper<FileShare> {
+
+    /**
+     * 按全局唯一分享码只解析所属租户，不扩大跨租户读取字段范围。
+     *
+     * @param shareCode 分享码
+     * @return 分享所属租户，不存在返回 null
+     */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("SELECT tenant_id FROM file_share WHERE share_code = #{shareCode} AND deleted = 0 LIMIT 1")
+    Long selectTenantIdByShareCodeGlobally(@Param("shareCode") String shareCode);
 
     /**
      * 根据分享码查询分享记录

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileSharingVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileSharingVO.java
@@ -1,9 +1,10 @@
 package cn.flying.dao.vo.file;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
@@ -31,6 +32,8 @@ public class FileSharingVO {
     @Schema(description = "分享有效期（分钟），最大 43200（30 天）")
     private Integer expireMinutes;
 
+    @Min(value = 0, message = "分享类型必须是 0 或 1")
+    @Max(value = 1, message = "分享类型必须是 0 或 1")
     @Schema(description = "分享类型：0-公开（无需登录），1-私密（需要登录），默认公开")
     private Integer shareType = 0;
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileAdminServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileAdminServiceImpl.java
@@ -388,7 +388,7 @@ public class FileAdminServiceImpl implements FileAdminService {
 
         fileShareMapper.update(null, wrapper);
         fileKeyEnvelopeService.revokeShareEnvelopes(share, SecurityUtils.getUserId(), reason);
-        LOGGER.info("管理员强制取消分享: shareCode={}, reason={}", shareCode, reason);
+        LOGGER.info("管理员强制取消分享: shareId={}, reason={}", share.getId(), reason);
     }
 
     // ==================== 工具方法 ====================

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileQueryServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileQueryServiceImpl.java
@@ -56,6 +56,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.concurrent.CompletableFuture;
@@ -83,8 +84,8 @@ import java.util.concurrent.CompletableFuture;
  * <ul>
  *   <li>userFiles - 用户文件列表（高命中率，key 格式: tenantId:userId）</li>
  *   <li>transaction - 区块链交易信息（key 格式: transactionHash）</li>
- *   <li>sharedFiles - 分享文件列表（key 格式: sharingCode）</li>
  * </ul>
+ * 匿名分享文件列表涉及实时授权、过期和删除状态，明确不使用方法级缓存。
  * </p>
  *
  * @author flyingcoding
@@ -392,16 +393,24 @@ public class FileQueryServiceImpl implements FileQueryService {
      * 根据分享码获取分享文件列表，并按过期时间判定取消/过期状态
      */
     @Override
-    @Cacheable(cacheNames = "sharedFiles", key = "#sharingCode", unless = "#result == null || #result.isEmpty()")
     public List<ShareFileVO> getShareFile(String sharingCode) {
-        FileShare share = requirePublicActiveShare(sharingCode);
-        List<String> fileHashList = parseFileHashes(share.getFileHashes());
-        if (CommonUtils.isEmpty(fileHashList)) {
-            return List.of();
+        if (!StringUtils.hasText(sharingCode)) {
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "分享码不能为空");
         }
+        Long shareTenantId = fileShareMapper.selectTenantIdByShareCodeGlobally(sharingCode);
+        if (shareTenantId == null) {
+            throw new GeneralException(ResultEnum.SHARE_NOT_FOUND);
+        }
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> {
+            FileShare share = requirePublicActiveShareInCurrentTenant(sharingCode);
+            List<String> fileHashList = parseFileHashes(share.getFileHashes());
+            if (CommonUtils.isEmpty(fileHashList)) {
+                return List.of();
+            }
 
-        List<File> files = listShareFilesInShareTenant(share, fileHashList);
-        return files.stream().map(ShareFileVO::fromFile).toList();
+            List<File> files = listShareFilesInShareTenant(share, fileHashList);
+            return files.stream().map(ShareFileVO::fromFile).toList();
+        });
     }
 
     /**
@@ -410,31 +419,27 @@ public class FileQueryServiceImpl implements FileQueryService {
      * @param sharingCode 分享码
      * @return 公开且有效的分享记录
      */
-    private FileShare requirePublicActiveShare(String sharingCode) {
-        if (!StringUtils.hasText(sharingCode)) {
-            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "分享码不能为空");
+    private FileShare requirePublicActiveShareInCurrentTenant(String sharingCode) {
+        int expiredCount = fileShareMapper.markAsExpiredIfNecessary(sharingCode);
+        FileShare share = fileShareMapper.selectByShareCode(sharingCode);
+        if (share != null && expiredCount > 0) {
+            share.setStatus(FileShare.STATUS_EXPIRED);
         }
-
-        FileShare share = TenantContext.runWithoutIsolation(() -> {
-            int expiredCount = fileShareMapper.markAsExpiredIfNecessary(sharingCode);
-            FileShare current = fileShareMapper.selectByShareCode(sharingCode);
-            if (current != null && expiredCount > 0) {
-                current.setStatus(FileShare.STATUS_EXPIRED);
-            }
-            return current;
-        });
 
         if (share == null) {
             throw new GeneralException(ResultEnum.SHARE_NOT_FOUND);
         }
-        if (share.getStatus() == FileShare.STATUS_CANCELLED) {
+        if (Objects.equals(share.getStatus(), FileShare.STATUS_CANCELLED)) {
             throw new GeneralException(ResultEnum.SHARE_CANCELLED);
         }
-        if (share.getStatus() == FileShare.STATUS_EXPIRED
+        if (Objects.equals(share.getStatus(), FileShare.STATUS_EXPIRED)
                 || (share.getExpireTime() != null && share.getExpireTime().before(new Date()))) {
             throw new GeneralException(ResultEnum.SHARE_EXPIRED);
         }
-        if (ShareType.fromCode(share.getShareType()).isPrivate()) {
+        if (!Objects.equals(share.getStatus(), FileShare.STATUS_ACTIVE)) {
+            throw new GeneralException(ResultEnum.FAIL, "分享状态无效");
+        }
+        if (!Objects.equals(share.getShareType(), ShareType.PUBLIC.getCode())) {
             throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED, "此分享需要登录后才能访问");
         }
         return share;
@@ -449,7 +454,7 @@ public class FileQueryServiceImpl implements FileQueryService {
      */
     private List<File> listShareFilesInShareTenant(FileShare share, List<String> fileHashList) {
         Long shareTenantId = share.getTenantId() != null ? share.getTenantId() : 0L;
-        return TenantContext.callWithTenant(shareTenantId, () -> {
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> {
             LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<File>()
                     .eq(File::getUid, share.getUserId())
                     .in(File::getFileHash, fileHashList);

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
@@ -793,6 +794,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         if (expireMinutes == null || expireMinutes <= 0) {
             throw new GeneralException(ResultEnum.PARAM_ERROR, "过期时间必须为正数");
         }
+        int validatedShareType = shareType != null ? shareType : ShareType.PUBLIC.getCode();
+        requireSupportedShareType(validatedShareType, ResultEnum.PARAM_IS_INVALID);
 
         // 去重后验证用户拥有所有要分享的文件（避免重复 hash 导致误报）
         List<String> distinctHashes = fileHash.stream().distinct().toList();
@@ -820,7 +823,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         Date expireTime = new Date(System.currentTimeMillis() + (long) expireMinutes * 60 * 1000L);
 
         // 分享码全局唯一（跨租户），提前检测避免唯一索引冲突导致 500
-        boolean exists = TenantContext.runWithoutIsolation(() -> fileShareMapper.selectByShareCode(sharingCode) != null);
+        boolean exists = findShareTenantIdGlobally(sharingCode) != null;
         if (exists) {
             throw new GeneralException(ResultEnum.BLOCKCHAIN_ERROR, "分享码冲突，请重试");
         }
@@ -829,7 +832,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
                 .setTenantId(tenantId != null ? tenantId : 0L)
                 .setUserId(userId)
                 .setShareCode(sharingCode)
-                .setShareType(shareType != null ? shareType : ShareType.PUBLIC.getCode())
+                .setShareType(validatedShareType)
                 .setFileHashes(JsonConverter.toJson(fileHash))
                 .setExpireTime(expireTime)
                 .setAccessCount(0)
@@ -839,8 +842,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         fileShareMapper.insert(fileShare);
         List<File> ownedFiles = this.list(ownershipWrapper);
         fileKeyEnvelopeService.saveShareEnvelopes(fileShare, ownedFiles, userId, "SHARE_CREATE");
-        log.info("分享码已生成: userId={}, shareCode={}, shareType={}, fileCount={}",
-                userId, sharingCode, ShareType.fromCode(fileShare.getShareType()).getName(), fileHash.size());
+        log.info("分享已生成: userId={}, shareId={}, shareType={}, fileCount={}",
+                userId, fileShare.getId(), ShareType.fromCode(fileShare.getShareType()).getName(), fileHash.size());
 
         return sharingCode;
     }
@@ -850,14 +853,20 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
      */
     @Override
     public List<ShareFileVO> getShareFile(String sharingCode) {
-        FileShare share = requirePublicActiveShare(sharingCode);
-        List<String> fileHashList = parseFileHashes(share.getFileHashes());
-        if (CommonUtils.isEmpty(fileHashList)) {
-            return List.of();
+        Long shareTenantId = findShareTenantIdGlobally(sharingCode);
+        if (shareTenantId == null) {
+            throw new GeneralException(ResultEnum.SHARE_NOT_FOUND);
         }
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> {
+            FileShare share = requirePublicActiveShare(sharingCode);
+            List<String> fileHashList = parseFileHashes(share.getFileHashes());
+            if (CommonUtils.isEmpty(fileHashList)) {
+                return List.of();
+            }
 
-        List<File> files = listShareFilesInShareTenant(share, fileHashList);
-        return files.stream().map(ShareFileVO::fromFile).toList();
+            List<File> files = listShareFilesInShareTenant(share, fileHashList);
+            return files.stream().map(ShareFileVO::fromFile).toList();
+        });
     }
 
     /**
@@ -871,20 +880,28 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "分享码不能为空");
         }
 
-        FileShare share = getShareByCode(shareCode);
+        int expiredCount = fileShareMapper.markAsExpiredIfNecessary(shareCode);
+        FileShare share = fileShareMapper.selectByShareCode(shareCode);
         if (share == null) {
             throw new GeneralException(ResultEnum.SHARE_NOT_FOUND);
         }
-        if (share.getStatus() == FileShare.STATUS_CANCELLED) {
+        if (expiredCount > 0) {
+            share.setStatus(FileShare.STATUS_EXPIRED);
+        }
+        if (Objects.equals(share.getStatus(), FileShare.STATUS_CANCELLED)) {
             throw new GeneralException(ResultEnum.SHARE_CANCELLED);
         }
-        if (share.getStatus() == FileShare.STATUS_EXPIRED
+        if (Objects.equals(share.getStatus(), FileShare.STATUS_EXPIRED)
                 || (share.getExpireTime() != null && share.getExpireTime().before(new Date()))) {
             throw new GeneralException(ResultEnum.SHARE_EXPIRED);
         }
-        if (ShareType.fromCode(share.getShareType()).isPrivate()) {
+        if (!Objects.equals(share.getStatus(), FileShare.STATUS_ACTIVE)) {
+            throw new GeneralException(ResultEnum.FAIL, "分享状态无效");
+        }
+        if (!Objects.equals(share.getShareType(), ShareType.PUBLIC.getCode())) {
             throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED, "此分享需要登录后才能访问");
         }
+        fileShareMapper.incrementAccessCountIfActive(shareCode);
         return share;
     }
 
@@ -897,7 +914,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
      */
     private List<File> listShareFilesInShareTenant(FileShare share, List<String> fileHashList) {
         Long shareTenantId = share.getTenantId() != null ? share.getTenantId() : 0L;
-        return TenantContext.callWithTenant(shareTenantId, () -> {
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> {
             LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<File>()
                     .eq(File::getUid, share.getUserId())
                     .in(File::getFileHash, fileHashList);
@@ -966,7 +983,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             // 计算链路深度：查询源文件的深度并加1
             int depth = 1;
             Long sourceTenantId = file.getTenantId() != null ? file.getTenantId() : TenantContext.getTenantIdOrDefault();
-            FileSource sourceFileSource = TenantContext.callWithTenant(
+            FileSource sourceFileSource = TenantContext.callWithTenantIsolation(
                     sourceTenantId,
                     () -> fileSourceMapper.selectByFileId(sourceFileId, sourceTenantId));
             if (sourceFileSource != null) {
@@ -1012,7 +1029,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             }
         }
 
-        log.info("成功保存分享文件: userId={}, 文件数量={}, shareCode={}", userId, fileList.size(), shareCode);
+        log.info("成功保存分享文件: userId={}, 文件数量={}", userId, fileList.size());
     }
 
     /**
@@ -1026,7 +1043,11 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "分享码不能为空");
         }
 
-        FileShare share = TenantContext.runWithoutIsolation(() -> {
+        Long shareTenantId = findShareTenantIdGlobally(shareCode);
+        if (shareTenantId == null) {
+            throw new GeneralException(ResultEnum.SHARE_NOT_FOUND);
+        }
+        FileShare share = TenantContext.callWithTenantIsolation(shareTenantId, () -> {
             int expiredCount = fileShareMapper.markAsExpiredIfNecessary(shareCode);
             FileShare current = fileShareMapper.selectByShareCode(shareCode);
             if (current != null && expiredCount > 0) {
@@ -1038,13 +1059,17 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         if (share == null) {
             throw new GeneralException(ResultEnum.SHARE_NOT_FOUND);
         }
-        if (share.getStatus() == FileShare.STATUS_CANCELLED) {
+        if (Objects.equals(share.getStatus(), FileShare.STATUS_CANCELLED)) {
             throw new GeneralException(ResultEnum.SHARE_CANCELLED);
         }
-        if (share.getStatus() == FileShare.STATUS_EXPIRED
+        if (Objects.equals(share.getStatus(), FileShare.STATUS_EXPIRED)
                 || (share.getExpireTime() != null && share.getExpireTime().before(new Date()))) {
             throw new GeneralException(ResultEnum.SHARE_EXPIRED);
         }
+        if (!Objects.equals(share.getStatus(), FileShare.STATUS_ACTIVE)) {
+            throw new GeneralException(ResultEnum.FAIL, "分享状态无效");
+        }
+        requireSupportedShareType(share.getShareType(), ResultEnum.FAIL);
         return share;
     }
 
@@ -1057,7 +1082,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
      */
     private List<File> listRequestedShareFiles(FileShare share, List<String> sharingFileIdList) {
         Long shareTenantId = share.getTenantId() != null ? share.getTenantId() : 0L;
-        return TenantContext.callWithTenant(shareTenantId, () -> {
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> {
             LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<File>()
                     .in(File::getId, sharingFileIdList);
             List<File> files = this.list(wrapper);
@@ -1198,7 +1223,6 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
 
     @Override
     @Transactional(rollbackFor = Exception.class)
-    @CacheEvict(cacheNames = "sharedFiles", key = "#shareCode")
     public void cancelShare(Long userId, String shareCode) {
         // 先验证分享是否属于该用户（从数据库查询）
         FileShare fileShare = fileShareMapper.selectByShareCode(shareCode);
@@ -1235,12 +1259,18 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         fileShareMapper.update(null, wrapper);
         fileKeyEnvelopeService.revokeShareEnvelopes(fileShare, userId, "USER_CANCEL_SHARE");
 
-        log.info("分享已取消: userId={}, shareCode={}", userId, shareCode);
+        log.info("分享已取消: userId={}, shareId={}", userId, fileShare.getId());
     }
 
     @Override
     @Transactional(rollbackFor = Exception.class)
     public void updateShare(Long userId, UpdateShareVO updateVO) {
+        if (updateVO.getShareType() != null) {
+            requireSupportedShareType(updateVO.getShareType(), ResultEnum.PARAM_IS_INVALID);
+        }
+        if (updateVO.getShareType() == null && updateVO.getExtendMinutes() == null) {
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "至少需要更新一项分享设置");
+        }
         FileShare fileShare = fileShareMapper.selectByShareCode(updateVO.getShareCode());
         if (fileShare == null) {
             throw new GeneralException(ResultEnum.FAIL, "分享记录不存在");
@@ -1252,13 +1282,19 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         }
 
         // 检查是否已取消
-        if (fileShare.getStatus() == FileShare.STATUS_CANCELLED) {
+        if (Objects.equals(fileShare.getStatus(), FileShare.STATUS_CANCELLED)) {
             throw new GeneralException(ResultEnum.FAIL, "分享已被取消，无法修改");
         }
+        if (!Objects.equals(fileShare.getStatus(), FileShare.STATUS_ACTIVE)
+                && !Objects.equals(fileShare.getStatus(), FileShare.STATUS_EXPIRED)) {
+            throw new GeneralException(ResultEnum.FAIL, "分享状态无效");
+        }
 
-        // 构建更新条件
+        // 条件更新保证并发取消一旦提交，延期或类型更新不能覆盖取消状态
         LambdaUpdateWrapper<FileShare> wrapper = new LambdaUpdateWrapper<FileShare>()
-                .eq(FileShare::getShareCode, updateVO.getShareCode());
+                .eq(FileShare::getShareCode, updateVO.getShareCode())
+                .eq(FileShare::getUserId, userId)
+                .ne(FileShare::getStatus, FileShare.STATUS_CANCELLED);
 
         // 更新分享类型
         if (updateVO.getShareType() != null) {
@@ -1268,30 +1304,36 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         // 延长有效期（从当前时间开始计算）
         if (updateVO.getExtendMinutes() != null && updateVO.getExtendMinutes() > 0) {
             Date newExpireTime = new Date(System.currentTimeMillis() + (long) updateVO.getExtendMinutes() * 60 * 1000L);
-            wrapper.set(FileShare::getExpireTime, newExpireTime);
-            // 如果已过期，重新激活
-            if (fileShare.getStatus() == FileShare.STATUS_EXPIRED) {
-                wrapper.set(FileShare::getStatus, FileShare.STATUS_ACTIVE);
-            }
+            wrapper.set(FileShare::getExpireTime, newExpireTime)
+                    .set(FileShare::getStatus, FileShare.STATUS_ACTIVE);
         }
 
-        fileShareMapper.update(null, wrapper);
-        log.info("分享设置已更新: userId={}, shareCode={}", userId, updateVO.getShareCode());
+        int updated = fileShareMapper.update(null, wrapper);
+        if (updated != 1) {
+            throw new GeneralException(ResultEnum.FAIL, "分享状态已变化，请刷新后重试");
+        }
+        log.info("分享设置已更新: userId={}, shareId={}", userId, fileShare.getId());
     }
 
     @Override
     public FileShare getShareByCode(String shareCode) {
-        if (!TenantContext.isSet()) {
-            return TenantContext.runWithoutIsolation(() -> getShareByCodeInternal(shareCode));
+        if (TenantContext.isSet()) {
+            return TenantContext.callWithTenantIsolation(
+                    TenantContext.requireTenantId(),
+                    () -> getShareByCodeInternal(shareCode));
         }
-        return getShareByCodeInternal(shareCode);
+        Long shareTenantId = findShareTenantIdGlobally(shareCode);
+        if (shareTenantId == null) {
+            return null;
+        }
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> getShareByCodeInternal(shareCode));
     }
 
     /**
      * 根据分享码查询分享记录，并在查询前做过期标记与访问计数更新。
      * <p>
-     * 注意：公开分享相关端点可能处于租户过滤白名单（无 X-Tenant-ID），调用方可通过
-     * {@link TenantContext#runWithoutIsolation(java.util.function.Supplier)} 在无租户上下文时跨租户查询。
+     * 注意：公开分享入口必须先通过 mapper 级窄查询恢复 owner tenant，再在 owner tenant
+     * 调用本方法；无租户上下文的跨租户兼容分支仅保留给既有服务接口，不得用于公开入口。
      * </p>
      *
      * @param shareCode 分享码
@@ -1309,7 +1351,7 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             }
             // 原子操作：仅当分享处于活跃状态时增加访问计数
             // 避免 TOCTOU 竞态条件
-            if (fileShare.getStatus() == FileShare.STATUS_ACTIVE) {
+            if (Objects.equals(fileShare.getStatus(), FileShare.STATUS_ACTIVE)) {
                 fileShareMapper.incrementAccessCountIfActive(shareCode);
             }
         }
@@ -1318,25 +1360,44 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
 
     @Override
     public ShareInfoVO getShareInfo(String shareCode) {
-        FileShare fileShare = getShareByCode(shareCode);
+        Long shareTenantId = findShareTenantIdGlobally(shareCode);
+        if (shareTenantId == null) {
+            return null;
+        }
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> getShareInfoInCurrentTenant(shareCode));
+    }
+
+    /**
+     * 在已经恢复的分享 owner 租户内读取分享详情及安全文件视图。
+     *
+     * @param shareCode 分享码
+     * @return 分享详情，不存在返回 null
+     */
+    private ShareInfoVO getShareInfoInCurrentTenant(String shareCode) {
+        int expiredCount = fileShareMapper.markAsExpiredIfNecessary(shareCode);
+        FileShare fileShare = fileShareMapper.selectByShareCode(shareCode);
         if (fileShare == null) {
             return null;
         }
+        if (expiredCount > 0) {
+            fileShare.setStatus(FileShare.STATUS_EXPIRED);
+        }
 
         // 分享状态校验
-        if (fileShare.getStatus() != null) {
-            if (fileShare.getStatus() == FileShare.STATUS_CANCELLED) {
-                ShareInfoVO cancelled = new ShareInfoVO();
-                cancelled.setShareCode(shareCode);
-                cancelled.setStatus(FileShare.STATUS_CANCELLED);
-                return cancelled;
-            }
-            if (fileShare.getStatus() == FileShare.STATUS_EXPIRED) {
-                ShareInfoVO expired = new ShareInfoVO();
-                expired.setShareCode(shareCode);
-                expired.setStatus(FileShare.STATUS_EXPIRED);
-                return expired;
-            }
+        if (Objects.equals(fileShare.getStatus(), FileShare.STATUS_CANCELLED)) {
+            ShareInfoVO cancelled = new ShareInfoVO();
+            cancelled.setShareCode(shareCode);
+            cancelled.setStatus(FileShare.STATUS_CANCELLED);
+            return cancelled;
+        }
+        if (Objects.equals(fileShare.getStatus(), FileShare.STATUS_EXPIRED)) {
+            ShareInfoVO expired = new ShareInfoVO();
+            expired.setShareCode(shareCode);
+            expired.setStatus(FileShare.STATUS_EXPIRED);
+            return expired;
+        }
+        if (!Objects.equals(fileShare.getStatus(), FileShare.STATUS_ACTIVE)) {
+            throw new GeneralException(ResultEnum.FAIL, "分享状态无效");
         }
 
         // 过期时间校验
@@ -1347,9 +1408,10 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             return expired;
         }
 
-        if (ShareType.fromCode(fileShare.getShareType()).isPrivate()) {
+        if (!Objects.equals(fileShare.getShareType(), ShareType.PUBLIC.getCode())) {
             throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED, "此分享需要登录后才能访问");
         }
+        fileShareMapper.incrementAccessCountIfActive(shareCode);
 
         // 解析文件哈希
         List<String> fileHashes = parseFileHashes(fileShare.getFileHashes());
@@ -1372,44 +1434,76 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
 
     @Override
     public List<byte[]> getPublicFile(String shareCode, String fileHash) {
-        // 验证分享有效性（公开分享）
-        ShareAccessContext accessContext = resolveShareAccess(shareCode, fileHash, ShareType.PUBLIC);
-        validateOwnerFileForInMemoryTransfer(accessContext.ownerId(), fileHash);
+        return callWithPublicShareAccess(shareCode, fileHash, accessContext -> {
+            validateOwnerFileForInMemoryTransfer(accessContext.ownerId(), fileHash);
 
-        // 使用 owner 的身份获取文件
-        Result<FileDetailVO> filePointer = fileRemoteClient.getFile(String.valueOf(accessContext.ownerId()), fileHash);
-        FileDetailVO detailVO = ResultUtils.getData(filePointer);
-        if (detailVO == null) {
-            throw new GeneralException(ResultEnum.FAIL, "无法获取文件详情");
-        }
-        String fileContent = detailVO.content();
-        if (CommonUtils.isEmpty(fileContent)) {
-            throw new GeneralException(ResultEnum.FAIL, "文件内容为空");
-        }
-        List<StoredObjectReference> references = StoredObjectReferenceCodec.parseChainContent(fileContent);
-        Result<List<byte[]>> fileListResult = fileRemoteClient.getFileListByHash(
-                references.stream().map(StoredObjectReference::storagePath).toList(),
-                references.stream().map(StoredObjectReference::cipherHash).toList());
-        List<byte[]> files = ResultUtils.getData(fileListResult);
-        incrementShareAccessCount(accessContext);
-        return files;
+            // 使用 owner 的身份获取文件
+            Result<FileDetailVO> filePointer = fileRemoteClient.getFile(
+                    String.valueOf(accessContext.ownerId()), fileHash);
+            FileDetailVO detailVO = ResultUtils.getData(filePointer);
+            if (detailVO == null) {
+                throw new GeneralException(ResultEnum.FAIL, "无法获取文件详情");
+            }
+            String fileContent = detailVO.content();
+            if (CommonUtils.isEmpty(fileContent)) {
+                throw new GeneralException(ResultEnum.FAIL, "文件内容为空");
+            }
+            List<StoredObjectReference> references = StoredObjectReferenceCodec.parseChainContent(fileContent);
+            Result<List<byte[]>> fileListResult = fileRemoteClient.getFileListByHash(
+                    references.stream().map(StoredObjectReference::storagePath).toList(),
+                    references.stream().map(StoredObjectReference::cipherHash).toList());
+            List<byte[]> files = ResultUtils.getData(fileListResult);
+            incrementShareAccessCount(accessContext);
+            return files;
+        });
     }
 
     @Override
     public FileDecryptInfoVO getPublicFileDecryptInfo(String shareCode, String fileHash) {
-        // 验证分享有效性（公开分享）
-        ShareAccessContext accessContext = resolveShareAccess(shareCode, fileHash, ShareType.PUBLIC);
+        return callWithPublicShareAccess(shareCode, fileHash, accessContext -> {
+            // 查询文件元数据
+            LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<File>()
+                    .eq(File::getUid, accessContext.ownerId())
+                    .eq(File::getFileHash, fileHash);
+            File file = this.getOne(wrapper);
+            if (file == null) {
+                throw new GeneralException(ResultEnum.FAIL, "文件不存在");
+            }
 
-        // 查询文件元数据
-        LambdaQueryWrapper<File> wrapper = new LambdaQueryWrapper<File>()
-                .eq(File::getUid, accessContext.ownerId())
-                .eq(File::getFileHash, fileHash);
-        File file = this.getOne(wrapper);
-        if (file == null) {
-            throw new GeneralException(ResultEnum.FAIL, "文件不存在");
+            return buildShareFileDecryptInfo(file, fileHash, accessContext, null);
+        });
+    }
+
+    /**
+     * 通过全局唯一分享码只解析 owner 租户，再在该租户内完成公开文件授权与业务操作。
+     *
+     * @param shareCode 分享码
+     * @param fileHash 文件哈希
+     * @param action owner 租户内执行的业务动作
+     * @param <T> 返回类型
+     * @return 业务结果
+     */
+    private <T> T callWithPublicShareAccess(String shareCode,
+                                            String fileHash,
+                                            Function<ShareAccessContext, T> action) {
+        Long shareTenantId = findShareTenantIdGlobally(shareCode);
+        if (shareTenantId == null) {
+            throw new GeneralException(ResultEnum.FAIL, "分享不存在");
         }
+        return TenantContext.callWithTenantIsolation(shareTenantId, () -> {
+            ShareAccessContext accessContext = resolveShareAccess(shareCode, fileHash, ShareType.PUBLIC);
+            return action.apply(accessContext);
+        });
+    }
 
-        return buildShareFileDecryptInfo(file, fileHash, accessContext, null);
+    /**
+     * 使用 mapper 级单条 SQL 例外只读取全局分享所属租户，避免打开线程级跨租户模式。
+     *
+     * @param shareCode 分享码
+     * @return 分享所属租户，不存在返回 null
+     */
+    private Long findShareTenantIdGlobally(String shareCode) {
+        return fileShareMapper.selectTenantIdByShareCodeGlobally(shareCode);
     }
 
     /**
@@ -1570,8 +1664,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         } catch (GeneralException e) {
             throw e;
         } catch (Exception e) {
-            log.error("解析分享文件参数失败: fileHash={}, shareCode={}, error={}",
-                    fileHash, accessContext.fileShare().getShareCode(), e.getMessage());
+            log.error("解析分享文件参数失败: fileId={}, shareId={}, errorType={}",
+                    file.getId(), accessContext.fileShare().getId(), e.getClass().getSimpleName());
             throw new GeneralException(ResultEnum.FAIL, "解析文件元数据失败");
         }
     }
@@ -1588,25 +1682,31 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
      * 验证分享访问权限并解析分享上下文
      */
     private ShareAccessContext resolveShareAccess(String shareCode, String fileHash, ShareType requiredType) {
+        int expiredCount = fileShareMapper.markAsExpiredIfNecessary(shareCode);
         FileShare fileShare = fileShareMapper.selectByShareCode(shareCode);
         if (fileShare != null) {
-            ShareType actualType = ShareType.fromCode(fileShare.getShareType());
-            if (requiredType != null && actualType != requiredType) {
+            if (expiredCount > 0) {
+                fileShare.setStatus(FileShare.STATUS_EXPIRED);
+            }
+            requireSupportedShareType(fileShare.getShareType(), ResultEnum.FAIL);
+            if (requiredType != null && !Objects.equals(fileShare.getShareType(), requiredType.getCode())) {
                 throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED, "此分享需要登录后才能访问");
             }
 
-            if (fileShare.getStatus() == FileShare.STATUS_CANCELLED) {
+            if (Objects.equals(fileShare.getStatus(), FileShare.STATUS_CANCELLED)) {
                 throw new GeneralException(ResultEnum.FAIL, "分享已被取消");
+            }
+
+            if (Objects.equals(fileShare.getStatus(), FileShare.STATUS_EXPIRED)) {
+                throw new GeneralException(ResultEnum.SHARE_EXPIRED);
+            }
+
+            if (!Objects.equals(fileShare.getStatus(), FileShare.STATUS_ACTIVE)) {
+                throw new GeneralException(ResultEnum.FAIL, "分享状态无效");
             }
 
             Date now = new Date();
             if (fileShare.getExpireTime() != null && fileShare.getExpireTime().before(now)) {
-                if (fileShare.getStatus() != FileShare.STATUS_EXPIRED) {
-                    LambdaUpdateWrapper<FileShare> wrapper = new LambdaUpdateWrapper<FileShare>()
-                            .eq(FileShare::getShareCode, shareCode)
-                            .set(FileShare::getStatus, FileShare.STATUS_EXPIRED);
-                    fileShareMapper.update(null, wrapper);
-                }
                 throw new GeneralException(ResultEnum.SHARE_EXPIRED);
             }
 
@@ -1619,6 +1719,19 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
         }
 
         throw new GeneralException(ResultEnum.FAIL, "分享不存在");
+    }
+
+    /**
+     * 校验持久化或调用方提供的分享类型，未知值不得降级为公开分享。
+     *
+     * @param shareType 分享类型代码
+     * @param errorType 非法类型对应的错误分类
+     */
+    private void requireSupportedShareType(Integer shareType, ResultEnum errorType) {
+        if (!Objects.equals(shareType, ShareType.PUBLIC.getCode())
+                && !Objects.equals(shareType, ShareType.PRIVATE.getCode())) {
+            throw new GeneralException(errorType, "分享类型必须是 0 或 1");
+        }
     }
 
     /**

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/ShareAuditServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/ShareAuditServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * 分享审计服务实现
@@ -54,18 +55,9 @@ public class ShareAuditServiceImpl implements ShareAuditService {
     @Override
     @Async
     public void logShareView(String shareCode, Long actorUserId, String ip, String userAgent) {
-        // 异步方法中需要显式设置租户上下文，因为ThreadLocal在异步线程中会丢失
-        // 访问日志使用分享所有者的租户ID
         try {
-            FileShare share = TenantContext.runWithoutIsolation(() ->
-                    fileShareMapper.selectByShareCode(shareCode));
-            if (share == null) {
-                log.warn("记录分享查看日志时分享不存在: {}", shareCode);
-                return;
-            }
-
-            Long tenantId = share.getTenantId();
-            TenantContext.runWithTenant(tenantId, () -> {
+            runWithShareOwnerTenant(shareCode, "查看", share -> {
+                Long tenantId = share.getTenantId();
                 ShareAccessLog logEntry = new ShareAccessLog()
                         .setShareCode(shareCode)
                         .setShareOwnerId(share.getUserId())
@@ -77,10 +69,10 @@ public class ShareAuditServiceImpl implements ShareAuditService {
                         .setTenantId(tenantId);
 
                 shareAccessLogMapper.insert(logEntry);
-                log.debug("记录分享查看: shareCode={}, actor={}", shareCode, actorUserId);
+                log.debug("记录分享查看: shareId={}, actor={}", share.getId(), actorUserId);
             });
         } catch (Exception e) {
-            log.error("记录分享查看日志失败: {}", e.getMessage());
+            log.error("记录分享查看日志失败: errorType={}", e.getClass().getSimpleName());
         }
     }
 
@@ -88,15 +80,8 @@ public class ShareAuditServiceImpl implements ShareAuditService {
     @Async
     public void logShareDownload(String shareCode, Long actorUserId, String fileHash, String fileName, String ip) {
         try {
-            FileShare share = TenantContext.runWithoutIsolation(() ->
-                    fileShareMapper.selectByShareCode(shareCode));
-            if (share == null) {
-                log.warn("记录分享下载日志时分享不存在: {}", shareCode);
-                return;
-            }
-
-            Long tenantId = share.getTenantId();
-            TenantContext.runWithTenant(tenantId, () -> {
+            runWithShareOwnerTenant(shareCode, "下载", share -> {
+                Long tenantId = share.getTenantId();
                 ShareAccessLog logEntry = new ShareAccessLog()
                         .setShareCode(shareCode)
                         .setShareOwnerId(share.getUserId())
@@ -109,10 +94,10 @@ public class ShareAuditServiceImpl implements ShareAuditService {
                         .setTenantId(tenantId);
 
                 shareAccessLogMapper.insert(logEntry);
-                log.debug("记录分享下载: shareCode={}, fileHash={}, actor={}", shareCode, fileHash, actorUserId);
+                log.debug("记录分享下载: shareId={}, actor={}", share.getId(), actorUserId);
             });
         } catch (Exception e) {
-            log.error("记录分享下载日志失败: {}", e.getMessage());
+            log.error("记录分享下载日志失败: errorType={}", e.getClass().getSimpleName());
         }
     }
 
@@ -120,15 +105,8 @@ public class ShareAuditServiceImpl implements ShareAuditService {
     @Async
     public void logShareSave(String shareCode, Long actorUserId, String fileHash, String fileName, String ip) {
         try {
-            FileShare share = TenantContext.runWithoutIsolation(() ->
-                    fileShareMapper.selectByShareCode(shareCode));
-            if (share == null) {
-                log.warn("记录分享保存日志时分享不存在: {}", shareCode);
-                return;
-            }
-
-            Long tenantId = share.getTenantId();
-            TenantContext.runWithTenant(tenantId, () -> {
+            runWithShareOwnerTenant(shareCode, "保存", share -> {
+                Long tenantId = share.getTenantId();
                 ShareAccessLog logEntry = new ShareAccessLog()
                         .setShareCode(shareCode)
                         .setShareOwnerId(share.getUserId())
@@ -141,11 +119,36 @@ public class ShareAuditServiceImpl implements ShareAuditService {
                         .setTenantId(tenantId);
 
                 shareAccessLogMapper.insert(logEntry);
-                log.debug("记录分享保存: shareCode={}, fileHash={}, actor={}", shareCode, fileHash, actorUserId);
+                log.debug("记录分享保存: shareId={}, actor={}", share.getId(), actorUserId);
             });
         } catch (Exception e) {
-            log.error("记录分享保存日志失败: {}", e.getMessage());
+            log.error("记录分享保存日志失败: errorType={}", e.getClass().getSimpleName());
         }
+    }
+
+    /**
+     * 仅用全局分享码解析 owner 租户，随后在 owner 租户内重新读取完整分享并执行审计动作。
+     *
+     * @param shareCode 分享码
+     * @param actionName 审计动作名称
+     * @param action owner 租户内的审计动作
+     */
+    private void runWithShareOwnerTenant(String shareCode,
+                                         String actionName,
+                                         Consumer<FileShare> action) {
+        Long tenantId = fileShareMapper.selectTenantIdByShareCodeGlobally(shareCode);
+        if (tenantId == null) {
+            log.warn("记录分享{}日志时分享不存在", actionName);
+            return;
+        }
+        TenantContext.runWithTenantIsolation(tenantId, () -> {
+            FileShare share = fileShareMapper.selectByShareCode(shareCode);
+            if (share == null) {
+                log.warn("记录分享{}日志时 owner 租户内分享不存在", actionName);
+                return;
+            }
+            action.accept(share);
+        });
     }
 
     // ==================== 访问日志查询（管理员专用）====================

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/job/ShareCleanupTask.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/job/ShareCleanupTask.java
@@ -6,8 +6,6 @@ import cn.flying.dao.mapper.FileShareMapper;
 import cn.flying.dao.mapper.TenantMapper;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -28,9 +26,6 @@ public class ShareCleanupTask {
 
     @Resource
     private TenantMapper tenantMapper;
-
-    @Resource(name = "cacheManager")
-    private CacheManager cacheManager;
 
     /**
      * 批量更新过期分享状态。
@@ -53,8 +48,6 @@ public class ShareCleanupTask {
                     if (updated > 0) {
                         totalUpdated += updated;
                         log.info("租户 {} 更新了 {} 条过期分享", tenantId, updated);
-                        // 清除 sharedFiles 缓存
-                        evictSharedFilesCache();
                     }
                 } catch (Exception e) {
                     log.error("租户 {} 更新过期分享失败: {}", tenantId, e.getMessage(), e);
@@ -74,15 +67,4 @@ public class ShareCleanupTask {
         }
     }
 
-    /**
-     * 清除 sharedFiles 缓存
-     * 由于无法确定具体的 shareCode，清除所有条目
-     */
-    private void evictSharedFilesCache() {
-        Cache cache = cacheManager.getCache("sharedFiles");
-        if (cache != null) {
-            cache.clear();
-            log.debug("已清除 sharedFiles 缓存");
-        }
-    }
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/remote/FileRemoteClient.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/remote/FileRemoteClient.java
@@ -275,7 +275,7 @@ public class FileRemoteClient {
     }
 
     private Result<SharingVO> getSharedFilesFallback(String sharingCode, Throwable t) {
-        log.error("BlockChain service getSharedFiles failed, code={}", sharingCode, t);
+        log.error("BlockChain service getSharedFiles failed, errorType={}", t.getClass().getSimpleName());
         return new Result<>(ResultEnum.GET_USER_SHARE_FILE_ERROR, null);
     }
 
@@ -308,7 +308,7 @@ public class FileRemoteClient {
     }
 
     private Result<Boolean> cancelShareFallback(CancelShareRequest request, Throwable t) {
-        log.error("BlockChain service cancelShare failed, shareCode={}", request.shareCode(), t);
+        log.error("BlockChain service cancelShare failed, errorType={}", t.getClass().getSimpleName());
         return new Result<>(ResultEnum.BLOCKCHAIN_ERROR, false);
     }
 
@@ -332,7 +332,8 @@ public class FileRemoteClient {
     }
 
     private Result<SharingVO> getShareInfoFallback(String shareCode, String requester, Throwable t) {
-        log.error("BlockChain service getShareInfo failed, shareCode={}, requester={}", shareCode, requester, t);
+        log.error("BlockChain service getShareInfo failed, requester={}, errorType={}",
+                requester, t.getClass().getSimpleName());
         return new Result<>(ResultEnum.GET_USER_SHARE_FILE_ERROR, null);
     }
 

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceEdgeCaseTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceEdgeCaseTest.java
@@ -18,6 +18,7 @@ import cn.flying.service.key.FileKeyEnvelopeService;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.remote.FileRemoteClient;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,14 @@ class FileQueryServiceEdgeCaseTest {
     private static final Long FILE_ID = 1L;
     private static final String FILE_HASH = "sha256_edge_hash";
     private static final String SHARE_CODE = "EDGE01";
+
+    /**
+     * 为公开分享边界用例提供全局分享码到 owner 租户的最小解析结果。
+     */
+    @BeforeEach
+    void setUpPublicShareTenant() {
+        lenient().when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(1L);
+    }
 
     /**
      * 构造本地分享记录，供公开分享元数据路径测试使用。
@@ -335,6 +344,44 @@ class FileQueryServiceEdgeCaseTest {
             GeneralException ex = assertThrows(GeneralException.class, () -> fileQueryService.getShareFile(SHARE_CODE));
 
             assertThat(ex.getResultEnum()).isEqualTo(ResultEnum.PERMISSION_UNAUTHORIZED);
+        }
+
+        /**
+         * 验证缺失或未知分享状态不会被匿名入口按有效分享处理。
+         */
+        @Test
+        @DisplayName("should reject missing or unknown share status")
+        void shouldRejectMissingOrUnknownShareStatus() {
+            for (Integer invalidStatus : new Integer[]{null, 99}) {
+                when(fileShareMapper.selectByShareCode(SHARE_CODE))
+                        .thenReturn(createShare(invalidStatus, null, ShareType.PUBLIC.getCode()));
+
+                GeneralException ex = assertThrows(
+                        GeneralException.class,
+                        () -> fileQueryService.getShareFile(SHARE_CODE));
+
+                assertThat(ex.getResultEnum()).isEqualTo(ResultEnum.FAIL);
+            }
+            verify(fileMapper, never()).selectList(any());
+        }
+
+        /**
+         * 验证缺失或未知分享类型不会因枚举默认值而降级成公开分享。
+         */
+        @Test
+        @DisplayName("should reject missing or unknown share type")
+        void shouldRejectMissingOrUnknownShareType() {
+            for (Integer invalidType : new Integer[]{null, 99}) {
+                when(fileShareMapper.selectByShareCode(SHARE_CODE))
+                        .thenReturn(createShare(FileShare.STATUS_ACTIVE, null, invalidType));
+
+                GeneralException ex = assertThrows(
+                        GeneralException.class,
+                        () -> fileQueryService.getShareFile(SHARE_CODE));
+
+                assertThat(ex.getResultEnum()).isEqualTo(ResultEnum.PERMISSION_UNAUTHORIZED);
+            }
+            verify(fileMapper, never()).selectList(any());
         }
     }
 

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceEdgeCaseTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceEdgeCaseTest.java
@@ -383,6 +383,77 @@ class FileQueryServiceEdgeCaseTest {
             }
             verify(fileMapper, never()).selectList(any());
         }
+
+        /**
+         * 验证全局分享码无法解析 owner 租户时立即按分享不存在失败关闭。
+         */
+        @Test
+        @DisplayName("should reject when global share tenant cannot be resolved")
+        void shouldRejectWhenGlobalShareTenantCannotBeResolved() {
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(null);
+
+            GeneralException ex = assertThrows(
+                    GeneralException.class,
+                    () -> fileQueryService.getShareFile(SHARE_CODE));
+
+            assertThat(ex.getResultEnum()).isEqualTo(ResultEnum.SHARE_NOT_FOUND);
+            verify(fileShareMapper, never()).selectByShareCode(anyString());
+            verifyNoInteractions(fileMapper);
+        }
+
+        /**
+         * 验证 owner 租户内分享记录消失时不会跨租户回退读取文件。
+         */
+        @Test
+        @DisplayName("should reject when share is missing inside owner tenant")
+        void shouldRejectWhenShareIsMissingInsideOwnerTenant() {
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(null);
+
+            GeneralException ex = assertThrows(
+                    GeneralException.class,
+                    () -> fileQueryService.getShareFile(SHARE_CODE));
+
+            assertThat(ex.getResultEnum()).isEqualTo(ResultEnum.SHARE_NOT_FOUND);
+            verifyNoInteractions(fileMapper);
+        }
+
+        /**
+         * 验证有效公开分享未绑定文件时返回不可变空列表且不执行文件查询。
+         */
+        @Test
+        @DisplayName("should return empty list when public share has no file hashes")
+        void shouldReturnEmptyListWhenPublicShareHasNoFileHashes() {
+            FileShare share = createShare(FileShare.STATUS_ACTIVE, null, ShareType.PUBLIC.getCode())
+                    .setFileHashes("[]");
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+
+            List<ShareFileVO> result = fileQueryService.getShareFile(SHARE_CODE);
+
+            assertThat(result).isEmpty();
+            verifyNoInteractions(fileMapper);
+        }
+
+        /**
+         * 验证数据库原子过期更新命中后，内存中的旧 active 状态也必须按已过期拒绝。
+         */
+        @Test
+        @DisplayName("should reject when database atomically marks share expired")
+        void shouldRejectWhenDatabaseAtomicallyMarksShareExpired() {
+            FileShare share = createShare(
+                    FileShare.STATUS_ACTIVE,
+                    new Date(System.currentTimeMillis() + 60_000),
+                    ShareType.PUBLIC.getCode());
+            when(fileShareMapper.markAsExpiredIfNecessary(SHARE_CODE)).thenReturn(1);
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+
+            GeneralException ex = assertThrows(
+                    GeneralException.class,
+                    () -> fileQueryService.getShareFile(SHARE_CODE));
+
+            assertThat(ex.getResultEnum()).isEqualTo(ResultEnum.SHARE_EXPIRED);
+            assertThat(share.getStatus()).isEqualTo(FileShare.STATUS_EXPIRED);
+            verifyNoInteractions(fileMapper);
+        }
     }
 
     @Nested

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
@@ -3,6 +3,7 @@ package cn.flying.service.impl;
 import cn.flying.common.constant.FileUploadStatus;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.exception.GeneralException;
+import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.IdUtils;
 import cn.flying.common.util.SecurityUtils;
 import cn.flying.dao.dto.Account;
@@ -36,6 +37,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -85,11 +87,18 @@ class FileQueryServiceTest {
     private static final Long FILE_ID = 1L;
     private static final String FILE_HASH = "sha256_test_hash";
     private static final String TRANSACTION_HASH = "0xtxhash";
-
     @BeforeEach
     void setUp() {
         FileTestBuilder.resetIdCounter();
         AccountTestBuilder.resetIdCounter();
+    }
+
+    /**
+     * 清理测试设置的租户上下文，避免 ThreadLocal 跨用例污染。
+     */
+    @AfterEach
+    void clearTenantContext() {
+        TenantContext.clear();
     }
 
     @Nested
@@ -468,10 +477,35 @@ class FileQueryServiceTest {
                 a.setUsername("owner");
             });
 
-            when(fileShareMapper.markAsExpiredIfNecessary("PUBLIC1")).thenReturn(0);
-            when(fileShareMapper.selectByShareCode("PUBLIC1")).thenReturn(share);
-            when(fileMapper.selectList(any())).thenReturn(List.of(sourceFile));
-            when(accountMapper.selectById(OTHER_USER_ID)).thenReturn(owner);
+            AtomicInteger shareLookups = new AtomicInteger();
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally("PUBLIC1")).thenAnswer(invocation -> {
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(99L, TenantContext.getTenantId());
+                return share.getTenantId();
+            });
+            when(fileShareMapper.selectByShareCode("PUBLIC1")).thenAnswer(invocation -> {
+                shareLookups.incrementAndGet();
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(share.getTenantId(), TenantContext.getTenantId());
+                return share;
+            });
+            when(fileShareMapper.markAsExpiredIfNecessary("PUBLIC1")).thenAnswer(invocation -> {
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(share.getTenantId(), TenantContext.getTenantId());
+                return 0;
+            });
+            when(fileMapper.selectList(any())).thenAnswer(invocation -> {
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(share.getTenantId(), TenantContext.getTenantId());
+                return List.of(sourceFile);
+            });
+            when(accountMapper.selectById(OTHER_USER_ID)).thenAnswer(invocation -> {
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(share.getTenantId(), TenantContext.getTenantId());
+                return owner;
+            });
+
+            TenantContext.setTenantId(99L);
 
             List<ShareFileVO> result;
             try (MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
@@ -483,6 +517,50 @@ class FileQueryServiceTest {
             assertEquals("ext_7", result.get(0).id());
             assertEquals("public.txt", result.get(0).fileName());
             assertEquals("owner", result.get(0).ownerName());
+            assertEquals(1, shareLookups.get());
+            assertEquals(99L, TenantContext.getTenantId());
+            assertFalse(TenantContext.isIgnoreIsolation());
+        }
+
+        /**
+         * 验证文件列表命中缓存后仍会实时校验分享状态，避免自然到期被缓存绕过。
+         */
+        @Test
+        @DisplayName("should validate share expiration before returning cached public files")
+        void shouldValidateShareExpirationBeforeReturningCachedPublicFiles() {
+            FileShare share = new FileShare()
+                    .setTenantId(1L)
+                    .setUserId(OTHER_USER_ID)
+                    .setShareCode("PUBLIC1")
+                    .setShareType(cn.flying.common.constant.ShareType.PUBLIC.getCode())
+                    .setFileHashes("[\"" + FILE_HASH + "\"]")
+                    .setExpireTime(new java.util.Date(System.currentTimeMillis() + 60_000))
+                    .setStatus(FileShare.STATUS_ACTIVE);
+            File sourceFile = new File()
+                    .setId(7L)
+                    .setTenantId(1L)
+                    .setUid(OTHER_USER_ID)
+                    .setFileName("public.txt")
+                    .setFileHash(FILE_HASH);
+
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally("PUBLIC1")).thenReturn(1L);
+            when(fileShareMapper.selectByShareCode("PUBLIC1")).thenReturn(share);
+            when(fileShareMapper.markAsExpiredIfNecessary("PUBLIC1")).thenReturn(0);
+            when(fileMapper.selectList(any())).thenReturn(List.of(sourceFile));
+            when(accountMapper.selectById(OTHER_USER_ID)).thenReturn(null);
+
+            try (MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                idUtilsMock.when(() -> IdUtils.toExternalId(7L)).thenReturn("ext_7");
+                assertEquals(1, fileQueryService.getShareFile("PUBLIC1").size());
+            }
+            share.setExpireTime(new java.util.Date(System.currentTimeMillis() - 1_000));
+            GeneralException ex = assertThrows(
+                    GeneralException.class,
+                    () -> fileQueryService.getShareFile("PUBLIC1"));
+
+            assertEquals(ResultEnum.SHARE_EXPIRED, ex.getResultEnum());
+            verify(fileShareMapper, times(2)).selectByShareCode("PUBLIC1");
+            verify(fileMapper, times(1)).selectList(any());
         }
 
         /**
@@ -495,6 +573,7 @@ class FileQueryServiceTest {
                     () -> fileQueryService.getShareFile(" "));
 
             assertEquals(ResultEnum.PARAM_IS_INVALID.getCode(), ex.getResultEnum().getCode());
+            verify(fileShareMapper, never()).selectTenantIdByShareCodeGlobally(anyString());
             verify(fileShareMapper, never()).selectByShareCode(anyString());
         }
     }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileServiceCacheTenantIsolationTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileServiceCacheTenantIsolationTest.java
@@ -130,6 +130,18 @@ class FileServiceCacheTenantIsolationTest {
     }
 
     /**
+     * 验证匿名分享文件查询不受方法级缓存短路，确保每次请求都重新校验授权与文件状态。
+     */
+    @Test
+    @DisplayName("should not cache authorization-sensitive public share file lookup")
+    void shouldNotCacheAuthorizationSensitivePublicShareFileLookup() throws NoSuchMethodException {
+        CacheOperationSource source = new AnnotationCacheOperationSource();
+        Method method = FileQueryServiceImpl.class.getMethod("getShareFile", String.class);
+
+        assertThat(source.getCacheOperations(method, FileQueryServiceImpl.class)).isNullOrEmpty();
+    }
+
+    /**
      * 证明相同用户在两个租户下各自首次回源，后续及交错切换均命中自己的缓存。
      */
     @Test

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileServiceTest.java
@@ -1,5 +1,8 @@
 package cn.flying.service.impl;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.constant.ShareType;
 import cn.flying.common.exception.GeneralException;
@@ -15,6 +18,7 @@ import cn.flying.dao.mapper.FileMapper;
 import cn.flying.dao.mapper.FileShareMapper;
 import cn.flying.dao.mapper.FileSourceMapper;
 import cn.flying.dao.mapper.ProofBundleIssuanceMapper;
+import cn.flying.dao.vo.file.FileDecryptInfoVO;
 import cn.flying.dao.vo.file.ShareFileVO;
 import cn.flying.dao.vo.file.ShareInfoVO;
 import cn.flying.dao.vo.file.UpdateShareVO;
@@ -32,6 +36,8 @@ import cn.flying.service.saga.FileSagaOrchestrator;
 import cn.flying.service.saga.FileUploadResult;
 import cn.flying.test.builders.FileTestBuilder;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.*;
@@ -45,6 +51,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -56,6 +63,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -149,6 +158,14 @@ class FileServiceTest {
         when(cacheManager.getCache(anyString())).thenReturn(cache);
     }
 
+    /**
+     * 清理测试设置的租户上下文，避免 ThreadLocal 跨用例污染。
+     */
+    @AfterEach
+    void clearTenantContext() {
+        TenantContext.clear();
+    }
+
     // ================== Helper Methods ==================
 
     private FileShare aFileShare() {
@@ -200,6 +217,7 @@ class FileServiceTest {
             when(fileMapper.selectCount(any())).thenReturn(1L);
             setupShareResultSuccess(SHARE_CODE);
             when(fileRemoteClient.shareFiles(any())).thenReturn(shareResult);
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(null);
             doAnswer(inv -> {
                 FileShare fs = inv.getArgument(0);
                 fs.setId(1L);
@@ -234,6 +252,7 @@ class FileServiceTest {
             when(fileMapper.selectCount(any())).thenReturn(1L);
             setupShareResultSuccess(SHARE_CODE);
             when(fileRemoteClient.shareFiles(any())).thenReturn(shareResult);
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(null);
             doAnswer(inv -> {
                 FileShare fs = inv.getArgument(0);
                 fs.setId(1L);
@@ -249,6 +268,42 @@ class FileServiceTest {
             ArgumentCaptor<FileShare> shareCaptor = ArgumentCaptor.forClass(FileShare.class);
             verify(fileShareMapper).insert(shareCaptor.capture());
             assertEquals(ShareType.PRIVATE.getCode(), shareCaptor.getValue().getShareType());
+        }
+
+        /**
+         * 验证创建公开分享时应用文本日志不会写入可直接使用的分享码。
+         */
+        @Test
+        @DisplayName("should not log raw share code after creation")
+        void shouldNotLogRawShareCodeAfterCreation() {
+            when(fileMapper.selectCount(any())).thenReturn(1L);
+            setupShareResultSuccess(SHARE_CODE);
+            when(fileRemoteClient.shareFiles(any())).thenReturn(shareResult);
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(null);
+            doAnswer(invocation -> {
+                FileShare share = invocation.getArgument(0);
+                share.setId(10L);
+                return 1;
+            }).when(fileShareMapper).insert(any(FileShare.class));
+
+            Logger logger = (Logger) LoggerFactory.getLogger(FileServiceImpl.class);
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.addAppender(appender);
+            try {
+                fileService.generateSharingCode(
+                        USER_ID,
+                        List.of(FILE_HASH),
+                        60,
+                        ShareType.PUBLIC.getCode());
+            } finally {
+                logger.detachAppender(appender);
+                appender.stop();
+            }
+
+            assertTrue(appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .noneMatch(message -> message.contains(SHARE_CODE)));
         }
 
         @Test
@@ -276,6 +331,21 @@ class FileServiceTest {
             GeneralException ex2 = assertThrows(GeneralException.class, () ->
                     fileService.generateSharingCode(USER_ID, fileHashes, 0, ShareType.PUBLIC.getCode()));
             assertEquals(ResultEnum.PARAM_ERROR.getCode(), ex2.getResultEnum().getCode());
+        }
+
+        /**
+         * 验证服务边界不会把未知分享类型降级为公开分享。
+         */
+        @Test
+        @DisplayName("should reject unsupported share type before remote or database side effects")
+        void shouldRejectUnsupportedShareType() {
+            GeneralException error = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.generateSharingCode(USER_ID, List.of(FILE_HASH), 60, 99));
+
+            assertEquals(ResultEnum.PARAM_IS_INVALID, error.getResultEnum());
+            verifyNoInteractions(fileRemoteClient);
+            verify(fileShareMapper, never()).insert(any(FileShare.class));
         }
 
         @Test
@@ -392,6 +462,63 @@ class FileServiceTest {
 
             assertEquals(ResultEnum.FAIL.getCode(), ex.getResultEnum().getCode());
         }
+
+        /**
+         * 验证直接调用服务时未知分享类型也在读取或更新数据库前被拒绝。
+         */
+        @Test
+        @DisplayName("should reject unsupported share type before update lookup")
+        void shouldRejectUnsupportedShareType() {
+            UpdateShareVO updateVO = createUpdateShareVO(SHARE_CODE, 99, null);
+
+            GeneralException error = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.updateShare(USER_ID, updateVO));
+
+            assertEquals(ResultEnum.PARAM_IS_INVALID, error.getResultEnum());
+            verify(fileShareMapper, never()).selectByShareCode(anyString());
+            verify(fileShareMapper, never()).update(any(), any());
+        }
+
+        /**
+         * 验证延期使用 owner、非取消状态条件，并在同一 SQL 中恢复 active 状态。
+         */
+        @Test
+        @DisplayName("should extend expired share with one cancellation-safe conditional update")
+        void shouldExtendExpiredShareWithConditionalUpdate() {
+            FileShare share = aFileShare(s -> s.setStatus(FileShare.STATUS_EXPIRED));
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+            when(fileShareMapper.update(isNull(), any())).thenReturn(1);
+            UpdateShareVO updateVO = createUpdateShareVO(SHARE_CODE, null, 60);
+
+            fileService.updateShare(USER_ID, updateVO);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Wrapper<FileShare>> wrapperCaptor = ArgumentCaptor.forClass(Wrapper.class);
+            verify(fileShareMapper).update(isNull(), wrapperCaptor.capture());
+            LambdaUpdateWrapper<FileShare> wrapper = (LambdaUpdateWrapper<FileShare>) wrapperCaptor.getValue();
+            assertTrue(wrapper.getSqlSet().contains("expire_time"));
+            assertTrue(wrapper.getSqlSet().contains("status"));
+            assertTrue(wrapper.getSqlSegment().contains("share_code"));
+            assertTrue(wrapper.getSqlSegment().contains("user_id"));
+            assertTrue(wrapper.getSqlSegment().contains("status"));
+        }
+
+        /**
+         * 验证空更新不会生成无 SET 子句的数据库语句。
+         */
+        @Test
+        @DisplayName("should reject update without any changed field")
+        void shouldRejectUpdateWithoutAnyChangedField() {
+            UpdateShareVO updateVO = createUpdateShareVO(SHARE_CODE, null, null);
+
+            GeneralException error = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.updateShare(USER_ID, updateVO));
+
+            assertEquals(ResultEnum.PARAM_IS_INVALID, error.getResultEnum());
+            verify(fileShareMapper, never()).selectByShareCode(anyString());
+        }
     }
 
     // ================== Delete Files Tests ==================
@@ -467,6 +594,14 @@ class FileServiceTest {
     @DisplayName("Get Share By Code")
     class GetShareByCode {
 
+        /**
+         * 为无请求租户上下文的兼容入口提供窄全局租户定位。
+         */
+        @BeforeEach
+        void stubGlobalTenantLookup() {
+            lenient().when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(1L);
+        }
+
         @Test
         @DisplayName("should return active share and increment access count")
         void shouldReturnActiveShareAndIncrementCount() {
@@ -485,6 +620,8 @@ class FileServiceTest {
             assertEquals(USER_ID, result.getUserId());
             assertTrue(result.getFileHashes().contains(FILE_HASH));
             verify(fileShareMapper).incrementAccessCountIfActive(SHARE_CODE);
+            assertFalse(TenantContext.isSet());
+            assertFalse(TenantContext.isIgnoreIsolation());
         }
 
         @Test
@@ -728,8 +865,9 @@ class FileServiceTest {
         @Test
         @DisplayName("should throw cancelled when expiration is negative")
         void shouldThrowCancelledWhenExpirationIsNegative() {
-            when(fileShareMapper.selectByShareCode(SHARE_CODE))
-                    .thenReturn(aFileShare(s -> s.setStatus(FileShare.STATUS_CANCELLED)));
+            FileShare share = aFileShare(s -> s.setStatus(FileShare.STATUS_CANCELLED));
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
 
             GeneralException ex = assertThrows(GeneralException.class, () -> fileService.getShareFile(SHARE_CODE));
 
@@ -742,8 +880,9 @@ class FileServiceTest {
         @Test
         @DisplayName("should throw expired when share is timeout")
         void shouldThrowExpiredWhenShareIsTimeout() {
-            when(fileShareMapper.selectByShareCode(SHARE_CODE))
-                    .thenReturn(aFileShare(s -> s.setExpireTime(new Date(System.currentTimeMillis() - 1000))));
+            FileShare share = aFileShare(s -> s.setExpireTime(new Date(System.currentTimeMillis() - 1000)));
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
 
             GeneralException ex = assertThrows(GeneralException.class, () -> fileService.getShareFile(SHARE_CODE));
 
@@ -756,8 +895,9 @@ class FileServiceTest {
         @Test
         @DisplayName("should throw cancelled when share is invalid")
         void shouldThrowCancelledWhenShareIsInvalid() {
-            when(fileShareMapper.selectByShareCode(SHARE_CODE))
-                    .thenReturn(aFileShare(s -> s.setStatus(FileShare.STATUS_CANCELLED)));
+            FileShare share = aFileShare(s -> s.setStatus(FileShare.STATUS_CANCELLED));
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
 
             GeneralException ex = assertThrows(GeneralException.class, () -> fileService.getShareFile(SHARE_CODE));
 
@@ -779,7 +919,9 @@ class FileServiceTest {
                     .setFileSize(1024L)
                     .setContentType("text/plain")
                     .setDeleted(0);
-            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(aFileShare());
+            FileShare share = aFileShare();
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
             when(fileMapper.selectList(any())).thenReturn(List.of(sourceFile));
 
             List<ShareFileVO> result;
@@ -805,6 +947,7 @@ class FileServiceTest {
         @Test
         @DisplayName("should return safe file view for public share info")
         void shouldReturnSafeFileViewForPublicShareInfo() {
+            FileShare share = aFileShare();
             File sourceFile = new File()
                     .setId(1L)
                     .setTenantId(1L)
@@ -813,8 +956,26 @@ class FileServiceTest {
                     .setFileHash(FILE_HASH)
                     .setFileParam("{\"initialKey\":\"secret\"}")
                     .setDeleted(0);
-            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(aFileShare());
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenAnswer(invocation -> {
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(99L, TenantContext.getTenantId());
+                return share.getTenantId();
+            });
+            AtomicInteger shareLookups = new AtomicInteger();
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenAnswer(invocation -> {
+                shareLookups.incrementAndGet();
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(share.getTenantId(), TenantContext.getTenantId());
+                return share;
+            });
+            when(fileShareMapper.markAsExpiredIfNecessary(SHARE_CODE)).thenAnswer(invocation -> {
+                assertFalse(TenantContext.isIgnoreIsolation());
+                assertEquals(share.getTenantId(), TenantContext.getTenantId());
+                return 0;
+            });
             when(fileMapper.selectList(any())).thenReturn(List.of(sourceFile));
+
+            TenantContext.setTenantId(99L);
 
             ShareInfoVO info;
             try (MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
@@ -827,6 +988,9 @@ class FileServiceTest {
             assertEquals(1, info.getFiles().size());
             assertEquals("ext_1", info.getFiles().get(0).id());
             assertEquals("public.txt", info.getFiles().get(0).fileName());
+            assertEquals(99L, TenantContext.getTenantId());
+            assertFalse(TenantContext.isIgnoreIsolation());
+            assertEquals(1, shareLookups.get());
         }
 
         /**
@@ -835,13 +999,46 @@ class FileServiceTest {
         @Test
         @DisplayName("should reject private share info")
         void shouldRejectPrivateShareInfo() {
-            when(fileShareMapper.selectByShareCode(SHARE_CODE))
-                    .thenReturn(aFileShare(s -> s.setShareType(ShareType.PRIVATE.getCode())));
+            FileShare share = aFileShare(s -> s.setShareType(ShareType.PRIVATE.getCode()));
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
 
             GeneralException ex = assertThrows(GeneralException.class, () -> fileService.getShareInfo(SHARE_CODE));
 
             assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED.getCode(), ex.getResultEnum().getCode());
             verify(fileMapper, never()).selectList(any());
+            verify(fileShareMapper, never()).incrementAccessCountIfActive(SHARE_CODE);
+        }
+
+        /**
+         * 验证匿名分享详情对缺失或未知状态、类型均失败关闭。
+         */
+        @Test
+        @DisplayName("should reject invalid status or type on public share info")
+        void shouldRejectInvalidStatusOrTypeOnPublicShareInfo() {
+            for (Integer invalidStatus : new Integer[]{null, 99}) {
+                FileShare share = aFileShare(s -> s.setStatus(invalidStatus));
+                when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+                when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+
+                GeneralException ex = assertThrows(
+                        GeneralException.class,
+                        () -> fileService.getShareInfo(SHARE_CODE));
+                assertEquals(ResultEnum.FAIL, ex.getResultEnum());
+            }
+
+            for (Integer invalidType : new Integer[]{null, 99}) {
+                FileShare share = aFileShare(s -> s.setShareType(invalidType));
+                when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+                when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+
+                GeneralException ex = assertThrows(
+                        GeneralException.class,
+                        () -> fileService.getShareInfo(SHARE_CODE));
+                assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED, ex.getResultEnum());
+            }
+            verify(fileMapper, never()).selectList(any());
+            verify(fileShareMapper, never()).incrementAccessCountIfActive(SHARE_CODE);
         }
 
         /**
@@ -850,8 +1047,9 @@ class FileServiceTest {
         @Test
         @DisplayName("should return empty status when share has no file hashes")
         void shouldReturnEmptyStatusWhenShareHasNoFileHashes() {
-            when(fileShareMapper.selectByShareCode(SHARE_CODE))
-                    .thenReturn(aFileShare(s -> s.setFileHashes("[]")));
+            FileShare share = aFileShare(s -> s.setFileHashes("[]"));
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
 
             ShareInfoVO info = fileService.getShareInfo(SHARE_CODE);
 
@@ -859,6 +1057,332 @@ class FileServiceTest {
             assertEquals(SHARE_CODE, info.getShareCode());
             assertEquals(ShareInfoVO.STATUS_EMPTY_FILES, info.getStatus());
             verify(fileMapper, never()).selectList(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Public Share Tenant Boundary")
+    class PublicShareTenantBoundary {
+
+        /**
+         * 验证公开分片下载只跨租户定位分享元数据，随后所有文件读取、远程调用和计数都在 owner 租户执行。
+         */
+        @Test
+        @DisplayName("should execute public download in share owner tenant and restore caller context")
+        void shouldExecutePublicDownloadInShareOwnerTenantAndRestoreCallerContext() {
+            FileShare share = aFileShare(s -> s.setTenantId(7L));
+            File sourceFile = new File()
+                    .setId(8L)
+                    .setTenantId(7L)
+                    .setUid(USER_ID)
+                    .setFileName("public.txt")
+                    .setFileHash(FILE_HASH)
+                    .setFileSize(3L);
+            AtomicInteger shareLookups = stubGlobalThenOwnerShareLookup(share, 99L);
+
+            when(fileMapper.selectOne(any())).thenAnswer(invocation -> {
+                assertOwnerTenant(7L);
+                return sourceFile;
+            });
+            when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH)).thenAnswer(invocation -> {
+                assertOwnerTenant(7L);
+                return Result.success(new FileDetailVO(
+                        String.valueOf(USER_ID),
+                        "public.txt",
+                        null,
+                        "{\"cipher-hash\":\"chunks/public-0\"}",
+                        FILE_HASH,
+                        null,
+                        null,
+                        3L,
+                        "text/plain"
+                ));
+            });
+            when(fileRemoteClient.getFileListByHash(
+                    List.of("chunks/public-0"), List.of("cipher-hash"))).thenAnswer(invocation -> {
+                assertOwnerTenant(7L);
+                return Result.success(List.of("abc".getBytes()));
+            });
+            when(fileShareMapper.incrementAccessCount(SHARE_CODE)).thenAnswer(invocation -> {
+                assertOwnerTenant(7L);
+                return 1;
+            });
+
+            TenantContext.setTenantId(99L);
+            TenantContext.setIgnoreIsolation(true);
+            List<byte[]> chunks = fileService.getPublicFile(SHARE_CODE, FILE_HASH);
+
+            assertEquals(1, chunks.size());
+            assertArrayEquals("abc".getBytes(), chunks.getFirst());
+            assertEquals(1, shareLookups.get());
+            assertEquals(99L, TenantContext.getTenantId());
+            assertTrue(TenantContext.isIgnoreIsolation());
+        }
+
+        /**
+         * 验证公开解密信息在 owner 租户读取文件和密钥信封，并在返回后恢复原调用者租户。
+         */
+        @Test
+        @DisplayName("should execute public decrypt lookup in share owner tenant and restore caller context")
+        void shouldExecutePublicDecryptLookupInShareOwnerTenantAndRestoreCallerContext() {
+            FileShare share = aFileShare(s -> s.setTenantId(7L));
+            File sourceFile = new File()
+                    .setId(8L)
+                    .setTenantId(7L)
+                    .setUid(USER_ID)
+                    .setFileName("public.txt")
+                    .setFileHash(FILE_HASH)
+                    .setFileParam("""
+                            {"encryptionAlgorithm":"AES-GCM","fileName":"public.txt","fileSize":3,"contentType":"text/plain","chunkCount":1}
+                            """);
+            AtomicInteger shareLookups = stubGlobalThenOwnerShareLookup(share, 99L);
+
+            when(fileMapper.selectOne(any(), anyBoolean())).thenAnswer(invocation -> {
+                assertOwnerTenant(7L);
+                return sourceFile;
+            });
+            when(fileKeyEnvelopeService.unwrapActiveShareInitialKey(
+                    eq(sourceFile),
+                    eq(FILE_HASH),
+                    eq(share),
+                    isNull(),
+                    eq("SHARE_DECRYPT")
+            )).thenAnswer(invocation -> {
+                assertOwnerTenant(7L);
+                return Optional.of("owner-share-key");
+            });
+
+            TenantContext.setTenantId(99L);
+            FileDecryptInfoVO decryptInfo = fileService.getPublicFileDecryptInfo(SHARE_CODE, FILE_HASH);
+
+            assertEquals("owner-share-key", decryptInfo.initialKey());
+            assertEquals(FILE_HASH, decryptInfo.fileHash());
+            assertEquals(1, shareLookups.get());
+            assertEquals(99L, TenantContext.getTenantId());
+            assertFalse(TenantContext.isIgnoreIsolation());
+        }
+
+        /**
+         * 验证匿名公开入口不能借分享码读取私密分享的文件内容或解密信息。
+         */
+        @Test
+        @DisplayName("should reject private share on both anonymous public file endpoints")
+        void shouldRejectPrivateShareOnAnonymousPublicFileEndpoints() {
+            FileShare share = aFileShare(s -> s.setShareType(ShareType.PRIVATE.getCode()));
+            stubPublicShareLookup(share);
+
+            GeneralException downloadError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFile(SHARE_CODE, FILE_HASH));
+            GeneralException decryptError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFileDecryptInfo(SHARE_CODE, FILE_HASH));
+
+            assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED, downloadError.getResultEnum());
+            assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED, decryptError.getResultEnum());
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证取消状态的分享在两个匿名公开文件入口都失败关闭。
+         */
+        @Test
+        @DisplayName("should reject cancelled share on both anonymous public file endpoints")
+        void shouldRejectCancelledShareOnAnonymousPublicFileEndpoints() {
+            FileShare share = aFileShare(s -> s.setStatus(FileShare.STATUS_CANCELLED));
+            stubPublicShareLookup(share);
+
+            GeneralException downloadError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFile(SHARE_CODE, FILE_HASH));
+            GeneralException decryptError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFileDecryptInfo(SHARE_CODE, FILE_HASH));
+
+            assertEquals(ResultEnum.FAIL, downloadError.getResultEnum());
+            assertEquals(ResultEnum.FAIL, decryptError.getResultEnum());
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证数据库已标记过期的分享即使过期时间异常地仍在未来，也不能被公开入口读取。
+         */
+        @Test
+        @DisplayName("should reject expired status even when expire time is still in future")
+        void shouldRejectExpiredStatusEvenWhenExpireTimeIsStillInFuture() {
+            FileShare share = aFileShare(s -> s.setStatus(FileShare.STATUS_EXPIRED));
+            stubPublicShareLookup(share);
+
+            GeneralException downloadError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFile(SHARE_CODE, FILE_HASH));
+            GeneralException decryptError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFileDecryptInfo(SHARE_CODE, FILE_HASH));
+
+            assertEquals(ResultEnum.SHARE_EXPIRED, downloadError.getResultEnum());
+            assertEquals(ResultEnum.SHARE_EXPIRED, decryptError.getResultEnum());
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证缺失或未知状态在两个匿名文件入口都失败关闭且不会触发数据读取。
+         */
+        @Test
+        @DisplayName("should reject missing or unknown status on anonymous public file endpoints")
+        void shouldRejectMissingOrUnknownStatusOnAnonymousPublicFileEndpoints() {
+            for (Integer invalidStatus : new Integer[]{null, 99}) {
+                FileShare share = aFileShare(s -> s.setStatus(invalidStatus));
+                stubPublicShareLookup(share);
+
+                GeneralException downloadError = assertThrows(
+                        GeneralException.class,
+                        () -> fileService.getPublicFile(SHARE_CODE, FILE_HASH));
+                GeneralException decryptError = assertThrows(
+                        GeneralException.class,
+                        () -> fileService.getPublicFileDecryptInfo(SHARE_CODE, FILE_HASH));
+
+                assertEquals(ResultEnum.FAIL, downloadError.getResultEnum());
+                assertEquals(ResultEnum.FAIL, decryptError.getResultEnum());
+            }
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证缺失或未知类型不能借枚举默认值降级成公开分享。
+         */
+        @Test
+        @DisplayName("should reject missing or unknown type on anonymous public file endpoints")
+        void shouldRejectMissingOrUnknownTypeOnAnonymousPublicFileEndpoints() {
+            for (Integer invalidType : new Integer[]{null, 99}) {
+                FileShare share = aFileShare(s -> s.setShareType(invalidType));
+                stubPublicShareLookup(share);
+
+                GeneralException downloadError = assertThrows(
+                        GeneralException.class,
+                        () -> fileService.getPublicFile(SHARE_CODE, FILE_HASH));
+                GeneralException decryptError = assertThrows(
+                        GeneralException.class,
+                        () -> fileService.getPublicFileDecryptInfo(SHARE_CODE, FILE_HASH));
+
+                assertEquals(ResultEnum.FAIL, downloadError.getResultEnum());
+                assertEquals(ResultEnum.FAIL, decryptError.getResultEnum());
+            }
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证未知持久化类型不能通过登录态分享下载或解密入口绕过类型校验。
+         */
+        @Test
+        @DisplayName("should reject unknown type on authenticated share file endpoints")
+        void shouldRejectUnknownTypeOnAuthenticatedShareFileEndpoints() {
+            FileShare share = aFileShare(s -> s.setShareType(99));
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+
+            GeneralException downloadError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getSharedFileContent(OTHER_USER_ID, SHARE_CODE, FILE_HASH));
+            GeneralException decryptError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getSharedFileDecryptInfo(OTHER_USER_ID, SHARE_CODE, FILE_HASH));
+
+            assertEquals(ResultEnum.FAIL, downloadError.getResultEnum());
+            assertEquals(ResultEnum.FAIL, decryptError.getResultEnum());
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证自然过期只调用带状态和时间条件的原子更新，不再执行无条件状态覆盖。
+         */
+        @Test
+        @DisplayName("should avoid unconditional status update when share expires naturally")
+        void shouldAvoidUnconditionalStatusUpdateWhenShareExpiresNaturally() {
+            FileShare share = aFileShare(s -> s.setExpireTime(new Date(System.currentTimeMillis() - 1_000L)));
+            stubPublicShareLookup(share);
+            when(fileShareMapper.markAsExpiredIfNecessary(SHARE_CODE)).thenReturn(1);
+
+            GeneralException error = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFile(SHARE_CODE, FILE_HASH));
+
+            assertEquals(ResultEnum.SHARE_EXPIRED, error.getResultEnum());
+            verify(fileShareMapper).markAsExpiredIfNecessary(SHARE_CODE);
+            verify(fileShareMapper, never()).update(any(), any());
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 验证分享未授权的文件哈希不能触发文件、密钥或远端存储读取。
+         */
+        @Test
+        @DisplayName("should reject file hash that is not included in public share")
+        void shouldRejectFileHashThatIsNotIncludedInPublicShare() {
+            FileShare share = aFileShare();
+            stubPublicShareLookup(share);
+            String unauthorizedHash = "sha256_not_in_share";
+
+            GeneralException downloadError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFile(SHARE_CODE, unauthorizedHash));
+            GeneralException decryptError = assertThrows(
+                    GeneralException.class,
+                    () -> fileService.getPublicFileDecryptInfo(SHARE_CODE, unauthorizedHash));
+
+            assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED, downloadError.getResultEnum());
+            assertEquals(ResultEnum.PERMISSION_UNAUTHORIZED, decryptError.getResultEnum());
+            assertNoPublicFileDataWasRead();
+        }
+
+        /**
+         * 为失败关闭用例伪造窄全局租户定位与 owner 租户内分享查询。
+         *
+         * @param share 待校验分享
+         */
+        private void stubPublicShareLookup(FileShare share) {
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(share.getTenantId());
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+        }
+
+        /**
+         * 断言授权失败发生在读取租户文件、密钥或远端存储之前。
+         */
+        private void assertNoPublicFileDataWasRead() {
+            verify(fileMapper, never()).selectOne(any());
+            verify(fileMapper, never()).selectOne(any(), anyBoolean());
+            verify(fileShareMapper, never()).incrementAccessCount(SHARE_CODE);
+            verifyNoInteractions(fileRemoteClient, fileKeyEnvelopeService);
+        }
+
+        /**
+         * 伪造全局分享定位与 owner 租户内的二次查询，并校验两阶段隔离边界。
+         *
+         * @param share 分享记录
+         * @param callerTenantId 原调用者租户
+         * @return 分享查询次数
+         */
+        private AtomicInteger stubGlobalThenOwnerShareLookup(FileShare share, long callerTenantId) {
+            AtomicInteger shareLookups = new AtomicInteger();
+            when(fileShareMapper.selectTenantIdByShareCodeGlobally(share.getShareCode())).thenAnswer(invocation -> {
+                assertEquals(callerTenantId, TenantContext.getTenantId());
+                return share.getTenantId();
+            });
+            when(fileShareMapper.selectByShareCode(share.getShareCode())).thenAnswer(invocation -> {
+                shareLookups.incrementAndGet();
+                assertOwnerTenant(share.getTenantId());
+                return share;
+            });
+            return shareLookups;
+        }
+
+        /**
+         * 断言当前执行只受 owner 租户隔离，未扩大跨租户绕过范围。
+         *
+         * @param ownerTenantId 分享 owner 租户
+         */
+        private void assertOwnerTenant(Long ownerTenantId) {
+            assertEquals(ownerTenantId, TenantContext.getTenantId());
+            assertFalse(TenantContext.isIgnoreIsolation());
         }
     }
 

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/ShareAuditServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/ShareAuditServiceImplTest.java
@@ -231,6 +231,26 @@ class ShareAuditServiceImplTest {
         }
     }
 
+    /**
+     * 验证三类异步审计写入失败均被隔离，不能反向破坏公开分享主流程。
+     */
+    @Test
+    @DisplayName("should isolate persistence failures for every share audit action")
+    void shouldIsolatePersistenceFailuresForEveryShareAuditAction() {
+        when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(createFileShare());
+        when(shareAccessLogMapper.insert(any(ShareAccessLog.class)))
+                .thenThrow(new IllegalStateException("audit unavailable"));
+
+        assertDoesNotThrow(() -> shareAuditService.logShareView(
+                SHARE_CODE, USER_ID, IP_ADDRESS, USER_AGENT));
+        assertDoesNotThrow(() -> shareAuditService.logShareDownload(
+                SHARE_CODE, USER_ID, FILE_HASH, FILE_NAME, IP_ADDRESS));
+        assertDoesNotThrow(() -> shareAuditService.logShareSave(
+                SHARE_CODE, USER_ID, FILE_HASH, FILE_NAME, IP_ADDRESS));
+
+        verify(shareAccessLogMapper, times(3)).insert(any(ShareAccessLog.class));
+    }
+
     @Nested
     @DisplayName("getShareAccessLogs")
     class GetShareAccessLogs {

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/ShareAuditServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/ShareAuditServiceImplTest.java
@@ -1,5 +1,9 @@
 package cn.flying.service.impl;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.exception.GeneralException;
 import cn.flying.common.tenant.TenantContext;
@@ -21,10 +25,10 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -63,18 +67,13 @@ class ShareAuditServiceImplTest {
 
     private MockedStatic<TenantContext> tenantContextMock;
 
-    @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
+        lenient().when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(TENANT_ID);
         tenantContextMock = mockStatic(TenantContext.class);
         tenantContextMock.when(TenantContext::getTenantId).thenReturn(TENANT_ID);
         tenantContextMock.when(TenantContext::requireTenantId).thenReturn(TENANT_ID);
-        tenantContextMock.when(() -> TenantContext.runWithoutIsolation(any(Supplier.class)))
-                .thenAnswer(inv -> {
-                    Supplier<?> supplier = inv.getArgument(0);
-                    return supplier.get();
-                });
-        tenantContextMock.when(() -> TenantContext.runWithTenant(anyLong(), any(Runnable.class)))
+        tenantContextMock.when(() -> TenantContext.runWithTenantIsolation(anyLong(), any(Runnable.class)))
                 .thenAnswer(inv -> {
                     Runnable runnable = inv.getArgument(1);
                     runnable.run();
@@ -99,7 +98,18 @@ class ShareAuditServiceImplTest {
 
             shareAuditService.logShareView(SHARE_CODE, USER_ID, IP_ADDRESS, USER_AGENT);
 
-            verify(shareAccessLogMapper).insert(any(ShareAccessLog.class));
+            ArgumentCaptor<ShareAccessLog> captor = ArgumentCaptor.forClass(ShareAccessLog.class);
+            verify(shareAccessLogMapper).insert(captor.capture());
+            ShareAccessLog inserted = captor.getValue();
+            assertEquals(TENANT_ID, inserted.getTenantId());
+            assertEquals(USER_ID, inserted.getShareOwnerId());
+            assertEquals(USER_ID, inserted.getActorUserId());
+            assertEquals(IP_ADDRESS, inserted.getActorIp());
+            assertEquals(USER_AGENT, inserted.getActorUa());
+            assertEquals(ShareAccessLog.ACTION_VIEW, inserted.getActionType());
+            verify(fileShareMapper).selectTenantIdByShareCodeGlobally(SHARE_CODE);
+            verify(fileShareMapper).selectByShareCode(SHARE_CODE);
+            tenantContextMock.verify(() -> TenantContext.runWithTenantIsolation(eq(TENANT_ID), any(Runnable.class)));
         }
 
         @Test
@@ -136,7 +146,15 @@ class ShareAuditServiceImplTest {
 
             shareAuditService.logShareDownload(SHARE_CODE, USER_ID, FILE_HASH, FILE_NAME, IP_ADDRESS);
 
-            verify(shareAccessLogMapper).insert(any(ShareAccessLog.class));
+            ArgumentCaptor<ShareAccessLog> captor = ArgumentCaptor.forClass(ShareAccessLog.class);
+            verify(shareAccessLogMapper).insert(captor.capture());
+            ShareAccessLog inserted = captor.getValue();
+            assertEquals(TENANT_ID, inserted.getTenantId());
+            assertEquals(USER_ID, inserted.getShareOwnerId());
+            assertEquals(FILE_HASH, inserted.getFileHash());
+            assertEquals(FILE_NAME, inserted.getFileName());
+            assertEquals(IP_ADDRESS, inserted.getActorIp());
+            assertEquals(ShareAccessLog.ACTION_DOWNLOAD, inserted.getActionType());
         }
 
         @Test
@@ -147,6 +165,43 @@ class ShareAuditServiceImplTest {
             shareAuditService.logShareDownload(SHARE_CODE, USER_ID, FILE_HASH, FILE_NAME, IP_ADDRESS);
 
             verify(shareAccessLogMapper, never()).insert(any(ShareAccessLog.class));
+        }
+
+        /**
+         * 验证成功和缺失分支的文本日志都不会泄露分享码或文件哈希。
+         */
+        @Test
+        @DisplayName("should not log raw share credentials")
+        void shouldNotLogRawShareCredentials() {
+            FileShare share = createFileShare();
+            when(fileShareMapper.selectByShareCode(SHARE_CODE)).thenReturn(share);
+
+            Logger logger = (Logger) LoggerFactory.getLogger(ShareAuditServiceImpl.class);
+            Level previousLevel = logger.getLevel();
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.setLevel(Level.DEBUG);
+            logger.addAppender(appender);
+            try {
+                shareAuditService.logShareDownload(
+                        SHARE_CODE,
+                        USER_ID,
+                        FILE_HASH,
+                        FILE_NAME,
+                        IP_ADDRESS);
+                when(fileShareMapper.selectTenantIdByShareCodeGlobally(SHARE_CODE)).thenReturn(null);
+                shareAuditService.logShareView(SHARE_CODE, USER_ID, IP_ADDRESS, USER_AGENT);
+            } finally {
+                logger.detachAppender(appender);
+                logger.setLevel(previousLevel);
+                appender.stop();
+            }
+
+            List<String> messages = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .toList();
+            assertTrue(messages.stream().noneMatch(message -> message.contains(SHARE_CODE)));
+            assertTrue(messages.stream().noneMatch(message -> message.contains(FILE_HASH)));
         }
     }
 

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/remote/FileRemoteClientTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/remote/FileRemoteClientTest.java
@@ -1,9 +1,14 @@
 package cn.flying.service.remote;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import cn.flying.platformapi.constant.Result;
 import cn.flying.platformapi.constant.ResultEnum;
 import cn.flying.platformapi.external.BlockChainService;
 import cn.flying.platformapi.external.DistributedStorageService;
+import cn.flying.platformapi.request.CancelShareRequest;
 import cn.flying.platformapi.request.GetShareInfoRequest;
 import cn.flying.platformapi.request.GetAttestationBatchRequest;
 import cn.flying.platformapi.request.GetUserShareCodesRequest;
@@ -27,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Method;
@@ -386,6 +392,66 @@ class FileRemoteClientTest {
 
         assertThat(result.getCode()).isEqualTo(ResultEnum.GET_USER_SHARE_FILE_ERROR.getCode());
         assertThat(result.getData()).isNull();
+    }
+
+    /**
+     * 验证公开分享查询与取消分享降级路径返回稳定错误且不泄露原始分享码。
+     */
+    @Test
+    void publicShareFallbacks_shouldReturnStableErrors() throws Exception {
+        String shareCode = "share-secret";
+        Method getSharedFilesFallback = FileRemoteClient.class.getDeclaredMethod(
+                "getSharedFilesFallback",
+                String.class,
+                Throwable.class
+        );
+        Method cancelShareFallback = FileRemoteClient.class.getDeclaredMethod(
+                "cancelShareFallback",
+                CancelShareRequest.class,
+                Throwable.class
+        );
+
+        assertThat(getSharedFilesFallback.getReturnType()).isEqualTo(Result.class);
+        assertThat(cancelShareFallback.getReturnType()).isEqualTo(Result.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(FileRemoteClient.class);
+        Level previousLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.setLevel(Level.ERROR);
+        logger.addAppender(appender);
+
+        Result<SharingVO> sharedFilesResult;
+        Result<Boolean> cancelShareResult;
+        try {
+            @SuppressWarnings("unchecked")
+            Result<SharingVO> sharedFilesFallback = (Result<SharingVO>) ReflectionTestUtils.invokeMethod(
+                    fileRemoteClient,
+                    "getSharedFilesFallback",
+                    shareCode,
+                    new RuntimeException("boom")
+            );
+            sharedFilesResult = sharedFilesFallback;
+            @SuppressWarnings("unchecked")
+            Result<Boolean> cancelFallback = (Result<Boolean>) ReflectionTestUtils.invokeMethod(
+                    fileRemoteClient,
+                    "cancelShareFallback",
+                    new CancelShareRequest(shareCode, "owner", "viewer"),
+                    new RuntimeException("boom")
+            );
+            cancelShareResult = cancelFallback;
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(previousLevel);
+            appender.stop();
+        }
+
+        assertThat(sharedFilesResult.getCode()).isEqualTo(ResultEnum.GET_USER_SHARE_FILE_ERROR.getCode());
+        assertThat(sharedFilesResult.getData()).isNull();
+        assertThat(cancelShareResult.getCode()).isEqualTo(ResultEnum.BLOCKCHAIN_ERROR.getCode());
+        assertThat(cancelShareResult.getData()).isFalse();
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .noneMatch(message -> message.contains(shareCode));
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -344,7 +345,8 @@ public class OperationLogAspect {
         if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
             path = path.substring(contextPath.length());
         }
-        String normalized = path.toLowerCase();
+        String normalized = SensitiveDataMasker.normalizePathForRouteMatching(path)
+                .toLowerCase(Locale.ROOT);
         return normalized.startsWith("/api/file")
                 || normalized.startsWith("/api/v1/files")
                 || normalized.startsWith("/api/v1/shares")

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/CacheConfiguration.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/CacheConfiguration.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
  * <ul>
  *   <li><b>Query 缓存</b>：userFiles, fileDecryptInfo, fileAddress - 高命中率读操作</li>
  *   <li><b>元数据缓存</b>：fileMeta, fileList - 文件元信息</li>
- *   <li><b>分享缓存</b>：sharedFiles - 分享文件查询</li>
  * </ul>
  *
  * <h3>缓存策略</h3>
@@ -42,7 +41,6 @@ public class CacheConfiguration {
     public static final String CACHE_USER_FILES = "userFiles";
     public static final String CACHE_FILE_DECRYPT_INFO = "fileDecryptInfo";
     public static final String CACHE_FILE_ADDRESS = "fileAddress";
-    public static final String CACHE_SHARED_FILES = "sharedFiles";
     public static final String CACHE_FILE_META = "fileMeta";
     public static final String CACHE_FILE_LIST = "fileList";
     public static final String CACHE_TRANSACTION = "transaction";
@@ -59,7 +57,6 @@ public class CacheConfiguration {
                 CACHE_USER_FILES,
                 CACHE_FILE_DECRYPT_INFO,
                 CACHE_FILE_ADDRESS,
-                CACHE_SHARED_FILES,
                 CACHE_TRANSACTION,
                 // 元数据缓存
                 CACHE_FILE_META,

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
@@ -99,7 +99,9 @@ public class SecurityConfiguration {
                                 "/error"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/shares/*/files").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/public/shares/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/public/shares/*/files/*/chunks",
+                                "/api/v1/public/shares/*/files/*/decrypt-info").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/public/proofs/*/status").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/public/proof-keys/*/versions/*").permitAll()
                         .requestMatchers("/api/v1/images/download/images/**").permitAll()

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/ShareController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/ShareController.java
@@ -9,6 +9,7 @@ import cn.flying.dao.vo.file.ShareInfoVO;
 import cn.flying.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +44,11 @@ public class ShareController {
      * @return 分享详情
      */
     @GetMapping("/{shareCode}/info")
-    @Operation(summary = "获取分享详情")
+    @Operation(
+            summary = "获取分享详情",
+            description = "匿名 GET；不需要 JWT 或租户头。即使提供 X-Tenant-ID 也会被忽略，服务端仅按 shareCode "
+                    + "解析 owner tenant，并在该租户内读取分享、文件、访问计数和分享审计数据。")
+    @SecurityRequirements
     @OperationLog(module = "分享", operationType = "查询", description = "获取分享详情")
     public Result<ShareInfoVO> getShareInfo(@Parameter(description = "分享码") @PathVariable String shareCode) {
         if (CommonUtils.isBlank(shareCode) || shareCode.length() > 64) {

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/ShareRestController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/ShareRestController.java
@@ -9,11 +9,13 @@ import cn.flying.dao.vo.file.FileSharingVO;
 import cn.flying.dao.vo.file.SaveSharingFile;
 import cn.flying.dao.vo.file.ShareFileVO;
 import cn.flying.dao.vo.file.UpdateShareVO;
+import cn.flying.security.TrustedClientIpResolver;
 import cn.flying.service.FileQueryService;
 import cn.flying.service.FileService;
 import cn.flying.service.ShareAuditService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,6 +46,8 @@ public class ShareRestController {
     private final FileQueryService fileQueryService;
 
     private final ShareAuditService shareAuditService;
+
+    private final TrustedClientIpResolver trustedClientIpResolver;
 
     /**
      * 创建分享（REST 新路径）。
@@ -94,7 +98,11 @@ public class ShareRestController {
      * @return 文件列表
      */
     @GetMapping("/api/v1/shares/{shareCode}/files")
-    @Operation(summary = "获取分享文件列表（REST）")
+    @Operation(
+            summary = "获取分享文件列表（REST）",
+            description = "匿名 GET；不需要 JWT 或租户头。调用者提供的 X-Tenant-ID 不参与授权或数据选择，"
+                    + "服务端仅按 shareCode 解析 owner tenant，并实时校验公开、有效和未过期状态。")
+    @SecurityRequirements
     @OperationLog(module = "文件操作", operationType = "查询", description = "获取分享文件列表（REST）")
     public Result<List<ShareFileVO>> getSharedFiles(@PathVariable String shareCode,
                                                     @RequestAttribute(value = Const.ATTR_USER_ID, required = false) Long userId,
@@ -171,8 +179,19 @@ public class ShareRestController {
      */
     @OperationLog(module = "文件操作", operationType = "查询", description = "公开分享下载文件")
     @GetMapping("/api/v1/public/shares/{shareCode}/files/{fileHash}/chunks")
-    @RateLimit(limit = 30, type = RateLimit.LimitType.IP, key = "public:download")
-    @Operation(summary = "公开分享下载文件（REST）")
+    @SecurityRequirements
+    @RateLimit(
+            limit = 30,
+            type = RateLimit.LimitType.IP,
+            key = "public:share-access",
+            tenantScoped = false,
+            clientIpMode = RateLimit.ClientIpMode.TRUSTED_PEER
+    )
+    @Operation(
+            summary = "公开分享下载文件（REST）",
+            description = "匿名 GET；不需要 JWT 或租户头，X-Tenant-ID 不参与授权。服务端按 shareCode 恢复 owner tenant，"
+                    + "并与公开解密接口共享规范客户端 IP 的 30 次/60 秒限流桶；第 31 次当前以 HTTP 200、"
+                    + "业务码 70005 拒绝。")
     public Result<List<byte[]>> publicDownload(@PathVariable String shareCode,
                                                @PathVariable String fileHash,
                                                HttpServletRequest request) {
@@ -190,8 +209,19 @@ public class ShareRestController {
      */
     @OperationLog(module = "文件操作", operationType = "查询", description = "获取公开分享文件解密信息")
     @GetMapping("/api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info")
-    @RateLimit(limit = 30, type = RateLimit.LimitType.IP, key = "public:decryptInfo")
-    @Operation(summary = "公开分享获取解密信息（REST）")
+    @SecurityRequirements
+    @RateLimit(
+            limit = 30,
+            type = RateLimit.LimitType.IP,
+            key = "public:share-access",
+            tenantScoped = false,
+            clientIpMode = RateLimit.ClientIpMode.TRUSTED_PEER
+    )
+    @Operation(
+            summary = "公开分享获取解密信息（REST）",
+            description = "匿名 GET；不需要 JWT 或租户头，X-Tenant-ID 不参与授权。服务端按 shareCode 恢复 owner tenant，"
+                    + "并与公开下载接口共享规范客户端 IP 的 30 次/60 秒限流桶；第 31 次当前以 HTTP 200、"
+                    + "业务码 70005 拒绝。")
     public Result<FileDecryptInfoVO> publicDecryptInfo(@Parameter(description = "分享码") @PathVariable String shareCode,
                                                        @Parameter(description = "文件哈希") @PathVariable String fileHash) {
         return Result.success(fileService.getPublicFileDecryptInfo(shareCode, fileHash));
@@ -201,9 +231,9 @@ public class ShareRestController {
      * 获取审计用客户端 IP。
      *
      * @param request 当前请求
-     * @return servlet 容器确认的客户端 IP
+     * @return 按可信代理配置规范化后的客户端 IP
      */
     private String getClientIp(HttpServletRequest request) {
-        return request.getRemoteAddr();
+        return trustedClientIpResolver.resolve(request);
     }
 }

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/FlowLimitingFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/FlowLimitingFilter.java
@@ -6,6 +6,7 @@ import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.DistributedRateLimiter;
 import cn.flying.common.util.ErrorPayloadFactory;
+import cn.flying.common.util.SensitiveDataMasker;
 import cn.flying.common.util.DistributedRateLimiter.RateLimitResult;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
@@ -116,7 +117,9 @@ public class FlowLimitingFilter extends HttpFilter {
         } else {
             Object tenantId = request.getAttribute(Const.ATTR_TENANT_ID);
             log.warn("Rate limited request: ip={}, uri={}, method={}, tenantId={}, result={}, limit={}, period={}, block={}",
-                    clientIp, request.getRequestURI(), request.getMethod(), tenantId, result, limit, period, blockTime);
+                    clientIp,
+                    SensitiveDataMasker.maskSensitivePathSegments(request.getRequestURI()),
+                    request.getMethod(), tenantId, result, limit, period, blockTime);
             writeBlockMessage(response, result);
         }
     }

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/IdSecurityFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/IdSecurityFilter.java
@@ -2,6 +2,7 @@ package cn.flying.filter;
 
 
 import cn.flying.common.util.Const;
+import cn.flying.common.util.SensitiveDataMasker;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -59,7 +60,7 @@ public class IdSecurityFilter extends OncePerRequestFilter {
                     request.setAttribute("resourceType", resourceType);
                     
                 } catch (NumberFormatException e) {
-                    log.warn("无效的ID格式: {}", request.getRequestURI());
+                    log.warn("无效的ID格式: {}", SensitiveDataMasker.maskSensitivePathSegments(requestURI));
                 }
             }
         }
@@ -78,4 +79,4 @@ public class IdSecurityFilter extends OncePerRequestFilter {
         // 仅处理GET请求并且是API路径
         return "GET".equals(method) && path.startsWith("/api/");
     }
-} 
+}

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/RequestLogFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/RequestLogFilter.java
@@ -21,6 +21,7 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -161,7 +162,8 @@ public class RequestLogFilter extends OncePerRequestFilter {
         if (requestUri == null) {
             return false;
         }
-        String normalizedPath = requestUri.toLowerCase();
+        String normalizedPath = SensitiveDataMasker.normalizePathForRouteMatching(requestUri)
+                .toLowerCase(Locale.ROOT);
         return SENSITIVE_RESPONSE_PATH_MARKERS.stream().anyMatch(normalizedPath::contains);
     }
 

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
@@ -6,6 +6,7 @@ import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.ErrorPayloadFactory;
+import cn.flying.common.util.SensitiveDataMasker;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,7 +28,7 @@ import java.util.UUID;
 /**
  * 租户过滤器
  * 对需要租户隔离的请求解析 X-Tenant-ID 并设置 TenantContext。
- * 公开 proof 路径不信任调用者提供的租户头，其他未携带租户ID的请求（白名单除外）返回错误。
+ * 匿名公开 proof/share 路径不信任调用者提供的租户头，其他未携带租户ID的请求（白名单除外）返回错误。
  */
 @Component
 @Order(Const.SECURITY_ORDER - 10)  // 在 JWT 过滤器之前执行
@@ -86,22 +87,24 @@ public class TenantFilter extends OncePerRequestFilter {
             TenantContext.clear();
 
             String requestUri = request.getRequestURI();
+            String maskedRequestUri = SensitiveDataMasker.maskSensitivePathSegments(requestUri);
             String requestPath = request.getServletPath();
             if (requestPath == null || requestPath.isEmpty()) {
                 requestPath = requestUri;
             }
+            String routeMatchingPath = SensitiveDataMasker.normalizePathForRouteMatching(requestPath);
 
-            boolean whitelisted = isWhitelisted(requestPath);
+            boolean whitelisted = isWhitelisted(routeMatchingPath);
 
-            // 公开 proof 必须完整忽略调用者租户头，包括重复或畸形值
-            if (whitelisted && shouldIgnoreTenantHeader(requestPath)) {
+            // 匿名公开资源必须完整忽略调用者租户头，包括重复或畸形值
+            if (whitelisted && shouldIgnoreTenantHeader(request.getMethod(), routeMatchingPath)) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
             // 租户身份头必须唯一，避免代理与 Servlet 对重复头采用不同解释
             if (hasMultipleTenantHeaders(request)) {
-                log.warn("请求包含重复的租户ID头: {} {}", request.getMethod(), requestUri);
+                log.warn("请求包含重复的租户ID头: {} {}", request.getMethod(), maskedRequestUri);
                 sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
                 return;
             }
@@ -110,12 +113,12 @@ public class TenantFilter extends OncePerRequestFilter {
 
             // 显式空头属于畸形租户身份，不能降级成“未提供”或让 SSE query 覆盖
             if (tenantIdHeader != null && tenantIdHeader.isEmpty()) {
-                log.warn("租户ID头为空: {} {}", request.getMethod(), requestUri);
+                log.warn("租户ID头为空: {} {}", request.getMethod(), maskedRequestUri);
                 sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "租户标识格式错误");
                 return;
             }
 
-            boolean sseConnectRequest = SSE_CONNECT_PATH.equals(requestPath);
+            boolean sseConnectRequest = SSE_CONNECT_PATH.equals(routeMatchingPath);
             if (tenantIdHeader == null) {
                 // 仅对 SSE 连接接口允许从参数中获取租户提示，因为 EventSource 不支持自定义 Header
                 if (sseConnectRequest) {
@@ -131,7 +134,7 @@ public class TenantFilter extends OncePerRequestFilter {
                     filterChain.doFilter(request, response);
                     return;
                 }
-                log.warn("请求缺少租户ID: {} {}", request.getMethod(), requestUri);
+                log.warn("请求缺少租户ID: {} {}", request.getMethod(), maskedRequestUri);
                 sendErrorResponse(response, ResultEnum.PARAM_IS_INVALID, "缺少租户标识 (X-Tenant-ID)");
                 return;
             }
@@ -148,7 +151,7 @@ public class TenantFilter extends OncePerRequestFilter {
             if (sseConnectRequest) {
                 // SSE 匿名握手只能获得 Redis namespace 提示，短令牌消费成功前不能建立权威租户上下文
                 request.setAttribute(Const.ATTR_SSE_TENANT_HINT, tenantId);
-                log.debug("SSE 租户提示已解析: uri={}", requestUri);
+                log.debug("SSE 租户提示已解析: uri={}", maskedRequestUri);
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -158,7 +161,7 @@ public class TenantFilter extends OncePerRequestFilter {
             // 存储到请求属性，供 JWT 过滤器之后使用
             request.setAttribute(Const.ATTR_TENANT_ID, tenantId);
 
-            log.debug("租户上下文已设置: tenantId={}, uri={}", tenantId, requestUri);
+            log.debug("租户上下文已设置: tenantId={}, uri={}", tenantId, maskedRequestUri);
 
             // 解析异常捕获必须止于租户头，避免吞掉下游业务抛出的 NumberFormatException
             filterChain.doFilter(request, response);
@@ -188,11 +191,25 @@ public class TenantFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 判断白名单路径是否必须忽略请求租户头，并使用路径段边界避免相似前缀误匹配。
+     * 判断白名单路径是否必须忽略请求租户头，并使用方法及路径段边界避免扩大匿名分享范围。
+     *
+     * @param method HTTP 方法
+     * @param uri 请求路径
+     * @return 是否忽略租户头
      */
-    private boolean shouldIgnoreTenantHeader(String uri) {
-        return TENANT_HEADER_IGNORED_PATHS.stream()
+    private boolean shouldIgnoreTenantHeader(String method, String uri) {
+        boolean publicProof = TENANT_HEADER_IGNORED_PATHS.stream()
                 .anyMatch(prefix -> matchesPathOrDescendant(uri, prefix));
+        if (publicProof) {
+            return true;
+        }
+        if (!"GET".equalsIgnoreCase(method)) {
+            return false;
+        }
+        if (uri.matches("^/api/v1/shares/[^/]+/(info|files)/?$")) {
+            return true;
+        }
+        return uri.matches("^/api/v1/public/shares/[^/]+/files/[^/]+/(chunks|decrypt-info)/?$");
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
@@ -130,7 +130,7 @@ public class TenantFilter extends OncePerRequestFilter {
             }
 
             if (tenantIdHeader == null || tenantIdHeader.isEmpty()) {
-                if (whitelisted) {
+                if (whitelisted && !isSharePathFamily(routeMatchingPath)) {
                     filterChain.doFilter(request, response);
                     return;
                 }
@@ -210,6 +210,17 @@ public class TenantFilter extends OncePerRequestFilter {
             return true;
         }
         return uri.matches("^/api/v1/public/shares/[^/]+/files/[^/]+/(chunks|decrypt-info)/?$");
+    }
+
+    /**
+     * 判断请求是否属于分享路径族，避免通用前缀白名单放宽非匿名 GET 或受保护 mutation。
+     *
+     * @param uri 请求路径
+     * @return 是否属于公开或受保护分享路径族
+     */
+    private boolean isSharePathFamily(String uri) {
+        return matchesPathOrDescendant(uri, "/api/v1/shares")
+                || matchesPathOrDescendant(uri, "/api/v1/public/shares");
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/handler/GlobalExceptionHandler.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.exception.GeneralException;
 import cn.flying.common.exception.RetryableException;
 import cn.flying.common.util.ErrorPayloadFactory;
+import cn.flying.common.util.SensitiveDataMasker;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -274,13 +275,14 @@ public class GlobalExceptionHandler {
             AsyncRequestTimeoutException ex, HttpServletRequest request) {
         String contentType = request.getHeader("Accept");
         String uri = request.getRequestURI();
+        String maskedUri = SensitiveDataMasker.maskSensitivePathSegments(uri);
 
         if (uri.contains("/sse/") || (contentType != null && contentType.contains("text/event-stream"))) {
-            log.debug("SSE 请求超时/断开: uri={}, error={}", uri, ex.getMessage());
+            log.debug("SSE 请求超时/断开: uri={}, error={}", maskedUri, ex.getMessage());
             return ResponseEntity.ok().build();
         }
 
-        log.warn("异步请求超时: uri={}, error={}", uri, ex.getMessage());
+        log.warn("异步请求超时: uri={}, error={}", maskedUri, ex.getMessage());
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
     }
 
@@ -292,15 +294,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Void> handleIOException(IOException ex, HttpServletRequest request) {
         String contentType = request.getHeader("Accept");
         String uri = request.getRequestURI();
+        String maskedUri = SensitiveDataMasker.maskSensitivePathSegments(uri);
 
         // SSE 连接断开是正常行为，只记录 debug 日志
         if (uri.contains("/sse/") || (contentType != null && contentType.contains("text/event-stream"))) {
-            log.debug("SSE 连接断开: uri={}, error={}", uri, ex.getMessage());
+            log.debug("SSE 连接断开: uri={}, error={}", maskedUri, ex.getMessage());
             return ResponseEntity.ok().build();
         }
 
         // 其他 IO 异常记录 warn 日志
-        log.warn("IO 异常: uri={}, error={}", uri, ex.getMessage());
+        log.warn("IO 异常: uri={}, error={}", maskedUri, ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -136,6 +136,52 @@ class OperationLogAspectTest {
     }
 
     /**
+     * 验证编码字面量和矩阵参数不能绕过操作日志的敏感文件参数与响应省略规则。
+     */
+    @Test
+    @DisplayName("Should omit encoded public share credentials from operation logs")
+    void shouldOmitEncodedPublicShareCredentialsFromOperationLogs() throws Throwable {
+        String shareCode = "share-secret-credential";
+        String fileHash = "file-hash-secret";
+        String responseSecret = "chunk-response-secret";
+        String path = "/api/v1/public/sh%61res;x=1/%2E/" + shareCode
+                + "/f%69les;v=2//" + fileHash + "/chunks";
+        SysOperationLogService operationLogService = mock(SysOperationLogService.class);
+        OperationLogAspect aspect = new OperationLogAspect(operationLogService, newResolver(""));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        request.setServletPath(path);
+        request.setRemoteAddr("198.51.100.32");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ProceedingJoinPoint joinPoint = publicShareAuditedJoinPoint(shareCode, fileHash, responseSecret);
+        Logger aspectLogger = (Logger) LoggerFactory.getLogger(OperationLogAspect.class);
+        Level previousLevel = aspectLogger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        aspectLogger.setLevel(Level.INFO);
+        aspectLogger.addAppender(appender);
+        try {
+            assertThat(aspect.doAround(joinPoint)).isEqualTo(responseSecret);
+        } finally {
+            aspectLogger.detachAppender(appender);
+            aspectLogger.setLevel(previousLevel);
+            appender.stop();
+        }
+
+        var captor = org.mockito.ArgumentCaptor.forClass(SysOperationLog.class);
+        verify(operationLogService).saveOperationLog(captor.capture());
+        assertThat(captor.getValue().getRequestParam()).isEqualTo("<sensitive-file-operation>");
+        assertThat(captor.getValue().getResponseResult()).isEqualTo("<sensitive-file-operation>");
+        assertThat(captor.getValue().getRequestUrl())
+                .isEqualTo("/api/v1/public/sh%61res;x=1/%2E/***/f%69les;v=2//***/chunks");
+
+        List<String> messages = appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+        assertThat(messages).noneMatch(message -> message.contains(shareCode)
+                || message.contains(fileHash)
+                || message.contains(responseSecret));
+    }
+
+    /**
      * 验证系统审计接口本身也会进入操作日志，避免敏感管理动作缺失审计记录。
      */
     @Test
@@ -383,6 +429,29 @@ class OperationLogAspectTest {
         return joinPoint;
     }
 
+    /**
+     * 构造携带公开分享凭据和敏感响应的测试连接点。
+     */
+    private ProceedingJoinPoint publicShareAuditedJoinPoint(
+            String shareCode,
+            String fileHash,
+            String response) throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        Method method = AuditedFixture.class.getDeclaredMethod(
+                "executePublicShare",
+                String.class,
+                String.class
+        );
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{shareCode, fileHash});
+        when(joinPoint.proceed()).thenReturn(response);
+        when(signature.getMethod()).thenReturn(method);
+        when(signature.getDeclaringTypeName()).thenReturn(AuditedFixture.class.getName());
+        when(signature.getName()).thenReturn(method.getName());
+        return joinPoint;
+    }
+
     private static final class AuditedFixture {
 
         /**
@@ -404,6 +473,20 @@ class OperationLogAspectTest {
         private ResponseEntity<Void> executeSensitive(String token) {
             assertThat(token).isNotNull();
             return ResponseEntity.ok().build();
+        }
+
+        /**
+         * 提供会保存响应数据的公开分享审计目标方法。
+         */
+        @OperationLog(
+                module = "file",
+                operationType = "query",
+                description = "public share audit",
+                saveResponseData = true)
+        private String executePublicShare(String shareCode, String fileHash) {
+            assertThat(shareCode).isNotBlank();
+            assertThat(fileHash).isNotBlank();
+            return "ok";
         }
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/PublicShareRateLimitIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/PublicShareRateLimitIT.java
@@ -1,0 +1,163 @@
+package cn.flying.aspect;
+
+import cn.flying.common.annotation.RateLimit;
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.config.RateLimitClientIpProperties;
+import cn.flying.controller.ShareRestController;
+import cn.flying.security.TrustedClientIpResolver;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 匿名公开分享端点共享限流桶的真实 Redis 集成测试。
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("Public share Redis rate-limit integration tests")
+class PublicShareRateLimitIT {
+
+    private static final String PEER_A = "198.51.100.44";
+    private static final String PEER_B = "198.51.100.45";
+    private static final String RATE_KEY_PREFIX = "rate:limit:public:share-access:v2:ip:";
+    private static final String PEER_A_KEY = RATE_KEY_PREFIX + PEER_A;
+
+    @Container
+    static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    private static LettuceConnectionFactory connectionFactory;
+    private static StringRedisTemplate redisTemplate;
+
+    private RateLimitAspect aspect;
+
+    /**
+     * 连接 Testcontainers 提供的真实 Redis，并初始化字符串模板。
+     */
+    @BeforeAll
+    static void connectRedis() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(
+                REDIS.getHost(), REDIS.getMappedPort(6379));
+        connectionFactory = new LettuceConnectionFactory(configuration);
+        connectionFactory.afterPropertiesSet();
+        connectionFactory.start();
+
+        redisTemplate = new StringRedisTemplate();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+    }
+
+    /**
+     * 清空真实 Redis，并构造只信任 direct peer 的生产切面。
+     */
+    @BeforeEach
+    void setUp() {
+        redisTemplate.execute((RedisCallback<Void>) connection -> {
+            connection.serverCommands().flushDb();
+            return null;
+        });
+        aspect = new RateLimitAspect(
+                redisTemplate,
+                new TrustedClientIpResolver(new RateLimitClientIpProperties(), "none", "", ""));
+    }
+
+    /**
+     * 清理当前线程的 servlet 请求上下文。
+     */
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    /**
+     * 释放 Lettuce 连接资源。
+     */
+    @AfterAll
+    static void disconnectRedis() {
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
+        }
+    }
+
+    /**
+     * 验证两个公开文件入口跨任意租户头共享 30 次配额，第 31 次拒绝且不同 peer 独立。
+     */
+    @Test
+    @DisplayName("should enforce one tenantless 30-per-minute bucket across both public share endpoints")
+    void shouldEnforceOneTenantlessBucketAcrossBothEndpoints() throws Throwable {
+        RateLimit downloadLimit = ShareRestController.class
+                .getMethod("publicDownload", String.class, String.class, jakarta.servlet.http.HttpServletRequest.class)
+                .getAnnotation(RateLimit.class);
+        RateLimit decryptLimit = ShareRestController.class
+                .getMethod("publicDecryptInfo", String.class, String.class)
+                .getAnnotation(RateLimit.class);
+        ProceedingJoinPoint downloadJoinPoint = mock(ProceedingJoinPoint.class);
+        ProceedingJoinPoint decryptJoinPoint = mock(ProceedingJoinPoint.class);
+
+        for (int index = 0; index < 15; index++) {
+            bindPeer(PEER_A, index % 2 == 0 ? "42" : "43");
+            aspect.around(downloadJoinPoint, downloadLimit);
+            bindPeer(PEER_A, index % 3 == 0 ? "invalid" : "0");
+            aspect.around(decryptJoinPoint, decryptLimit);
+        }
+
+        bindPeer(PEER_A, "999");
+        GeneralException denied = assertThrows(
+                GeneralException.class,
+                () -> aspect.around(downloadJoinPoint, downloadLimit));
+
+        assertSame(ResultEnum.PERMISSION_LIMIT, denied.getResultEnum());
+        verify(downloadJoinPoint, times(15)).proceed();
+        verify(decryptJoinPoint, times(15)).proceed();
+        assertThat(redisTemplate.opsForValue().get(PEER_A_KEY)).isEqualTo("30");
+        assertThat(redisTemplate.getExpire(PEER_A_KEY, TimeUnit.SECONDS)).isBetween(1L, 60L);
+        assertThat(redisTemplate.keys("rate:limit:public:share-access:*")).containsExactly(PEER_A_KEY);
+
+        bindPeer(PEER_B, "42");
+        aspect.around(downloadJoinPoint, downloadLimit);
+        assertThat(redisTemplate.opsForValue().get(RATE_KEY_PREFIX + PEER_B)).isEqualTo("1");
+        assertThat(redisTemplate.keys("rate:limit:public:share-access:*")).isEqualTo(Set.of(
+                PEER_A_KEY,
+                RATE_KEY_PREFIX + PEER_B));
+    }
+
+    /**
+     * 绑定 direct peer、伪造转发头及任意租户头，模拟修复前可拆桶的恶意请求。
+     *
+     * @param peer socket 对端地址
+     * @param tenantHeader 调用者提供的租户头
+     */
+    private void bindPeer(String peer, String tenantHeader) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr(peer);
+        request.addHeader("X-Tenant-ID", tenantHeader);
+        request.addHeader("X-Forwarded-For", "203.0.113.91");
+        request.addHeader("X-Real-IP", "203.0.113.92");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
@@ -99,6 +99,27 @@ class SecurityConfigurationTest {
     }
 
     /**
+     * 验证公开分享只放行四个精确 GET 合同，近似前缀和写操作仍需认证。
+     */
+    @Test
+    void shouldPermitOnlyExactPublicShareReadEndpoints() throws Exception {
+        String securityConfiguration = Files.readString(Path.of("src/main/java/cn/flying/config/SecurityConfiguration.java"));
+
+        assertTrue(securityConfiguration.contains(
+                ".requestMatchers(HttpMethod.GET, \"/api/v1/shares/*/info\").permitAll()"));
+        assertTrue(securityConfiguration.contains(
+                ".requestMatchers(HttpMethod.GET, \"/api/v1/shares/*/files\").permitAll()"));
+        assertTrue(securityConfiguration.contains(
+                "\"/api/v1/public/shares/*/files/*/chunks\","));
+        assertTrue(securityConfiguration.contains(
+                "\"/api/v1/public/shares/*/files/*/decrypt-info\").permitAll()"));
+        assertFalse(securityConfiguration.contains(
+                ".requestMatchers(HttpMethod.GET, \"/api/v1/public/shares/**\").permitAll()"));
+        assertFalse(securityConfiguration.contains(
+                ".requestMatchers(\"/api/v1/public/shares/**\").permitAll()"));
+    }
+
+    /**
      * 验证 Knife4j 默认使用生产模式，避免默认暴露接口文档。
      */
     @Test

--- a/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
@@ -59,6 +59,7 @@ import cn.flying.service.TicketService;
 import cn.flying.service.proof.ProofBundleService;
 import cn.flying.service.proof.signed.SignedProofArchiveService;
 import cn.flying.service.sse.SseEmitterManager;
+import cn.flying.security.TrustedClientIpResolver;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -147,6 +148,9 @@ class OpenApiContractExportTest {
 
     @MockitoBean
     private ShareAuditService shareAuditService;
+
+    @MockitoBean
+    private TrustedClientIpResolver trustedClientIpResolver;
 
     @MockitoBean
     private FileQueryService fileQueryService;
@@ -271,6 +275,39 @@ class OpenApiContractExportTest {
                 "/api/v1/public/proofs/{proofId}/status")).isTrue();
         assertThat(rootNode.path("paths").has(
                 "/api/v1/public/proof-keys/{keyId}/versions/{keyVersion}")).isTrue();
+        assertPublicOperation(
+                rootNode,
+                "/api/v1/shares/{shareCode}/info",
+                "#/components/schemas/ResultShareInfoVO",
+                "shareCode");
+        assertPublicOperation(
+                rootNode,
+                "/api/v1/shares/{shareCode}/files",
+                "#/components/schemas/ResultListShareFileVO",
+                "shareCode");
+        assertPublicOperation(
+                rootNode,
+                "/api/v1/public/shares/{shareCode}/files/{fileHash}/chunks",
+                "#/components/schemas/ResultListByte[]",
+                "shareCode",
+                "fileHash");
+        assertPublicOperation(
+                rootNode,
+                "/api/v1/public/shares/{shareCode}/files/{fileHash}/decrypt-info",
+                "#/components/schemas/ResultFileDecryptInfoVO",
+                "shareCode",
+                "fileHash");
+        assertProtectedOperation(rootNode, "/api/v1/shares", "post");
+        assertProtectedOperation(rootNode, "/api/v1/shares/{shareCode}", "patch");
+        assertProtectedOperation(rootNode, "/api/v1/shares/{shareCode}/files/save", "post");
+        assertProtectedOperation(
+                rootNode,
+                "/api/v1/shares/{shareCode}/files/{fileHash}/chunks",
+                "get");
+        assertProtectedOperation(
+                rootNode,
+                "/api/v1/shares/{shareCode}/files/{fileHash}/decrypt-info",
+                "get");
         assertSignedProofArchiveResponseContract(
                 rootNode, "/api/v1/files/{id}/proof-bundle.zip");
         assertSignedProofArchiveResponseContract(
@@ -339,6 +376,55 @@ class OpenApiContractExportTest {
         assertThat(issuedStatuses).containsExactly("ACTIVE", "SUPERSEDED");
 
         return normalizeOpenApiDocument(rootNode);
+    }
+
+    /**
+     * 验证匿名分享 GET 在 OpenAPI 中显式覆盖全局 Bearer 要求，且不声明租户请求头。
+     *
+     * @param rootNode OpenAPI 根节点
+     * @param path 匿名分享路径模板
+     * @param responseSchemaRef 成功响应 schema 引用
+     * @param pathParameters 必需路径参数
+     */
+    private void assertPublicOperation(JsonNode rootNode,
+                                       String path,
+                                       String responseSchemaRef,
+                                       String... pathParameters) {
+        JsonNode operation = rootNode.path("paths").path(path).path("get");
+
+        assertThat(operation.isMissingNode()).isFalse();
+        assertThat(operation.path("security").isArray()).isTrue();
+        assertThat(operation.path("security")).isEmpty();
+        assertThat(operation.path("description").asText()).contains("X-Tenant-ID", "owner tenant");
+
+        List<String> allParameterNames = operation.path("parameters").findValuesAsText("name");
+        assertThat(allParameterNames).noneMatch(name -> "X-Tenant-ID".equalsIgnoreCase(name));
+
+        List<String> actualPathParameters = new ArrayList<>();
+        operation.path("parameters").forEach(parameter -> {
+            if ("path".equals(parameter.path("in").asText())) {
+                actualPathParameters.add(parameter.path("name").asText());
+                assertThat(parameter.path("required").asBoolean()).isTrue();
+                assertThat(parameter.path("schema").path("type").asText()).isEqualTo("string");
+            }
+        });
+        assertThat(actualPathParameters).containsExactlyInAnyOrder(pathParameters);
+        assertThat(operation.path("responses").path("200").path("content").path("*/*")
+                .path("schema").path("$ref").asText()).isEqualTo(responseSchemaRef);
+    }
+
+    /**
+     * 校验分享写入和登录态文件入口继续继承全局 Bearer 合同。
+     *
+     * @param rootNode OpenAPI 根节点
+     * @param path 受保护路径
+     * @param method 小写 HTTP 方法
+     */
+    private void assertProtectedOperation(JsonNode rootNode, String path, String method) {
+        JsonNode operation = rootNode.path("paths").path(path).path(method);
+
+        assertThat(operation.isMissingNode()).isFalse();
+        assertThat(operation.has("security")).isFalse();
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/FileShareE2ETest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/FileShareE2ETest.java
@@ -330,12 +330,12 @@ class FileShareE2ETest extends BaseControllerIntegrationTest {
     }
 
     @Nested
-    @DisplayName("Tenant Isolation")
-    class TenantIsolation {
+    @DisplayName("Anonymous Tenant Boundary")
+    class AnonymousTenantBoundary {
 
         @Test
-        @DisplayName("should not access share from different tenant")
-        void shouldNotAccessShareFromDifferentTenant() throws Exception {
+        @DisplayName("should resolve public share from owner tenant despite caller tenant header")
+        void shouldResolvePublicShareFromOwnerTenantDespiteCallerTenantHeader() throws Exception {
             File file = createTestFile(ownerUserId);
 
             FileSharingVO sharingVO = new FileSharingVO();
@@ -350,14 +350,18 @@ class FileShareE2ETest extends BaseControllerIntegrationTest {
             String shareCode = objectMapper.readTree(createResult.getResponse().getContentAsString())
                     .get("data").asText();
 
-            setTestUser(recipientUserId, 999L);
-            MvcResult accessResult = performGet(SHARE_URL + "/" + shareCode + "/info")
+            mockMvc.perform(get(SHARE_URL + "/" + shareCode + "/info"))
                     .andExpect(status().isOk())
-                    .andReturn();
+                    .andExpect(jsonPath("$.code").value(200))
+                    .andExpect(jsonPath("$.data.files[0].fileHash").value(file.getFileHash()));
 
-            int code = objectMapper.readTree(accessResult.getResponse().getContentAsString())
-                    .get("code").asInt();
-            assertThat(code).isNotEqualTo(200);
+            for (String tenantHeader : List.of("999", "invalid-tenant")) {
+                mockMvc.perform(get(SHARE_URL + "/" + shareCode + "/info")
+                                .header(HEADER_TENANT_ID, tenantHeader))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.code").value(200))
+                        .andExpect(jsonPath("$.data.files[0].fileHash").value(file.getFileHash()));
+            }
         }
     }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/PublicShareAuditTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/PublicShareAuditTenantIsolationIT.java
@@ -1,0 +1,538 @@
+package cn.flying.controller;
+
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.tenant.TenantContext;
+import cn.flying.common.util.IdUtils;
+import cn.flying.dao.dto.Account;
+import cn.flying.dao.dto.File;
+import cn.flying.dao.dto.FileShare;
+import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.dao.mapper.FileMapper;
+import cn.flying.dao.mapper.FileShareMapper;
+import cn.flying.platformapi.constant.Result;
+import cn.flying.platformapi.response.FileDetailVO;
+import cn.flying.test.support.BaseControllerIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 匿名公开分享的 owner tenant、统一客户端 IP 与审计归属真实 MySQL/Redis 集成测试。
+ */
+@TestPropertySource(properties = "spring.web.rate-limit.client-ip.trusted-proxies=10.0.0.0/8")
+@DisplayName("Public share tenant and audit isolation integration tests")
+class PublicShareAuditTenantIsolationIT extends BaseControllerIntegrationTest {
+
+    private static final long OWNER_TENANT_ID = 42L;
+    private static final long FORGED_TENANT_ID = 43L;
+    private static final String UNTRUSTED_PEER = "198.51.100.44";
+    private static final String RATE_LIMIT_PEER = "198.51.100.45";
+    private static final String TRUSTED_PEER = "10.0.0.20";
+    private static final String TRUSTED_CLIENT = "203.0.113.7";
+    private static final String RATE_KEY_PREFIX = "rate:limit:public:share-access:v2:ip:";
+    private static final String INFO_AUDIT_URL = "/api/v1/shares/***/info";
+    private static final String FILES_AUDIT_URL = "/api/v1/shares/***/files";
+    private static final String CHUNKS_AUDIT_URL = "/api/v1/public/shares/***/files/***/chunks";
+    private static final String DECRYPT_AUDIT_URL = "/api/v1/public/shares/***/files/***/decrypt-info";
+    private static final List<String> PUBLIC_AUDIT_URLS = List.of(
+            INFO_AUDIT_URL,
+            FILES_AUDIT_URL,
+            CHUNKS_AUDIT_URL,
+            DECRYPT_AUDIT_URL);
+
+    @Autowired
+    private AccountMapper accountMapper;
+
+    @Autowired
+    private FileMapper fileMapper;
+
+    @Autowired
+    private FileShareMapper fileShareMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private long ownerUserId;
+    private long fileId;
+    private String shareCode;
+    private String fileHash;
+
+    /**
+     * 清理共享测试状态、创建非零租户公开分享并伪造远端分片响应。
+     */
+    @BeforeEach
+    void setUpPublicShareFixture() {
+        clearPublicAuditRows();
+        clearPublicRateKeys();
+
+        ownerUserId = IdUtils.nextEntityId();
+        fileId = IdUtils.nextEntityId();
+        shareCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+        fileHash = "sha256-public-share-" + UUID.randomUUID().toString().replace("-", "");
+        setTestUser(ownerUserId, OWNER_TENANT_ID);
+        insertOwnerFixture();
+        stubPublicDownload();
+    }
+
+    /**
+     * 清理本用例创建的数据、审计行、限流键和本地分享缓存。
+     */
+    @AfterEach
+    void tearDownPublicShareFixture() {
+        clearPublicRateKeys();
+        jdbcTemplate.update("DELETE FROM share_access_log WHERE share_code = ?", shareCode);
+        jdbcTemplate.update("DELETE FROM file_share WHERE share_code = ?", shareCode);
+        jdbcTemplate.update("DELETE FROM file WHERE id = ?", fileId);
+        jdbcTemplate.update("DELETE FROM account WHERE id = ?", ownerUserId);
+        clearPublicAuditRows();
+        jdbcTemplate.update("DELETE FROM sys_operation_log WHERE request_url = ?", "/api/v1/shares/***");
+    }
+
+    /**
+     * 验证四个匿名入口忽略全部租户头形态，并将业务、审计和限流身份恢复到可信边界。
+     */
+    @Test
+    @DisplayName("should ignore every tenant header form and keep owner/system audit boundaries")
+    void shouldIgnoreEveryTenantHeaderFormAndKeepAuditBoundaries() throws Exception {
+        Map<String, String> canonicalResponseByPath = new LinkedHashMap<>();
+
+        for (TenantHeaderCase headerCase : tenantHeaderCases()) {
+            for (String path : publicPaths()) {
+                MockHttpServletRequestBuilder request = get(path)
+                        .with(remoteAddress(UNTRUSTED_PEER))
+                        .header("X-Forwarded-For", "203.0.113.91")
+                        .header("X-Real-IP", "203.0.113.92")
+                        .header("User-Agent", "PublicShareIT/1.0");
+                headerCase.configure().accept(request);
+
+                MvcResult result = mockMvc.perform(request)
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.code").value(200))
+                        .andReturn();
+                String body = result.getResponse().getContentAsString();
+                String canonicalBody = canonicalResponseByPath.putIfAbsent(path, body);
+                if (canonicalBody != null) {
+                    assertThat(body)
+                            .as("tenant header case %s must not change %s", headerCase.name(), path)
+                            .isEqualTo(canonicalBody);
+                }
+            }
+        }
+
+        awaitShareAccessLogCount(12);
+        assertThat(redisTemplate.opsForValue().get(RATE_KEY_PREFIX + UNTRUSTED_PEER)).isEqualTo("12");
+        assertThat(redisTemplate.keys("rate:limit:public:share-access:*")).containsExactly(
+                RATE_KEY_PREFIX + UNTRUSTED_PEER);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT access_count FROM file_share WHERE share_code = ?",
+                Integer.class,
+                shareCode)).isEqualTo(12);
+
+        List<AuditRow> systemRows = selectPublicOperationRows();
+        assertThat(systemRows).hasSize(24).allSatisfy(row -> {
+            assertThat(row.tenantId()).isZero();
+            assertThat(row.ip()).isEqualTo(UNTRUSTED_PEER);
+            assertThat(row.ip()).hasSizeLessThanOrEqualTo(50);
+        });
+        assertThat(systemRows).extracting(AuditRow::url)
+                .containsOnlyElementsOf(PUBLIC_AUDIT_URLS);
+
+        List<ShareAuditRow> shareRows = selectShareAccessRows();
+        assertThat(shareRows).hasSize(12).allSatisfy(row -> {
+            assertThat(row.tenantId()).isEqualTo(OWNER_TENANT_ID);
+            assertThat(row.ip()).isEqualTo(UNTRUSTED_PEER);
+            assertThat(row.ip()).hasSizeLessThanOrEqualTo(50);
+        });
+        assertThat(shareRows).filteredOn(row -> row.actionType() == 1).hasSize(6);
+        assertThat(shareRows).filteredOn(row -> row.actionType() == 2).hasSize(6);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM share_access_log WHERE share_code = ? AND tenant_id = ?",
+                Long.class,
+                shareCode,
+                FORGED_TENANT_ID)).isZero();
+    }
+
+    /**
+     * 验证可信代理合法链在系统审计、分享审计和 Redis 桶中使用同一规范化客户端 IP。
+     */
+    @Test
+    @DisplayName("should use one canonical client IP behind a trusted proxy")
+    void shouldUseOneCanonicalClientIpBehindTrustedProxy() throws Exception {
+        String filesPath = "/api/v1/shares/" + shareCode + "/files";
+        String chunksPath = "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/chunks";
+
+        for (String path : List.of(filesPath, chunksPath)) {
+            mockMvc.perform(get(path)
+                            .with(remoteAddress(TRUSTED_PEER))
+                            .header("X-Forwarded-For", TRUSTED_CLIENT + ", 10.1.0.8, 10.2.0.9")
+                            .header(HEADER_TENANT_ID, FORGED_TENANT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        awaitShareAccessLogCount(2);
+        assertThat(redisTemplate.opsForValue().get(RATE_KEY_PREFIX + TRUSTED_CLIENT)).isEqualTo("1");
+        assertThat(selectPublicOperationRows()).hasSize(2).allSatisfy(row -> {
+            assertThat(row.tenantId()).isZero();
+            assertThat(row.ip()).isEqualTo(TRUSTED_CLIENT);
+        });
+        assertThat(selectShareAccessRows()).hasSize(2).allSatisfy(row -> {
+            assertThat(row.tenantId()).isEqualTo(OWNER_TENANT_ID);
+            assertThat(row.ip()).isEqualTo(TRUSTED_CLIENT);
+        });
+    }
+
+    /**
+     * 验证分享从公开改为私密后匿名列表立即失败关闭。
+     */
+    @Test
+    @DisplayName("should reject public file list immediately when share becomes private")
+    void shouldRejectPublicFileListImmediatelyWhenShareBecomesPrivate() throws Exception {
+        String filesPath = "/api/v1/shares/" + shareCode + "/files";
+        mockMvc.perform(get(filesPath).with(remoteAddress(UNTRUSTED_PEER)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        mockMvc.perform(withAuth(patch("/api/v1/shares/{shareCode}", shareCode)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shareCode\":\"" + shareCode + "\",\"shareType\":1}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        mockMvc.perform(get(filesPath).with(remoteAddress(UNTRUSTED_PEER)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(ResultEnum.PERMISSION_UNAUTHORIZED.getCode()));
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT share_type FROM file_share WHERE share_code = ?",
+                Integer.class,
+                shareCode)).isEqualTo(1);
+        awaitShareAccessLogCount(1);
+    }
+
+    /**
+     * 验证一次成功读取后分享自然到期时不会返回此前的公开文件列表。
+     */
+    @Test
+    @DisplayName("should reject public file list after a previously active share expires")
+    void shouldRejectPublicFileListAfterPreviouslyActiveShareExpires() throws Exception {
+        String filesPath = "/api/v1/shares/" + shareCode + "/files";
+        mockMvc.perform(get(filesPath).with(remoteAddress(UNTRUSTED_PEER)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200));
+
+        jdbcTemplate.update(
+                "UPDATE file_share SET status = ?, expire_time = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE share_code = ?",
+                FileShare.STATUS_ACTIVE,
+                shareCode);
+
+        mockMvc.perform(get(filesPath).with(remoteAddress(UNTRUSTED_PEER)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(ResultEnum.SHARE_EXPIRED.getCode()));
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT status FROM file_share WHERE share_code = ?",
+                Integer.class,
+                shareCode)).isEqualTo(FileShare.STATUS_EXPIRED);
+        awaitShareAccessLogCount(1);
+    }
+
+    /**
+     * 验证伪造有效租户头也不能把匿名调用升级为受保护的写入或登录态下载权限。
+     */
+    @Test
+    @DisplayName("should keep protected share mutations and private download paths authenticated")
+    void shouldKeepProtectedShareMutationsAndPrivateDownloadPathsAuthenticated() throws Exception {
+        String tenantHeader = String.valueOf(FORGED_TENANT_ID);
+        int originalShareType = jdbcTemplate.queryForObject(
+                "SELECT share_type FROM file_share WHERE share_code = ?",
+                Integer.class,
+                shareCode);
+
+        mockMvc.perform(patch("/api/v1/shares/{shareCode}", shareCode)
+                        .header(HEADER_TENANT_ID, tenantHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"shareType\":1}"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(post("/api/v1/shares/{shareCode}/files/save", shareCode)
+                        .header(HEADER_TENANT_ID, tenantHeader)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sharingFileIdList\":[]}"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/shares/{shareCode}/files/{fileHash}/chunks", shareCode, fileHash)
+                        .header(HEADER_TENANT_ID, tenantHeader))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/shares/{shareCode}/files/{fileHash}/decrypt-info", shareCode, fileHash)
+                        .header(HEADER_TENANT_ID, tenantHeader))
+                .andExpect(status().isUnauthorized());
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT share_type FROM file_share WHERE share_code = ?",
+                Integer.class,
+                shareCode)).isEqualTo(originalShareType);
+        assertThat(selectShareAccessRows()).isEmpty();
+    }
+
+    /**
+     * 验证两个公开文件入口共享 30 次桶，且第 31 次保持当前 HTTP 200 加业务码 70005 合同。
+     */
+    @Test
+    @DisplayName("should return business rate-limit code on the 31st shared public request")
+    void shouldReturnBusinessRateLimitCodeOnThirtyFirstSharedPublicRequest() throws Exception {
+        String chunksPath = "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/chunks";
+        String decryptPath = "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/decrypt-info";
+
+        for (int index = 0; index < 30; index++) {
+            String path = index % 2 == 0 ? chunksPath : decryptPath;
+            mockMvc.perform(get(path).with(remoteAddress(RATE_LIMIT_PEER)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value(200));
+        }
+
+        mockMvc.perform(get(chunksPath).with(remoteAddress(RATE_LIMIT_PEER)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(ResultEnum.PERMISSION_LIMIT.getCode()));
+
+        assertThat(redisTemplate.opsForValue().get(RATE_KEY_PREFIX + RATE_LIMIT_PEER)).isEqualTo("30");
+        awaitShareAccessLogCount(15);
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT access_count FROM file_share WHERE share_code = ?",
+                Integer.class,
+                shareCode)).isEqualTo(15);
+    }
+
+    /**
+     * 在 owner tenant 内插入账户、文件和分享，确保跨租户读取只能从分享码开始。
+     */
+    private void insertOwnerFixture() {
+        Account account = new Account();
+        account.setId(ownerUserId);
+        account.setTenantId(OWNER_TENANT_ID);
+        account.setUsername("public_share_owner_" + ownerUserId);
+        account.setPassword("$2a$10$PublicShareTenantBoundaryTestPasswordHashValue000000000000");
+        account.setEmail("public_share_owner_" + ownerUserId + "@example.test");
+        account.setRole("user");
+        account.setNickname("Public Share Owner");
+        account.setRegisterTime(new Date());
+        account.setUpdateTime(new Date());
+        account.setDeleted(0);
+
+        File file = new File()
+                .setId(fileId)
+                .setTenantId(OWNER_TENANT_ID)
+                .setUid(ownerUserId)
+                .setFileName("public-share.txt")
+                .setFileHash(fileHash)
+                .setFileParam("""
+                        {"encryptionAlgorithm":"NONE","fileName":"public-share.txt","fileSize":3,"contentType":"text/plain","chunkCount":1}
+                        """)
+                .setClassification("document")
+                .setStatus(1)
+                .setDeleted(0)
+                .setVersion(1)
+                .setIsLatest(1)
+                .setVersionGroupId(fileId)
+                .setCreateTime(new Date());
+
+        FileShare share = new FileShare()
+                .setId(IdUtils.nextEntityId())
+                .setTenantId(OWNER_TENANT_ID)
+                .setUserId(ownerUserId)
+                .setShareCode(shareCode)
+                .setShareType(0)
+                .setFileHashes("[\"" + fileHash + "\"]")
+                .setExpireTime(new Date(System.currentTimeMillis() + 3_600_000L))
+                .setAccessCount(0)
+                .setStatus(FileShare.STATUS_ACTIVE)
+                .setCreateTime(new Date())
+                .setUpdateTime(new Date())
+                .setDeleted(0);
+
+        TenantContext.runWithTenant(OWNER_TENANT_ID, () -> {
+            accountMapper.insert(account);
+            fileMapper.insert(file);
+            fileShareMapper.insert(share);
+        });
+    }
+
+    /**
+     * 为公开分片下载伪造链上对象引用和真实字节返回，其余数据库授权仍使用生产实现。
+     */
+    private void stubPublicDownload() {
+        when(fileRemoteClient.getFile(String.valueOf(ownerUserId), fileHash)).thenReturn(Result.success(
+                new FileDetailVO(
+                        String.valueOf(ownerUserId),
+                        "public-share.txt",
+                        null,
+                        "{\"cipher-hash\":\"chunks/public-share-0\"}",
+                        fileHash,
+                        null,
+                        null,
+                        3L,
+                        "text/plain")));
+        when(fileRemoteClient.getFileListByHash(
+                List.of("chunks/public-share-0"),
+                List.of("cipher-hash")))
+                .thenReturn(Result.success(List.of("abc".getBytes(StandardCharsets.UTF_8))));
+    }
+
+    /**
+     * 返回四个必须忽略调用者租户头的匿名 GET 路径。
+     */
+    private List<String> publicPaths() {
+        return List.of(
+                "/api/v1/shares/" + shareCode + "/info",
+                "/api/v1/shares/" + shareCode + "/files",
+                "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/chunks",
+                "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/decrypt-info");
+    }
+
+    /**
+     * 构造缺失、system、其他租户、畸形、空值和重复租户头矩阵。
+     */
+    private List<TenantHeaderCase> tenantHeaderCases() {
+        return List.of(
+                new TenantHeaderCase("absent", request -> { }),
+                new TenantHeaderCase("system", request -> request.header(HEADER_TENANT_ID, "0")),
+                new TenantHeaderCase("other-tenant", request -> request.header(
+                        HEADER_TENANT_ID, String.valueOf(FORGED_TENANT_ID))),
+                new TenantHeaderCase("malformed", request -> request.header(HEADER_TENANT_ID, "not-a-tenant")),
+                new TenantHeaderCase("empty", request -> request.header(HEADER_TENANT_ID, "")),
+                new TenantHeaderCase("duplicate", request -> request.header(
+                        HEADER_TENANT_ID,
+                        String.valueOf(OWNER_TENANT_ID),
+                        String.valueOf(FORGED_TENANT_ID))));
+    }
+
+    /**
+     * 等待异步分享审计达到预期数量，超时则保留实际计数作为断言证据。
+     *
+     * @param expectedCount 预期审计行数
+     */
+    private void awaitShareAccessLogCount(int expectedCount) throws InterruptedException {
+        long deadlineNanos = System.nanoTime() + 5_000_000_000L;
+        long currentCount;
+        do {
+            currentCount = shareAccessLogCount();
+            if (currentCount >= expectedCount) {
+                break;
+            }
+            Thread.sleep(25L);
+        } while (System.nanoTime() < deadlineNanos);
+
+        assertThat(currentCount).isEqualTo(expectedCount);
+    }
+
+    /**
+     * 查询当前分享的访问审计数量。
+     */
+    private long shareAccessLogCount() {
+        Long count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM share_access_log WHERE share_code = ?",
+                Long.class,
+                shareCode);
+        return count != null ? count : 0L;
+    }
+
+    /**
+     * 查询四个匿名公开入口的系统操作日志。
+     */
+    private List<AuditRow> selectPublicOperationRows() {
+        return jdbcTemplate.query(
+                """
+                SELECT tenant_id, request_ip, request_url
+                FROM sys_operation_log
+                WHERE request_url IN (?, ?, ?, ?)
+                """,
+                (resultSet, rowNumber) -> new AuditRow(
+                        resultSet.getLong("tenant_id"),
+                        resultSet.getString("request_ip"),
+                        resultSet.getString("request_url")),
+                INFO_AUDIT_URL,
+                FILES_AUDIT_URL,
+                CHUNKS_AUDIT_URL,
+                DECRYPT_AUDIT_URL);
+    }
+
+    /**
+     * 查询当前分享的 owner-scoped 分享访问日志。
+     */
+    private List<ShareAuditRow> selectShareAccessRows() {
+        return jdbcTemplate.query(
+                "SELECT tenant_id, actor_ip, action_type FROM share_access_log WHERE share_code = ?",
+                (resultSet, rowNumber) -> new ShareAuditRow(
+                        resultSet.getLong("tenant_id"),
+                        resultSet.getString("actor_ip"),
+                        resultSet.getInt("action_type")),
+                shareCode);
+    }
+
+    /**
+     * 设置 MockMvc 请求的直接 socket 对端地址。
+     */
+    private RequestPostProcessor remoteAddress(String peer) {
+        return request -> {
+            request.setRemoteAddr(peer);
+            return request;
+        };
+    }
+
+    /**
+     * 清理四个公开分享审计 URL 的历史系统日志，隔离复用容器中的测试状态。
+     */
+    private void clearPublicAuditRows() {
+        jdbcTemplate.update(
+                "DELETE FROM sys_operation_log WHERE request_url IN (?, ?, ?, ?)",
+                INFO_AUDIT_URL,
+                FILES_AUDIT_URL,
+                CHUNKS_AUDIT_URL,
+                DECRYPT_AUDIT_URL);
+    }
+
+    /**
+     * 清理公开分享限流键，隔离复用 Redis 容器中的测试状态。
+     */
+    private void clearPublicRateKeys() {
+        var keys = redisTemplate.keys("rate:limit:public:share-access:*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    private record TenantHeaderCase(
+            String name,
+            Consumer<MockHttpServletRequestBuilder> configure) {
+    }
+
+    private record AuditRow(long tenantId, String ip, String url) {
+    }
+
+    private record ShareAuditRow(long tenantId, String ip, int actionType) {
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/ShareControllerIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/ShareControllerIntegrationTest.java
@@ -143,9 +143,8 @@ class ShareControllerIntegrationTest extends BaseControllerIntegrationTest {
             createFileShare(testUserId, testTenantId, shareCode, "[\"" + fileHash + "\"]",
                     FileShare.STATUS_ACTIVE, new Date(System.currentTimeMillis() + 3600000));
 
-            // Request without Authorization header
-            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info")
-                            .header(HEADER_TENANT_ID, testTenantId))
+            // 不发送 Authorization 或租户头，服务端仅通过分享码恢复 owner tenant。
+            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200))
                     .andExpect(jsonPath("$.data.shareCode").value(shareCode));
@@ -164,8 +163,7 @@ class ShareControllerIntegrationTest extends BaseControllerIntegrationTest {
                     "[\"" + fileHash1 + "\",\"" + fileHash2 + "\"]",
                     FileShare.STATUS_ACTIVE, new Date(System.currentTimeMillis() + 3600000));
 
-            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info")
-                            .header(HEADER_TENANT_ID, testTenantId))
+            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200))
                     .andExpect(jsonPath("$.data.files").isArray())
@@ -211,8 +209,7 @@ class ShareControllerIntegrationTest extends BaseControllerIntegrationTest {
             createFileShare(testUserId, testTenantId, shareCode, "[\"" + fileHash + "\"]",
                     FileShare.STATUS_CANCELLED, new Date(System.currentTimeMillis() + 3600000));
 
-            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info")
-                            .header(HEADER_TENANT_ID, testTenantId))
+            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(50011))
                     .andExpect(jsonPath("$.message").value("分享链接已被取消"));
@@ -396,8 +393,7 @@ class ShareControllerIntegrationTest extends BaseControllerIntegrationTest {
             share.setShareType(0); // public
             TenantContext.runWithTenant(testTenantId, () -> fileShareMapper.updateById(share));
 
-            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info")
-                            .header(HEADER_TENANT_ID, testTenantId))
+            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200))
                     .andExpect(jsonPath("$.data.shareType").value(0));
@@ -415,8 +411,7 @@ class ShareControllerIntegrationTest extends BaseControllerIntegrationTest {
             share.setShareType(1); // private
             TenantContext.runWithTenant(testTenantId, () -> fileShareMapper.updateById(share));
 
-            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info")
-                            .header(HEADER_TENANT_ID, testTenantId))
+            mockMvc.perform(get(BASE_URL + "/" + shareCode + "/info"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(ResultEnum.PERMISSION_UNAUTHORIZED.getCode()))
                     .andExpect(jsonPath("$.message").value("此分享需要登录后才能访问"));

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/ShareRestControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/ShareRestControllerTest.java
@@ -1,5 +1,6 @@
 package cn.flying.controller;
 
+import cn.flying.common.annotation.RateLimit;
 import cn.flying.common.constant.Result;
 import cn.flying.dao.vo.file.FileDecryptInfoVO;
 import cn.flying.dao.vo.file.FileSharingVO;
@@ -9,6 +10,8 @@ import cn.flying.dao.vo.file.UpdateShareVO;
 import cn.flying.service.FileQueryService;
 import cn.flying.service.FileService;
 import cn.flying.service.ShareAuditService;
+import cn.flying.security.TrustedClientIpResolver;
+import jakarta.validation.Validation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +23,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,6 +46,9 @@ class ShareRestControllerTest {
     @Mock
     private ShareAuditService shareAuditService;
 
+    @Mock
+    private TrustedClientIpResolver trustedClientIpResolver;
+
     private ShareRestController controller;
 
     /**
@@ -48,7 +56,13 @@ class ShareRestControllerTest {
      */
     @BeforeEach
     void setUp() {
-        controller = new ShareRestController(fileService, fileQueryService, shareAuditService);
+        controller = new ShareRestController(
+                fileService,
+                fileQueryService,
+                shareAuditService,
+                trustedClientIpResolver
+        );
+        lenient().when(trustedClientIpResolver.resolve(any())).thenReturn("203.0.113.7");
     }
 
     /**
@@ -108,8 +122,11 @@ class ShareRestControllerTest {
         assertEquals(fileHash, publicDecryptResult.getData().fileHash());
 
         verify(fileService).updateShare(eq(userId), any(UpdateShareVO.class));
-        verify(shareAuditService).logShareView(eq(shareCode), eq(userId), eq("10.0.0.10"), eq("JUnit"));
-        verify(shareAuditService).logShareDownload(eq(shareCode), eq(userId), eq(fileHash), eq(null), eq("10.0.0.10"));
+        verify(shareAuditService).logShareView(eq(shareCode), eq(userId), eq("203.0.113.7"), eq("JUnit"));
+        verify(shareAuditService).logShareDownload(
+                eq(shareCode), eq(userId), eq(fileHash), eq(null), eq("203.0.113.7"));
+        verify(shareAuditService).logShareDownload(
+                eq(shareCode), eq(null), eq(fileHash), eq(null), eq("203.0.113.7"));
     }
 
     /**
@@ -128,6 +145,48 @@ class ShareRestControllerTest {
 
         assertEquals("保存成功", result.getData());
         assertEquals("path-code", saveVO.getShareCode());
-        verify(fileService).saveShareFile(eq(List.of("f-1")), eq("path-code"), eq("127.0.0.1"));
+        verify(fileService).saveShareFile(eq(List.of("f-1")), eq("path-code"), eq("203.0.113.7"));
+    }
+
+    /**
+     * 验证两个匿名公开下载端点共用可信客户端 IP，且限流桶不再按调用者租户拆分。
+     */
+    @Test
+    void shouldUseGlobalTrustedPeerRateLimitForAnonymousPublicShareEndpoints() throws NoSuchMethodException {
+        RateLimit downloadRateLimit = ShareRestController.class
+                .getMethod("publicDownload", String.class, String.class, jakarta.servlet.http.HttpServletRequest.class)
+                .getAnnotation(RateLimit.class);
+        RateLimit decryptRateLimit = ShareRestController.class
+                .getMethod("publicDecryptInfo", String.class, String.class)
+                .getAnnotation(RateLimit.class);
+
+        assertNotNull(downloadRateLimit);
+        assertNotNull(decryptRateLimit);
+        assertFalse(downloadRateLimit.tenantScoped());
+        assertFalse(decryptRateLimit.tenantScoped());
+        assertEquals(RateLimit.ClientIpMode.TRUSTED_PEER, downloadRateLimit.clientIpMode());
+        assertEquals(RateLimit.ClientIpMode.TRUSTED_PEER, decryptRateLimit.clientIpMode());
+        assertEquals(RateLimit.LimitType.IP, downloadRateLimit.type());
+        assertEquals(RateLimit.LimitType.IP, decryptRateLimit.type());
+        assertEquals(downloadRateLimit.key(), decryptRateLimit.key());
+        assertEquals(30, downloadRateLimit.limit());
+        assertEquals(60, downloadRateLimit.period());
+    }
+
+    /**
+     * 验证创建分享请求在控制器校验阶段只接受公开或私密两种类型。
+     */
+    @Test
+    void shouldRejectUnsupportedCreateShareTypeAtValidationBoundary() {
+        FileSharingVO request = new FileSharingVO();
+        request.setFileHash(List.of("hash-1"));
+        request.setExpireMinutes(60);
+        request.setShareType(99);
+
+        try (var factory = Validation.buildDefaultValidatorFactory()) {
+            var violations = factory.getValidator().validate(request);
+            assertEquals(1, violations.size());
+            assertEquals("shareType", violations.iterator().next().getPropertyPath().toString());
+        }
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/FlowLimitingFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/FlowLimitingFilterTest.java
@@ -1,5 +1,9 @@
 package cn.flying.filter;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.DistributedRateLimiter;
 import cn.flying.common.util.DistributedRateLimiter.RateLimitResult;
@@ -8,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -100,6 +105,143 @@ class FlowLimitingFilterTest {
             filter.doFilter(request, response, filterChain);
 
             assertThat(response.getStatus()).isEqualTo(429);
+        }
+
+        /**
+         * 验证限流拒绝日志不会暴露可用于重放匿名分享请求的分享码和文件哈希。
+         */
+        @Test
+        @DisplayName("Should mask public share credentials in rate limit logs")
+        void shouldMaskPublicShareCredentialsInRateLimitLogs() throws ServletException, IOException {
+            String shareCode = "share-secret-credential";
+            String fileHash = "file-hash-secret";
+            request.setMethod("GET");
+            request.setRequestURI("/api/v1/public/sh%61res/" + shareCode
+                    + ";probe=1/f%69les/" + fileHash + ";probe=2/chunks");
+            request.setRemoteAddr("192.168.1.1");
+            when(rateLimiter.tryAcquireWithBlock(anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+                    .thenReturn(RateLimitResult.RATE_LIMITED);
+
+            Logger logger = (Logger) LoggerFactory.getLogger(FlowLimitingFilter.class);
+            Level previousLevel = logger.getLevel();
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.setLevel(Level.WARN);
+            logger.addAppender(appender);
+            try {
+                filter.doFilter(request, response, filterChain);
+            } finally {
+                logger.detachAppender(appender);
+                logger.setLevel(previousLevel);
+                appender.stop();
+            }
+
+            List<String> messages = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .toList();
+            assertThat(messages).anyMatch(message ->
+                    message.contains("/api/v1/public/sh%61res/***/f%69les/***/chunks"));
+            assertThat(messages).noneMatch(message ->
+                    message.contains(shareCode) || message.contains(fileHash));
+        }
+
+        /**
+         * 验证静态段编码且矩阵参数非法时，限流拒绝日志仍不会暴露匿名分享凭据。
+         */
+        @Test
+        @DisplayName("Should mask credentials when encoded routes contain invalid matrix parameters")
+        void shouldMaskCredentialsWhenEncodedRoutesContainInvalidMatrixParameters()
+                throws ServletException, IOException {
+            String shareCode = "share-secret-credential";
+            String fileHash = "file-hash-secret";
+            request.setMethod("GET");
+            request.setRequestURI("/api/v1/public/sh%61res;bad=%ZZ/" + shareCode
+                    + "/f%69les;bad=%ZZ/" + fileHash + "/chunks");
+            request.setRemoteAddr("192.168.1.1");
+            when(rateLimiter.tryAcquireWithBlock(anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+                    .thenReturn(RateLimitResult.RATE_LIMITED);
+
+            Logger logger = (Logger) LoggerFactory.getLogger(FlowLimitingFilter.class);
+            Level previousLevel = logger.getLevel();
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.setLevel(Level.WARN);
+            logger.addAppender(appender);
+            try {
+                filter.doFilter(request, response, filterChain);
+            } finally {
+                logger.detachAppender(appender);
+                logger.setLevel(previousLevel);
+                appender.stop();
+            }
+
+            List<String> messages = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .toList();
+            assertThat(messages).anyMatch(message -> message.contains(
+                    "/api/v1/public/sh%61res;bad=%ZZ/***/f%69les;bad=%ZZ/***/chunks"));
+            assertThat(messages).noneMatch(message ->
+                    message.contains(shareCode) || message.contains(fileHash));
+        }
+
+        /**
+         * 验证容器规范化空段、点段和父段时，限流拒绝日志仍不会暴露实际分享凭据。
+         */
+        @Test
+        @DisplayName("Should mask credentials in container-normalized public share routes")
+        void shouldMaskCredentialsInContainerNormalizedPublicShareRoutes()
+                throws ServletException, IOException {
+            String shareCode = "share-secret-credential";
+            String fileHash = "file-hash-secret";
+            List<String> requestUris = List.of(
+                    "/api/v1/public/shares/./" + shareCode + "/files/" + fileHash + "/chunks",
+                    "/api/v1/public/shares//" + shareCode + "/files/" + fileHash + "/chunks",
+                    "/api/v1/public/shares/%2E/" + shareCode + "/files/" + fileHash + "/chunks",
+                    "/api/v1/public/shares/decoy-secret/../" + shareCode
+                            + "/files/" + fileHash + "/chunks",
+                    "/api/v1/public/shares/encoded-decoy/%2e%2E/" + shareCode
+                            + "/files/" + fileHash + "/chunks"
+            );
+            request.setMethod("GET");
+            request.setRemoteAddr("192.168.1.1");
+            when(rateLimiter.tryAcquireWithBlock(anyString(), anyString(), anyInt(), anyInt(), anyInt()))
+                    .thenReturn(RateLimitResult.RATE_LIMITED);
+
+            Logger logger = (Logger) LoggerFactory.getLogger(FlowLimitingFilter.class);
+            Level previousLevel = logger.getLevel();
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.setLevel(Level.WARN);
+            logger.addAppender(appender);
+            try {
+                for (String requestUri : requestUris) {
+                    request.setRequestURI(requestUri);
+                    filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+                }
+            } finally {
+                logger.detachAppender(appender);
+                logger.setLevel(previousLevel);
+                appender.stop();
+            }
+
+            List<String> messages = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .toList();
+            assertThat(messages).anyMatch(message ->
+                    message.contains("/api/v1/public/shares/./***/files/***/chunks"));
+            assertThat(messages).anyMatch(message ->
+                    message.contains("/api/v1/public/shares//***/files/***/chunks"));
+            assertThat(messages).anyMatch(message ->
+                    message.contains("/api/v1/public/shares/%2E/***/files/***/chunks"));
+            assertThat(messages).anyMatch(message ->
+                    message.contains("/api/v1/public/shares/***/../***/files/***/chunks"));
+            assertThat(messages).anyMatch(message ->
+                    message.contains("/api/v1/public/shares/***/%2e%2E/***/files/***/chunks"));
+            assertThat(messages).noneMatch(message ->
+                    message.contains(shareCode)
+                            || message.contains(fileHash)
+                            || message.contains("decoy-secret")
+                            || message.contains("encoded-decoy"));
         }
     }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/IdSecurityFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/IdSecurityFilterTest.java
@@ -1,9 +1,14 @@
 package cn.flying.filter;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -157,6 +162,36 @@ class IdSecurityFilterTest {
             filter.doFilterInternal(request, response, filterChain);
 
             assertThat(request.getAttribute("secureResourceId")).isEqualTo(550L);
+        }
+
+        /**
+         * 验证超长 ID 异常日志会脱敏分享码和文件哈希，避免异常路径泄露访问凭据。
+         */
+        @Test
+        @DisplayName("Should mask share credentials in invalid ID logs")
+        void shouldMaskShareCredentialsInInvalidIdLogs() throws ServletException, IOException {
+            String shareCode = "999999999999999999999999999999";
+            String fileHash = "file-hash-secret";
+            request.setMethod("GET");
+            request.setRequestURI("/api/shares/" + shareCode + "/files/" + fileHash + "/chunks");
+
+            Logger logger = (Logger) LoggerFactory.getLogger(IdSecurityFilter.class);
+            Level previousLevel = logger.getLevel();
+            ListAppender<ILoggingEvent> appender = new ListAppender<>();
+            appender.start();
+            logger.setLevel(Level.WARN);
+            logger.addAppender(appender);
+            try {
+                filter.doFilterInternal(request, response, filterChain);
+            } finally {
+                logger.detachAppender(appender);
+                logger.setLevel(previousLevel);
+                appender.stop();
+            }
+
+            assertThat(appender.list.stream().map(ILoggingEvent::getFormattedMessage))
+                    .anyMatch(message -> message.contains("/api/shares/***/files/***/chunks"))
+                    .noneMatch(message -> message.contains(shareCode) || message.contains(fileHash));
         }
     }
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/RequestLogFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/RequestLogFilterTest.java
@@ -344,6 +344,31 @@ class RequestLogFilterTest {
         }
 
         /**
+         * 验证编码字面量和矩阵参数不能绕过公开分享响应体的缓存与日志禁用规则。
+         */
+        @Test
+        @DisplayName("Should not wrap encoded public share responses")
+        void shouldNotWrapEncodedPublicShareResponses() throws ServletException, IOException {
+            String path = "/api/v1/public/sh%61res;x=1/%2E/share-secret/f%69les;v=2//hash-secret/chunks";
+            request.setRequestURI(path);
+            request.setServletPath(path);
+            request.setMethod("GET");
+
+            filter.doFilter(request, response, filterChain);
+
+            assertThat(filterChain.getResponse()).isNotInstanceOf(ContentCachingResponseWrapper.class);
+            String content = ReflectionTestUtils.invokeMethod(
+                    filter,
+                    "buildResponseLogContent",
+                    request,
+                    "application/json",
+                    HttpServletResponse.SC_OK,
+                    "chunk-response-secret".getBytes(StandardCharsets.UTF_8)
+            );
+            assertThat(content).isEqualTo("<skipped>");
+        }
+
+        /**
          * 验证日志路径会脱敏分享码、文件哈希和交易哈希。
          */
         @Test

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
@@ -1,5 +1,9 @@
 package cn.flying.filter;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
@@ -11,11 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.IOException;
-
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -198,39 +203,97 @@ class TenantFilterTest {
     }
 
     /**
-     * 白名单路径不强制要求租户头，但若主动携带租户头，应写入 TenantContext 与 request attribute，
-     * 以便后续 MyBatis-Plus 租户拦截器能正确注入 tenant_id 条件。
+     * 四类匿名公开分享 GET 及其等价编码形式必须完整忽略调用者租户头。
      */
     @Test
-    @DisplayName("should set tenant context for whitelisted path when tenant header present")
-    void shouldSetTenantContextForWhitelistedPathWhenTenantHeaderPresent() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/shares/abc/info");
-        request.setServletPath("/api/v1/shares/abc/info");
-        request.addHeader("X-Tenant-ID", "12");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        AtomicLong capturedTenantId = new AtomicLong(-1);
+    @DisplayName("should ignore every tenant header form for anonymous public share GET endpoints")
+    void shouldIgnoreEveryTenantHeaderFormForAnonymousPublicShareGetEndpoints()
+            throws ServletException, IOException {
+        AtomicLong chainCalls = new AtomicLong();
         doAnswer(invocation -> {
-            capturedTenantId.set(TenantContext.getTenantId() != null ? TenantContext.getTenantId() : -1);
+            MockHttpServletRequest chainedRequest = invocation.getArgument(0);
+            assertNull(TenantContext.getTenantId());
+            assertNull(chainedRequest.getAttribute(Const.ATTR_TENANT_ID));
+            chainCalls.incrementAndGet();
             return null;
         }).when(filterChain).doFilter(any(), any());
 
-        filter.doFilterInternal(request, response, filterChain);
+        String[] paths = {
+                "/api/v1/shares/abc/info",
+                "/api/v1/shares/abc/files",
+                "/api/v1/public/shares/abc/files/hash-1/chunks",
+                "/api/v1/public/shares/abc/files/hash-1/decrypt-info",
+                "/api/v1/sh%61res/abc/info",
+                "/api/v1/shares;x=1/abc/files",
+                "/api/v1/public/sh%61res/abc/f%69les/hash-1/chunks",
+                "/api/v1/public/shares;x=1/abc/files;v=2/hash-1/decrypt-info",
+                "/api/v1/shares/./abc/info",
+                "/api/v1/shares//abc/files",
+                "/api/v1/public/shares/%2E/abc/files/hash-1/chunks",
+                "/api/v1/public/shares/decoy/../abc/files/hash-1/decrypt-info",
+                "/api/v1/public/shares/encoded-decoy/%2e%2E/abc/files/hash-1/chunks"
+        };
+        String[] tenantHeaders = {null, "0", "12", "invalid-tenant", ""};
 
-        verify(filterChain).doFilter(request, response);
-        assertEquals(12L, capturedTenantId.get());
-        assertEquals(12L, request.getAttribute(Const.ATTR_TENANT_ID));
-        assertNull(TenantContext.getTenantId());
+        for (String path : paths) {
+            for (String tenantHeader : tenantHeaders) {
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+                request.setServletPath(path);
+                if (tenantHeader != null) {
+                    request.addHeader("X-Tenant-ID", tenantHeader);
+                }
+                MockHttpServletResponse response = new MockHttpServletResponse();
+
+                filter.doFilterInternal(request, response, filterChain);
+
+                assertEquals(200, response.getStatus());
+                assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+                assertNull(TenantContext.getTenantId());
+            }
+        }
+
+        assertEquals(65L, chainCalls.get());
+        verify(filterChain, times(65)).doFilter(any(), any());
     }
 
     /**
-     * 非 proof 白名单路径携带畸形租户头时应返回 400，且不得污染请求属性或线程租户上下文。
+     * 匿名公开分享 GET 对重复租户头也必须完全忽略，不能让代理差异改变公开合同。
+     */
+    @Test
+    @DisplayName("should ignore duplicate tenant headers for anonymous public share GET endpoints")
+    void shouldIgnoreDuplicateTenantHeadersForAnonymousPublicShareGetEndpoints()
+            throws ServletException, IOException {
+        for (String path : new String[]{
+                "/api/v1/shares/abc/info",
+                "/api/v1/shares/abc/files",
+                "/api/v1/public/shares/abc/files/hash-1/chunks",
+                "/api/v1/public/shares/abc/files/hash-1/decrypt-info",
+                "/api/v1/public/sh%61res/abc/f%69les/hash-1/chunks",
+                "/api/v1/public/shares/%2E/abc/files/hash-1/chunks"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+            request.setServletPath(path);
+            request.addHeader("X-Tenant-ID", "12");
+            request.addHeader("X-Tenant-ID", "13");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(200, response.getStatus());
+            assertNull(request.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(TenantContext.getTenantId());
+        }
+
+        verify(filterChain, times(6)).doFilter(any(), any());
+    }
+
+    /**
+     * 非公开资源白名单路径携带畸形租户头时应返回 400，且不得污染请求属性或线程租户上下文。
      */
     @Test
     @DisplayName("should reject invalid tenant header for non-proof whitelisted path")
     void shouldRejectInvalidTenantHeaderForNonProofWhitelistedPath() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/shares/abc/info");
-        request.setServletPath("/api/v1/shares/abc/info");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/actuator/health");
+        request.setServletPath("/actuator/health");
         request.addHeader("X-Tenant-ID", "invalid-tenant");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
@@ -251,7 +314,7 @@ class TenantFilterTest {
     @Test
     @DisplayName("should reject a single empty tenant header outside public proof endpoints")
     void shouldRejectSingleEmptyTenantHeaderOutsidePublicProofEndpoints() throws ServletException, IOException {
-        for (String path : new String[]{"/api/v1/shares/abc/info", "/api/v1/sse/connect"}) {
+        for (String path : new String[]{"/actuator/health", "/api/v1/sse/connect"}) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
             request.setServletPath(path);
             request.addHeader("X-Tenant-ID", "");
@@ -273,12 +336,12 @@ class TenantFilterTest {
     }
 
     /**
-     * 非 proof 白名单和受保护路径都必须拒绝重复租户头，避免有歧义的租户身份被静默采用。
+     * 非公开资源白名单和受保护路径都必须拒绝重复租户头，避免有歧义的租户身份被静默采用。
      */
     @Test
     @DisplayName("should reject duplicate tenant headers outside public proof endpoints")
     void shouldRejectDuplicateTenantHeadersOutsidePublicProofEndpoints() throws ServletException, IOException {
-        String[] paths = {"/api/v1/shares/abc/info", "/api/v1/files"};
+        String[] paths = {"/actuator/health", "/api/v1/files"};
         String[][] duplicateValues = {
                 {"12", "12"},
                 {"12", "13"},
@@ -307,6 +370,57 @@ class TenantFilterTest {
         }
 
         verifyNoInteractions(filterChain);
+    }
+
+    /**
+     * 验证租户头拒绝分支和正常调试日志均不会暴露分享码或文件哈希。
+     */
+    @Test
+    @DisplayName("should mask share credentials in tenant filter logs")
+    void shouldMaskShareCredentialsInTenantFilterLogs() throws ServletException, IOException {
+        String shareCode = "share-secret-credential";
+        String fileHash = "file-hash-secret";
+        String path = "/api/v1/shares/" + shareCode + "/files/" + fileHash + "/chunks";
+
+        Logger logger = (Logger) LoggerFactory.getLogger(TenantFilter.class);
+        Level previousLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.setLevel(Level.DEBUG);
+        logger.addAppender(appender);
+        try {
+            MockHttpServletRequest duplicateHeaderRequest = new MockHttpServletRequest("GET", path);
+            duplicateHeaderRequest.setServletPath(path);
+            duplicateHeaderRequest.addHeader("X-Tenant-ID", "12");
+            duplicateHeaderRequest.addHeader("X-Tenant-ID", "13");
+            filter.doFilterInternal(duplicateHeaderRequest, new MockHttpServletResponse(), filterChain);
+
+            MockHttpServletRequest emptyHeaderRequest = new MockHttpServletRequest("GET", path);
+            emptyHeaderRequest.setServletPath(path);
+            emptyHeaderRequest.addHeader("X-Tenant-ID", "");
+            filter.doFilterInternal(emptyHeaderRequest, new MockHttpServletResponse(), filterChain);
+
+            MockHttpServletRequest missingHeaderRequest = new MockHttpServletRequest("GET", path);
+            missingHeaderRequest.setServletPath(path);
+            filter.doFilterInternal(missingHeaderRequest, new MockHttpServletResponse(), filterChain);
+
+            MockHttpServletRequest validHeaderRequest = new MockHttpServletRequest("GET", path);
+            validHeaderRequest.setServletPath(path);
+            validHeaderRequest.addHeader("X-Tenant-ID", "12");
+            filter.doFilterInternal(validHeaderRequest, new MockHttpServletResponse(), filterChain);
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(previousLevel);
+            appender.stop();
+        }
+
+        List<String> messages = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+        assertTrue(messages.stream().anyMatch(message ->
+                message.contains("/api/v1/shares/***/files/***/chunks")));
+        assertTrue(messages.stream().noneMatch(message ->
+                message.contains(shareCode) || message.contains(fileHash)));
     }
 
     /**
@@ -356,20 +470,28 @@ class TenantFilterTest {
     }
 
     /**
-     * /api/v1/shares 下除公开文件列表外的路径必须携带租户头，防止绕过租户校验。
+     * /api/v1/shares 下除两个匿名 GET 外的路径必须携带租户头，防止绕过租户校验。
      */
     @Test
     @DisplayName("should reject missing tenant header for protected shares path")
     void shouldRejectMissingTenantHeaderForProtectedSharesPath() throws ServletException, IOException {
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/shares");
-        request.setServletPath("/api/v1/shares");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        for (String path : new String[]{
+                "/api/v1/shares",
+                "/api/v1/shares/abc/files/save",
+                "/api/v1/shares/abc/files/hash-1/chunks",
+                "/api/v1/shares/abc/files/hash-1/decrypt-info"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", path);
+            request.setServletPath(path);
+            MockHttpServletResponse response = new MockHttpServletResponse();
 
-        filter.doFilterInternal(request, response, filterChain);
+            filter.doFilterInternal(request, response, filterChain);
 
-        verify(filterChain, never()).doFilter(request, response);
-        assertEquals(400, response.getStatus());
-        assertTrue(response.getContentAsString().contains(String.valueOf(ResultEnum.PARAM_IS_INVALID.getCode())));
+            assertEquals(400, response.getStatus());
+            assertTrue(response.getContentAsString()
+                    .contains(String.valueOf(ResultEnum.PARAM_IS_INVALID.getCode())));
+        }
+
+        verifyNoInteractions(filterChain);
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
@@ -475,12 +475,21 @@ class TenantFilterTest {
     @Test
     @DisplayName("should reject missing tenant header for protected shares path")
     void shouldRejectMissingTenantHeaderForProtectedSharesPath() throws ServletException, IOException {
-        for (String path : new String[]{
-                "/api/v1/shares",
-                "/api/v1/shares/abc/files/save",
-                "/api/v1/shares/abc/files/hash-1/chunks",
-                "/api/v1/shares/abc/files/hash-1/decrypt-info"}) {
-            MockHttpServletRequest request = new MockHttpServletRequest("POST", path);
+        String[][] protectedRequests = {
+                {"POST", "/api/v1/shares"},
+                {"POST", "/api/v1/shares/abc/info"},
+                {"POST", "/api/v1/shares/abc/files"},
+                {"POST", "/api/v1/shares/abc/files/save"},
+                {"POST", "/api/v1/shares/abc/files/hash-1/chunks"},
+                {"POST", "/api/v1/shares/abc/files/hash-1/decrypt-info"},
+                {"POST", "/api/v1/public/shares/abc/files/hash-1/chunks"},
+                {"POST", "/api/v1/public/shares/abc/files/hash-1/decrypt-info"},
+                {"GET", "/api/v1/public/shares/abc/files/hash-1/metadata"}
+        };
+        for (String[] protectedRequest : protectedRequests) {
+            String method = protectedRequest[0];
+            String path = protectedRequest[1];
+            MockHttpServletRequest request = new MockHttpServletRequest(method, path);
             request.setServletPath(path);
             MockHttpServletResponse response = new MockHttpServletResponse();
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/handler/GlobalExceptionHandlerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/handler/GlobalExceptionHandlerTest.java
@@ -1,5 +1,9 @@
 package cn.flying.filter.handler;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import cn.flying.common.constant.ErrorPayload;
 import cn.flying.common.constant.Result;
 import cn.flying.common.constant.ResultEnum;
@@ -12,6 +16,7 @@ import jakarta.validation.Path;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -27,6 +32,7 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,6 +42,28 @@ import static org.mockito.Mockito.when;
 class GlobalExceptionHandlerTest {
 
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    /**
+     * 捕获全局异常处理器日志，供敏感路径脱敏断言复用。
+     */
+    private List<String> captureLogMessages(Level level, Runnable action) {
+        Logger logger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        Level previousLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.setLevel(level);
+        logger.addAppender(appender);
+        try {
+            action.run();
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(previousLevel);
+            appender.stop();
+        }
+        return appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
 
     // ---- existing tests (refactored to use shared handler instance) ----
 
@@ -386,6 +414,28 @@ class GlobalExceptionHandlerTest {
 
             assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
         }
+
+        /**
+         * 验证异步超时日志不会暴露匿名分享的路径凭据。
+         */
+        @Test
+        @DisplayName("should mask public share credentials in timeout logs")
+        void shouldMaskPublicShareCredentialsInTimeoutLogs() {
+            String shareCode = "share-secret-credential";
+            String fileHash = "file-hash-secret";
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            when(request.getRequestURI()).thenReturn(
+                    "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/chunks");
+            when(request.getHeader("Accept")).thenReturn("application/json");
+
+            List<String> messages = captureLogMessages(Level.WARN, () ->
+                    handler.handleAsyncRequestTimeoutException(new AsyncRequestTimeoutException(), request));
+
+            assertTrue(messages.stream().anyMatch(message ->
+                    message.contains("/api/v1/public/shares/***/files/***/chunks")));
+            assertTrue(messages.stream().noneMatch(message ->
+                    message.contains(shareCode) || message.contains(fileHash)));
+        }
     }
 
     @Nested
@@ -416,6 +466,28 @@ class GlobalExceptionHandlerTest {
                     new IOException("Connection reset"), request);
 
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        }
+
+        /**
+         * 验证 IO 异常日志不会暴露匿名分享的路径凭据。
+         */
+        @Test
+        @DisplayName("should mask public share credentials in IO exception logs")
+        void shouldMaskPublicShareCredentialsInIoExceptionLogs() {
+            String shareCode = "share-secret-credential";
+            String fileHash = "file-hash-secret";
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            when(request.getRequestURI()).thenReturn(
+                    "/api/v1/public/shares/" + shareCode + "/files/" + fileHash + "/decrypt-info");
+            when(request.getHeader("Accept")).thenReturn("application/json");
+
+            List<String> messages = captureLogMessages(Level.WARN, () ->
+                    handler.handleIOException(new IOException("Connection reset"), request));
+
+            assertTrue(messages.stream().anyMatch(message ->
+                    message.contains("/api/v1/public/shares/***/files/***/decrypt-info")));
+            assertTrue(messages.stream().noneMatch(message ->
+                    message.contains(shareCode) || message.contains(fileHash)));
         }
     }
 

--- a/platform-frontend/src/lib/api/client.test.ts
+++ b/platform-frontend/src/lib/api/client.test.ts
@@ -320,6 +320,42 @@ describe("API Client", () => {
         expect(options.headers.get("Authorization")).toBeNull();
       });
 
+      it("should skip tenant header only when skipTenant is true", async () => {
+        const mockFetch = createMockFetch({});
+        const api = createApiClient({
+          baseUrl: "https://api.test.com",
+          fetch: mockFetch,
+          tenantId: "tenant-123",
+          getToken: () => "my-auth-token",
+        });
+
+        await api.get("/public-share", {
+          skipAuth: true,
+          skipTenant: true,
+        });
+
+        const [, options] = mockFetch.mock.calls[0];
+        expect(options.headers.get("Authorization")).toBeNull();
+        expect(options.headers.get("X-Tenant-ID")).toBeNull();
+      });
+
+      it("should remove a caller-provided tenant header when skipTenant is true", async () => {
+        const mockFetch = createMockFetch({});
+        const api = createApiClient({
+          baseUrl: "https://api.test.com",
+          fetch: mockFetch,
+          tenantId: "tenant-123",
+        });
+
+        await api.get("/public-share", {
+          skipTenant: true,
+          headers: { "x-tenant-id": "forged-tenant" },
+        });
+
+        const [, options] = mockFetch.mock.calls[0];
+        expect(options.headers.get("X-Tenant-ID")).toBeNull();
+      });
+
       it("should include tenant ID header", async () => {
         const mockFetch = createMockFetch({});
         const api = createApiClient({

--- a/platform-frontend/src/lib/api/client.ts
+++ b/platform-frontend/src/lib/api/client.ts
@@ -121,6 +121,7 @@ export interface RequestConfig {
   params?: RequestParams;
   timeout?: number;
   skipAuth?: boolean;
+  skipTenant?: boolean;
   retries?: number;
 }
 
@@ -169,7 +170,9 @@ function buildHeaders(
     ...(config?.headers || {}),
   });
 
-  if (tenantId) {
+  if (config?.skipTenant) {
+    headers.delete("X-Tenant-ID");
+  } else if (tenantId) {
     headers.set("X-Tenant-ID", tenantId);
   }
 

--- a/platform-frontend/src/lib/api/endpoints/files.test.ts
+++ b/platform-frontend/src/lib/api/endpoints/files.test.ts
@@ -230,6 +230,7 @@ describe("files endpoints", () => {
     expect(result).toEqual([{ id: "shared-1" }]);
     expect(clientMocks.api.get).toHaveBeenCalledWith("/shares/code-a/files", {
       skipAuth: true,
+      skipTenant: true,
     });
   });
 
@@ -275,12 +276,12 @@ describe("files endpoints", () => {
     expect(clientMocks.api.get).toHaveBeenNthCalledWith(
       1,
       "/public/shares/share-public/files/hash-2/chunks",
-      { skipAuth: true },
+      { skipAuth: true, skipTenant: true },
     );
     expect(clientMocks.api.get).toHaveBeenNthCalledWith(
       2,
       "/public/shares/share-public/files/hash-2/decrypt-info",
-      { skipAuth: true },
+      { skipAuth: true, skipTenant: true },
     );
   });
 

--- a/platform-frontend/src/lib/api/endpoints/files.ts
+++ b/platform-frontend/src/lib/api/endpoints/files.ts
@@ -156,6 +156,7 @@ export async function getSharedFiles(
 ): Promise<SharedFileVO[]> {
   return api.get<SharedFileVO[]>(`/shares/${sharingCode}/files`, {
     skipAuth: true,
+    skipTenant: true,
   });
 }
 
@@ -281,6 +282,7 @@ export async function publicDownloadEncryptedChunks(
     `/public/shares/${shareCode}/files/${fileHash}/chunks`,
     {
       skipAuth: true,
+      skipTenant: true,
     },
   );
 }
@@ -300,6 +302,7 @@ export async function publicGetDecryptInfo(
     `/public/shares/${shareCode}/files/${fileHash}/decrypt-info`,
     {
       skipAuth: true,
+      skipTenant: true,
     },
   );
 }

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -1547,7 +1547,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** 公开分享下载文件（REST） */
+        /**
+         * 公开分享下载文件（REST）
+         * @description 匿名 GET；不需要 JWT 或租户头，X-Tenant-ID 不参与授权。服务端按 shareCode 恢复 owner tenant，并与公开解密接口共享规范客户端 IP 的 30 次/60 秒限流桶；第 31 次当前以 HTTP 200、业务码 70005 拒绝。
+         */
         get: operations["publicDownload"];
         put?: never;
         post?: never;
@@ -1564,7 +1567,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** 公开分享获取解密信息（REST） */
+        /**
+         * 公开分享获取解密信息（REST）
+         * @description 匿名 GET；不需要 JWT 或租户头，X-Tenant-ID 不参与授权。服务端按 shareCode 恢复 owner tenant，并与公开下载接口共享规范客户端 IP 的 30 次/60 秒限流桶；第 31 次当前以 HTTP 200、业务码 70005 拒绝。
+         */
         get: operations["publicDecryptInfo"];
         put?: never;
         post?: never;
@@ -1615,7 +1621,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** 获取分享文件列表（REST） */
+        /**
+         * 获取分享文件列表（REST）
+         * @description 匿名 GET；不需要 JWT 或租户头。调用者提供的 X-Tenant-ID 不参与授权或数据选择，服务端仅按 shareCode 解析 owner tenant，并实时校验公开、有效和未过期状态。
+         */
         get: operations["getSharedFiles"];
         put?: never;
         post?: never;
@@ -1683,7 +1692,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** 获取分享详情 */
+        /**
+         * 获取分享详情
+         * @description 匿名 GET；不需要 JWT 或租户头。即使提供 X-Tenant-ID 也会被忽略，服务端仅按 shareCode 解析 owner tenant，并在该租户内读取分享、文件、访问计数和分享审计数据。
+         */
         get: operations["getShareInfo"];
         put?: never;
         post?: never;

--- a/tools/docs/check_consistency.py
+++ b/tools/docs/check_consistency.py
@@ -59,12 +59,7 @@ LEGACY_ROUTE_RULES = (
 ALLOWED_NON_OPENAPI_METHOD_ROUTES = {
     ("POST", "/api/v1/auth/login"),
     ("POST", "/api/v1/auth/logout"),
-    ("GET", "/api/v1/shares/**"),
     ("POST", "/api/v1/verify"),
-}
-
-ALLOWED_NON_OPENAPI_PATHS = {
-    "/api/v1/shares/**",
 }
 
 FORBIDDEN_ENV_VARS = {
@@ -214,8 +209,6 @@ def check_routes(root: Path, openapi_path: Path) -> CheckResult:
             line = line_number_from_index(content, match.start())
 
             if (method, route) in ALLOWED_NON_OPENAPI_METHOD_ROUTES:
-                continue
-            if route in ALLOWED_NON_OPENAPI_PATHS:
                 continue
 
             supported_methods = openapi_methods.get(route)


### PR DESCRIPTION
## 关联任务

- 父任务：`.trellis/tasks/07-13-roadmap-p1-proof-productization`
- 子任务：`.trellis/tasks/07-17-roadmap-p1-public-share-anonymous-tenant-boundary`
- 路线图阶段：`ROADMAP_new.md` P1，proof model productization

## 问题背景

匿名公开分享请求此前可能让调用者提供的 `X-Tenant-ID` 参与租户上下文、审计归属和限流键计算。伪造租户头可能污染审计租户，并让同一客户端拆分限流桶。公开分享的权威租户应只由服务端根据全局唯一 `shareCode` 恢复，转发头也只能在可信代理边界内用于解析客户端 IP。

## 修改内容

- 仅对四个精确匿名 GET public-share 路径忽略租户头；精确路径的非 GET、公开前缀下的非合同路径、私有接口和分享变更接口继续要求租户并失败关闭。
- 跨租户查询被限制为通过全局唯一 `shareCode` 读取 `file_share.tenant_id`；完整 share、file、key envelope、访问计数和分享审计随后全部在 owner tenant 上下文中执行。
- private、revoked、expired、未知类型或状态、未包含文件等路径继续失败关闭。
- 移除匿名文件列表的最终授权结果缓存，确保撤销、过期和文件删除在下一次请求立即生效。
- public download/decrypt 改用无 tenant scope 的可信客户端 IP 限流；调用者不能通过 tenant、`X-Forwarded-For` 或 `X-Real-IP` 拆分桶。
- 匿名系统操作日志固定归 system tenant，`share_access_log` 固定归 owner tenant；三类审计复用规范化可信客户端 IP。
- 收紧 Spring Security 的匿名放行路径；前端公开分享请求不再发送 tenant header。
- 加固敏感 URI 日志脱敏，覆盖编码段、matrix 参数、非法编码、重复分隔符和点段规范化场景。
- 同步生成的 OpenAPI 前端类型，并更新 API、安全、运维、路线图文档及 CI 中 Failsafe 精确报告门禁。

## 影响范围

- `platform-backend/backend-common`
- `platform-backend/backend-dao`
- `platform-backend/backend-service`
- `platform-backend/backend-web`
- `platform-frontend`
- `.github/workflows/test.yml`
- API、安全、运维和路线图文档

不包含数据库 schema migration，也不改变受保护分享 mutation、登录态下载或私有分享合同。

## 测试与修复证据

- 当前 head：`29587fdc4327f178c7683c33c604b0001c9df666`。
- `mvn verify -pl backend-common,backend-service,backend-web -am`：全 Reactor 构建成功；backend-service 959、backend-web 381，零失败/错误，所有 JaCoCo 模块门禁通过。
- `-Pit` 本地运行进入 Failsafe；本机无 Docker，Testcontainers 报告为条件跳过，最终在 `ProofStatusTimestampMigrationIT` 明确因 Docker 不可用停止。真实 IT 以 CI 精确报告为最终证据。
- 覆盖修复定向 104 个相关测试通过；按 `origin/main` 变更行与 JaCoCo XML 保守计算，完整分支覆盖为 265/325（81.54%），普通行命中为 90.77%。
- 前端 Prettier、ESLint、Svelte/TypeScript 检查通过（0 error/warning）；33 files / 466 tests 通过。
- 合同测试 59/59、合同指纹 2 entries、生成类型 CI 同构检查通过。
- platform-api 7/7、platform-fisco 158/158、platform-storage 169/169。
- 文档一致性 routes/env/roadmap/versions、`actionlint`、`git diff --check` 通过。
- 已完成直接人工安全与完整代码审查，未启用 security 插件，当前无剩余已知 finding。

## CI 验收要求

只有当前 head 的所有检查通过、无未解决意见、无冲突且验收标准满足后才合并。CI 必须验证：

- `PublicShareRateLimitIT`：1 test，0 skip/failure/error；同一真实客户端第 31 次被现有业务限流合同拒绝。
- `PublicShareAuditTenantIsolationIT`：6 tests，0 skip/failure/error；伪造 tenant/forwarded 头不能污染系统或分享审计。
- 后端、前端、合约一致性、构建、文档、Codecov patch、CodeQL、Trivy 和仓库原生扫描全部通过。

## 最终 CI 验收

- 当前 head `29587fdc4327f178c7683c33c604b0001c9df666` 的 [Test Suite 29635728410](https://github.com/SoarCollab/RecordPlatform/actions/runs/29635728410) 全部成功：Backend Tests、Frontend Tests、Security Scan、Contract Consistency、Build Verification。
- Backend Tests 内 8 个 Failsafe 精确报告步骤全部成功，其中 `PublicShareRateLimitIT` 要求 1 test / 0 skip，`PublicShareAuditTenantIsolationIT` 要求 6 tests / 0 skip。
- Docs Consistency、全部 CodeQL、Trivy、Automatic Dependency Submission 均成功。
- `codecov/patch` 最终为 82.53%，超过 80.00% 目标。
- PR 合并前状态：`CLEAN`、`MERGEABLE`，无 review thread、无未解决意见。

## 风险评估

- 跨租户读取范围被限制为单列 owner tenant 查询，避免扩大到 file、account 或 key envelope。
- 限流 key 切换会重置旧 tenant-scoped 桶；上线期间继续依赖全局 socket 限流，并监控现有 `HTTP 200 + Result.code=70005` 合同。
- URI 脱敏逻辑修改覆盖日志可观测面，已增加多层回归测试，业务路由行为不变。
- API 的成功响应结构保持兼容；公开调用者不再需要知道 owner tenant。
- 通用分享白名单的缺头回退已收紧为精确 GET/path 双重边界；合法四类匿名 GET 保持兼容，非合同路径和 mutation 不再被前缀白名单放行。

## 回滚方式

合并后优先对 PR 的 squash/merge 提交执行单次 `git revert <merge-sha>`。若必须在合并前逐提交回滚，按逆序回滚 `29587fdc`、`20049e07`、`c1c42dd3`。历史可疑日志只做只读统计和人工评估，不自动删除或改写。
