### PR TITLE
fix: remediate storage Commons advisories

### DIFF
--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -26,6 +26,8 @@
         <skywalking.toolkit.version>9.6.0</skywalking.toolkit.version>
         <netty.version>4.2.16.Final</netty.version>
         <testcontainers.version>1.20.4</testcontainers.version>
+        <commons-compress.version>1.28.0</commons-compress.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
         <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
     </properties>
     <dependencies>
@@ -212,6 +214,17 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Keep transitive test components on repository-approved versions. -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
             <!-- Override Bouncy Castle to fix CVE-2026-5598 (Covert Timing Channel)
                  Note: Project does not use Bouncy Castle directly or FrodoEngine.
                  Upgrading as a precaution. -->
@@ -257,6 +270,14 @@
                                 <requireJavaVersion>
                                     <version>[21,22)</version>
                                 </requireJavaVersion>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.apache.commons:commons-compress:(,1.26.0)</exclude>
+                                        <exclude>org.apache.commons:commons-lang3:(,3.18.0)</exclude>
+                                    </excludes>
+                                    <searchTransitive>true</searchTransitive>
+                                    <message>Commons dependency security floors: commons-compress must be at least 1.26.0 and commons-lang3 must be at least 3.18.0.</message>
+                                </bannedDependencies>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## 背景

P2-1 为 `platform-storage` 增加 Testcontainers `1.20.4` 后，测试依赖图解析出
`org.apache.commons:commons-compress:1.24.0`，触发 Dependabot #582
(`GHSA-4265-ccf5-phj5`) 与 #583 (`GHSA-4g9r-vxhx-9pgx`)。两项均为
development/transitive 告警，最低修复版本为 `1.26.0`。

## 修改

- 保持 Testcontainers `1.20.4` 和现有 test scope 不变。
- 在 `platform-storage` dependency management 中将：
  - Commons Compress 固定为 `1.28.0`；
  - Commons Lang3 固定为 `3.20.0`，避免 Compress 1.28.0 被父 BOM 降到已有告警的 3.17.0。
- 在现有 Maven Enforcer execution 中检查最终传递依赖并禁止：
  - Commons Compress `<1.26.0`；
  - Commons Lang3 `<3.18.0`。
- 未新增 direct dependency，未修改生产源码、API、配置、测试、CI 或质量阈值。

## 依赖与门禁证据

- 标准 `mvn -f platform-storage/pom.xml validate` 成功。
- 安全边界 `Compress 1.26.0 / Lang3 3.18.0` 的 validate 成功。
- test tree 最终解析：

  ```text
  org.testcontainers:testcontainers:1.20.4:test
  \- org.apache.commons:commons-compress:1.28.0:test (managed from 1.24.0)
     \- org.apache.commons:commons-lang3:3.20.0:test (managed from 3.18.0)
  ```

- runtime tree 与 storage 可执行 JAR 的 `BOOT-INF/lib` 均不含 Commons Compress/Lang3。
- `-Dcommons-compress.version=1.24.0` 按预期退出 1，并命中 Testcontainers 的禁止坐标。
- `-Dcommons-lang3.version=3.17.0` 按预期退出 1，并命中 Compress 的禁止传递坐标。

## 本地验证

- Storage unit：383 tests，0 failures/errors/skipped。
- Storage constrained heap：1 test，0 failures/errors/skipped。
- Platform API：7 tests，全部通过；`clean install` 成功。
- Verifier：SDK 119、CLI 10、Web 28，全部通过；SDK coverage gate 和 `clean install` 成功。
- FISCO：158 tests，全部通过。
- Backend unit reactor：`backend-common,backend-service,backend-web -am` 成功。
- Frontend：frozen install、format、lint、Svelte check、481 coverage tests、build 全部成功。
- Contracts：Python unittest 59 tests 与 catalog fingerprint verify 成功。
- Docs：OpenAPI export、generated types check、routes/env/roadmap/versions consistency、VitePress build 成功。
- Repository：Actionlint、XML、`git diff --check` 成功。
- Root reactor：14 modules `clean package -DskipTests` 成功（测试由上述独立命令执行）。
- Trivy filesystem CRITICAL/HIGH：0 findings；它不作为 Medium #582/#583 关闭证明。

## 本地环境边界

本机没有 Docker CLI/daemon（`docker info` 退出 127，`/var/run/docker.sock` 不存在）。
Storage `clean verify -Pit` 在 383 个单元测试通过后，3 个真实容器测试类因 Testcontainers
找不到 Docker 环境报错且 0 skipped；Backend `verify -Pit` 同样在容器阶段受阻。
这些结果明确记为环境阻塞，不视为通过；PR CI 必须真实执行容器测试与镜像构建。

## 直接审查

- 未启用 security plugin；直接审查了 POM diff、effective POM、依赖图、Enforcer 正反用例、
  runtime JAR、仓库扫描和测试输出。
- 未新增凭据、repository/pluginRepository、动态版本、非可信镜像源或测试弱化。
- 未混入 Dependabot PR #305 的其他升级、P2-2、P2-5 stash 或 verifier/P6 范围。

## 风险与回滚

风险主要是 Testcontainers 与覆盖后的 Commons 组件存在测试运行时兼容差异；由 PR CI 的
MinIO、Redis lifecycle、Degraded Redis CAS 和 constrained-heap 门禁证明兼容性。

回滚使用正常 revert 本 PR 的 squash merge。回滚会重新暴露 #582/#583，因此回滚后必须
继续阻塞 P2-2，并重新制定独立修复方案，不能 dismiss 告警代替修复。

## 合并验收

- [ ] 所有适用 PR checks 成功，无未解决 review thread，无冲突。
- [ ] 正常 squash merge，不使用 admin bypass。
- [ ] exact-main Test Suite、Automatic Dependency Submission、CodeQL、Code Quality 成功。
- [ ] Dependabot #582/#583 均为 `fixed`，无 dismissed/auto-dismissed。
- [ ] 刷新后的 Dependency Graph SBOM 不含 Commons Compress `<1.26.0`。
