### PR TITLE
feat: add bounded authenticated downloads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,9 +42,9 @@
 | 指标 | 当前值 | 证据路径 |
 |------|--------|----------|
 | REST 控制器 | 30 | `platform-backend/backend-web/src/main/java` |
-| 后端服务类 | 134 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 164 | `platform-backend/**/src/test/java` |
-| 数据库迁移 | 33（V1.0.0 ~ V1.15.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
+| 后端服务类 | 138 | `platform-backend/backend-service/src/main/java` |
+| 后端测试文件 | 167 | `platform-backend/**/src/test/java` |
+| 数据库迁移 | 34（V1.0.0 ~ V1.16.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | CI 流水线（核心） | 5 | `.github/workflows/test.yml`, `perf-smoke.yml`, `docs.yml`, `security-poc.yml`, `docs-consistency.yml` |
 
 ### 表 1：PR 合并阻断门禁（已就位）

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@
 |------|--------|----------|
 | REST 控制器 | 30 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 138 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 167 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 168 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 34（V1.0.0 ~ V1.16.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | CI 流水线（核心） | 5 | `.github/workflows/test.yml`, `perf-smoke.yml`, `docs.yml`, `security-poc.yml`, `docs-consistency.yml` |
 

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/entity/FileChunkManifest.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/entity/FileChunkManifest.java
@@ -56,6 +56,8 @@ public class FileChunkManifest implements Serializable {
 
     private String storageBackend;
 
+    private String encryptionMetadata;
+
     private String manifestJson;
 
     private String status;

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/entity/FileChunkManifestItem.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/entity/FileChunkManifestItem.java
@@ -44,6 +44,10 @@ public class FileChunkManifestItem implements Serializable {
 
     private Long size;
 
+    private Long plainSize;
+
+    private Integer frameCount;
+
     private String storagePath;
 
     private String storageBackend;

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDecryptInfoVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDecryptInfoVO.java
@@ -19,6 +19,22 @@ public record FileDecryptInfoVO(
         @Schema(description = "分片数量")
         Integer chunkCount,
         @Schema(description = "文件哈希")
-        String fileHash
+        String fileHash,
+        @Schema(description = "原始上传分片大小；历史文件可能为空")
+        Long chunkSize
 ) {
+
+    /**
+     * 保留历史六参数构造调用，旧文件没有可用的分片大小证据时返回 null。
+     */
+    public FileDecryptInfoVO(
+            String initialKey,
+            String fileName,
+            Long fileSize,
+            String contentType,
+            Integer chunkCount,
+            String fileHash
+    ) {
+        this(initialKey, fileName, fileSize, contentType, chunkCount, fileHash, null);
+    }
 }

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDownloadEncryptionVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDownloadEncryptionVO.java
@@ -1,0 +1,27 @@
+package cn.flying.dao.vo.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 下载端用于选择并验证版本化加密格式的描述信息。
+ */
+@Schema(description = "文件下载加密格式描述")
+public record FileDownloadEncryptionVO(
+        @Schema(description = "加密格式版本：0=NONE，1=legacy，2=framed AEAD")
+        Integer formatVersion,
+        @Schema(description = "算法套件")
+        String algorithmSuite,
+        @Schema(description = "文件级 nonce，Base64URL 无填充")
+        String fileNonce,
+        @Schema(description = "单帧明文大小")
+        Integer framePlainSize,
+        @Schema(description = "帧密钥派生算法")
+        String keyDerivation,
+        @Schema(description = "帧 nonce 派生算法")
+        String nonceDerivation,
+        @Schema(description = "AAD 字节合同标识")
+        String aadSchema,
+        @Schema(description = "AEAD 标签字节数")
+        Integer tagSize
+) {
+}

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDownloadMetadataVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDownloadMetadataVO.java
@@ -25,6 +25,8 @@ public record FileDownloadMetadataVO(
         String manifestSchemaId,
         @Schema(description = "manifest hash")
         String manifestHash,
+        @Schema(description = "不含密钥材料的 canonical manifest JSON")
+        String canonicalManifestJson,
         @Schema(description = "哈希算法")
         String hashAlgorithm,
         @Schema(description = "加密算法")
@@ -35,7 +37,33 @@ public record FileDownloadMetadataVO(
         long chunkSize,
         @Schema(description = "分片总数")
         int totalChunks,
+        @Schema(description = "版本化加密格式描述；历史 manifest 可为空")
+        FileDownloadEncryptionVO encryption,
         @Schema(description = "有序分片下载 URL 列表")
         List<FileDownloadPartVO> parts
 ) {
+
+    /**
+     * 保留旧下载元数据构造调用，历史响应不携带版本化加密描述。
+     */
+    public FileDownloadMetadataVO(
+            String fileId,
+            String fileHash,
+            String fileName,
+            long fileSize,
+            String contentType,
+            String initialKey,
+            String manifestSchemaId,
+            String manifestHash,
+            String hashAlgorithm,
+            String encryptionAlgorithm,
+            String storageBackend,
+            long chunkSize,
+            int totalChunks,
+            List<FileDownloadPartVO> parts
+    ) {
+        this(fileId, fileHash, fileName, fileSize, contentType, initialKey,
+                manifestSchemaId, manifestHash, null, hashAlgorithm, encryptionAlgorithm,
+                storageBackend, chunkSize, totalChunks, null, parts);
+    }
 }

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDownloadPartVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileDownloadPartVO.java
@@ -17,11 +17,55 @@ public record FileDownloadPartVO(
         long expiresAtEpochSeconds,
         @Schema(description = "分片 storagePath")
         String storagePath,
+        @Schema(description = "manifest 归属的存储后端")
+        String storageBackend,
+        @Schema(description = "manifest 中的对象 ETag；历史 metadata 可为空")
+        String etag,
         @Schema(description = "明文分片哈希")
         String plainHash,
         @Schema(description = "密文分片哈希")
         String cipherHash,
         @Schema(description = "校验算法")
-        String checksumAlgorithm
+        String checksumAlgorithm,
+        @Schema(description = "分片明文字节数；历史 manifest 可为空")
+        Long plainSize,
+        @Schema(description = "分片认证 frame 数量；非 v2 可为空")
+        Integer frameCount
 ) {
+
+    /**
+     * 保留旧下载分片构造调用，历史 manifest 不携带 framed 字段。
+     */
+    public FileDownloadPartVO(
+            int index,
+            long size,
+            String downloadUrl,
+            long expiresAtEpochSeconds,
+            String storagePath,
+            String plainHash,
+            String cipherHash,
+            String checksumAlgorithm
+    ) {
+        this(index, size, downloadUrl, expiresAtEpochSeconds, storagePath,
+                null, null, plainHash, cipherHash, checksumAlgorithm, null, null);
+    }
+
+    /**
+     * 保留新增明文尺寸/frame 字段的构造调用，同时允许旧 metadata 缺少存储证据。
+     */
+    public FileDownloadPartVO(
+            int index,
+            long size,
+            String downloadUrl,
+            long expiresAtEpochSeconds,
+            String storagePath,
+            String plainHash,
+            String cipherHash,
+            String checksumAlgorithm,
+            Long plainSize,
+            Integer frameCount
+    ) {
+        this(index, size, downloadUrl, expiresAtEpochSeconds, storagePath,
+                null, null, plainHash, cipherHash, checksumAlgorithm, plainSize, frameCount);
+    }
 }

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileUploadState.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/FileUploadState.java
@@ -94,6 +94,39 @@ public class FileUploadState {
     @Schema(description = "上传恢复协议版本；为空表示升级前会话，必须失败关闭")
     private Integer recoverySchemaVersion;
 
+    @Schema(description = "普通代理上传加密恢复版本")
+    private Integer encryptionRecoveryVersion;
+
+    @Schema(description = "普通代理上传对象格式版本：1=legacy，2=framed")
+    private Integer encryptionFormatVersion;
+
+    @Schema(description = "普通代理上传对象算法套件")
+    private String encryptionAlgorithmSuite;
+
+    @Schema(description = "普通代理上传文件级 DEK（仅受控 Redis 检查点）")
+    private byte[] fileDataKey;
+
+    @Schema(description = "普通代理上传文件级 nonce（仅受控 Redis 检查点）")
+    private byte[] fileNonce;
+
+    @Schema(description = "普通代理上传 framed 明文 frame 大小")
+    private Integer framePlainSize;
+
+    @Schema(description = "普通代理上传密钥派生算法")
+    private String keyDerivation;
+
+    @Schema(description = "普通代理上传 nonce 派生算法")
+    private String nonceDerivation;
+
+    @Schema(description = "普通代理上传 AAD 合同")
+    private String aadSchema;
+
+    @Schema(description = "普通代理上传 AEAD 标签大小")
+    private Integer tagSize;
+
+    @Schema(description = "普通代理上传 active manifest hash 检查点")
+    private String manifestHash;
+
     public FileUploadState(Long userId, String fileName, long fileSize, String contentType, String clientId, int chunkSize, int totalChunks) {
         this(userId, fileName, fileSize, contentType, clientId, chunkSize, totalChunks, null);
     }
@@ -122,6 +155,7 @@ public class FileUploadState {
         this.totalChunks = totalChunks;
         // 参数化构造只用于创建新会话；Jackson 读取旧 JSON 使用无参构造，缺字段仍保持 null。
         this.recoverySchemaVersion = 1;
+        this.encryptionRecoveryVersion = 1;
         this.startTime = System.currentTimeMillis();
         this.lastActivityTime = this.startTime;
         this.lastProgressLogTime = 0;

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/assistant/FileUploadRedisStateManager.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/assistant/FileUploadRedisStateManager.java
@@ -1262,6 +1262,23 @@ public class FileUploadRedisStateManager {
                 && Objects.equals(
                     expected.getRecoverySchemaVersion(),
                     persisted.getRecoverySchemaVersion())
+                && Objects.equals(
+                    expected.getEncryptionRecoveryVersion(),
+                    persisted.getEncryptionRecoveryVersion())
+                && Objects.equals(
+                    expected.getEncryptionFormatVersion(),
+                    persisted.getEncryptionFormatVersion())
+                && Objects.equals(
+                    expected.getEncryptionAlgorithmSuite(),
+                    persisted.getEncryptionAlgorithmSuite())
+                && Arrays.equals(expected.getFileDataKey(), persisted.getFileDataKey())
+                && Arrays.equals(expected.getFileNonce(), persisted.getFileNonce())
+                && Objects.equals(expected.getFramePlainSize(), persisted.getFramePlainSize())
+                && Objects.equals(expected.getKeyDerivation(), persisted.getKeyDerivation())
+                && Objects.equals(expected.getNonceDerivation(), persisted.getNonceDerivation())
+                && Objects.equals(expected.getAadSchema(), persisted.getAadSchema())
+                && Objects.equals(expected.getTagSize(), persisted.getTagSize())
+                && Objects.equals(expected.getManifestHash(), persisted.getManifestHash())
                 && Objects.equals(expected.getCleanupRetryCount(), persisted.getCleanupRetryCount());
     }
 
@@ -1312,6 +1329,33 @@ public class FileUploadRedisStateManager {
                 "recoverySchemaVersion",
                 current.getRecoverySchemaVersion(),
                 update.getRecoverySchemaVersion()));
+        update.setEncryptionRecoveryVersion(mergeStableValue(
+                "encryptionRecoveryVersion",
+                current.getEncryptionRecoveryVersion(),
+                update.getEncryptionRecoveryVersion()));
+        update.setEncryptionFormatVersion(mergeStableValue(
+                "encryptionFormatVersion",
+                current.getEncryptionFormatVersion(),
+                update.getEncryptionFormatVersion()));
+        update.setEncryptionAlgorithmSuite(mergeStableValue(
+                "encryptionAlgorithmSuite",
+                current.getEncryptionAlgorithmSuite(),
+                update.getEncryptionAlgorithmSuite()));
+        update.setFileDataKey(mergeStableBytes(
+                "fileDataKey", current.getFileDataKey(), update.getFileDataKey()));
+        update.setFileNonce(mergeStableBytes(
+                "fileNonce", current.getFileNonce(), update.getFileNonce()));
+        update.setFramePlainSize(mergeStableValue(
+                "framePlainSize", current.getFramePlainSize(), update.getFramePlainSize()));
+        update.setKeyDerivation(mergeStableValue(
+                "keyDerivation", current.getKeyDerivation(), update.getKeyDerivation()));
+        update.setNonceDerivation(mergeStableValue(
+                "nonceDerivation", current.getNonceDerivation(), update.getNonceDerivation()));
+        update.setAadSchema(mergeStableValue(
+                "aadSchema", current.getAadSchema(), update.getAadSchema()));
+        update.setTagSize(mergeStableValue("tagSize", current.getTagSize(), update.getTagSize()));
+        update.setManifestHash(mergeStableValue(
+                "manifestHash", current.getManifestHash(), update.getManifestHash()));
         update.setSuid(mergeStableValue("suid", current.getSuid(), update.getSuid()));
         update.setUploadTempPath(mergeStableValue(
                 "uploadTempPath", current.getUploadTempPath(), update.getUploadTempPath()));
@@ -1373,6 +1417,22 @@ public class FileUploadRedisStateManager {
                 || !Objects.equals(
                     current.getRecoverySchemaVersion(),
                     update.getRecoverySchemaVersion())
+                || !Objects.equals(
+                    current.getEncryptionRecoveryVersion(),
+                    update.getEncryptionRecoveryVersion())
+                || !Objects.equals(
+                    current.getEncryptionFormatVersion(),
+                    update.getEncryptionFormatVersion())
+                || !Objects.equals(
+                    current.getEncryptionAlgorithmSuite(),
+                    update.getEncryptionAlgorithmSuite())
+                || !Arrays.equals(current.getFileDataKey(), update.getFileDataKey())
+                || !Arrays.equals(current.getFileNonce(), update.getFileNonce())
+                || !Objects.equals(current.getFramePlainSize(), update.getFramePlainSize())
+                || !Objects.equals(current.getKeyDerivation(), update.getKeyDerivation())
+                || !Objects.equals(current.getNonceDerivation(), update.getNonceDerivation())
+                || !Objects.equals(current.getAadSchema(), update.getAadSchema())
+                || !Objects.equals(current.getTagSize(), update.getTagSize())
                 || (current.getFileName() != null && update.getFileName() != null
                     && !Objects.equals(current.getFileName(), update.getFileName()))
                 || current.getFileSize() != update.getFileSize()
@@ -1397,6 +1457,22 @@ public class FileUploadRedisStateManager {
             throw new IllegalStateException("上传会话稳定字段发生变化: " + field);
         }
         return current;
+    }
+
+    /**
+     * 合并只允许首次赋值的 byte[] 稳定字段，避免引用相等导致检查点漂移。
+     */
+    private byte[] mergeStableBytes(String field, byte[] current, byte[] update) {
+        if (current == null) {
+            return update == null ? null : update.clone();
+        }
+        if (update == null) {
+            return current.clone();
+        }
+        if (!Arrays.equals(current, update)) {
+            throw new IllegalStateException("上传会话稳定字段发生变化: " + field);
+        }
+        return current.clone();
     }
 
     /**

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/encryption/EncryptionProperties.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/encryption/EncryptionProperties.java
@@ -60,6 +60,16 @@ public class EncryptionProperties {
     private int benchmarkIterations = 3;
 
     /**
+     * 新建普通后端代理上传使用的对象格式，支持 v2 framed 或 legacy v1 回滚。
+     */
+    private String writerFormat = "v2";
+
+    /**
+     * framed v2 的 nominal 明文 frame 大小，默认 1MiB。
+     */
+    private int framePlainSize = 1024 * 1024;
+
+    /**
      * 获取解析后的算法枚举
      */
     public EncryptionAlgorithm getAlgorithmEnum() {

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/encryption/FramedAeadCrypto.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/encryption/FramedAeadCrypto.java
@@ -1,0 +1,312 @@
+package cn.flying.service.encryption;
+
+import javax.crypto.Mac;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * framed AES-GCM v2 的字节序、HKDF、AAD 和 wire header 工具。
+ */
+public final class FramedAeadCrypto {
+
+    public static final byte[] MAGIC = new byte[]{'R', 'P', 'F', '2'};
+    public static final int FORMAT_VERSION = 2;
+    public static final int ALGORITHM_ID_AES_256_GCM = 1;
+    public static final int CHUNK_HEADER_SIZE = 44;
+    public static final int FRAME_HEADER_SIZE = 12;
+    public static final int TAG_SIZE = 16;
+    public static final int FILE_NONCE_SIZE = 16;
+    public static final int FILE_DEK_SIZE = 32;
+    public static final int FRAME_NONCE_SIZE = 12;
+    /** 单个分片允许的最大认证 frame 数，防止不可信计数导致长循环。 */
+    public static final int MAX_FRAMES_PER_PART = 10_000;
+    public static final int MIN_FRAME_PLAIN_SIZE = 64 * 1024;
+    public static final int MAX_FRAME_PLAIN_SIZE = 4 * 1024 * 1024;
+    public static final String KEY_INFO_PREFIX = "cn.flying.framed-aead.v2/key";
+    public static final String NONCE_INFO_PREFIX = "cn.flying.framed-aead.v2/nonce";
+    public static final String AAD_PREFIX = "cn.flying.framed-aead.aad.v2";
+
+    private FramedAeadCrypto() {
+    }
+
+    /**
+     * 构造 44 字节 chunk header，所有整数使用 unsigned big-endian。
+     */
+    public static byte[] buildChunkHeader(
+            int chunkIndex,
+            int chunkCount,
+            int framePlainSize,
+            int frameCount,
+            long chunkPlainSize,
+            byte[] fileNonce
+    ) {
+        validateChunkCoordinates(chunkIndex, chunkCount, framePlainSize, frameCount, chunkPlainSize, fileNonce);
+        ByteBuffer buffer = ByteBuffer.allocate(CHUNK_HEADER_SIZE).order(ByteOrder.BIG_ENDIAN);
+        buffer.put(MAGIC)
+                .put((byte) FORMAT_VERSION)
+                .put((byte) ALGORITHM_ID_AES_256_GCM)
+                .putShort((short) 0)
+                .putInt(chunkIndex)
+                .putInt(chunkCount)
+                .putInt(framePlainSize)
+                .putInt(frameCount)
+                .putInt((int) chunkPlainSize)
+                .put(fileNonce.clone());
+        return buffer.array();
+    }
+
+    /**
+     * 解析并校验 44 字节 chunk header。
+     */
+    public static ChunkHeader parseChunkHeader(byte[] header) {
+        if (header == null || header.length != CHUNK_HEADER_SIZE) {
+            throw new IllegalArgumentException("chunk header length is invalid");
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN);
+        byte[] magic = new byte[MAGIC.length];
+        buffer.get(magic);
+        int version = Byte.toUnsignedInt(buffer.get());
+        int algorithmId = Byte.toUnsignedInt(buffer.get());
+        int flags = Short.toUnsignedInt(buffer.getShort());
+        int chunkIndex = buffer.getInt();
+        int chunkCount = buffer.getInt();
+        int framePlainSize = buffer.getInt();
+        int frameCount = buffer.getInt();
+        long chunkPlainSize = Integer.toUnsignedLong(buffer.getInt());
+        byte[] fileNonce = new byte[FILE_NONCE_SIZE];
+        buffer.get(fileNonce);
+        if (!Arrays.equals(MAGIC, magic)
+                || version != FORMAT_VERSION
+                || algorithmId != ALGORITHM_ID_AES_256_GCM
+                || flags != 0) {
+            throw new IllegalArgumentException("unsupported framed AEAD chunk header");
+        }
+        validateChunkCoordinates(chunkIndex, chunkCount, framePlainSize, frameCount, chunkPlainSize, fileNonce);
+        return new ChunkHeader(version, algorithmId, flags, chunkIndex, chunkCount,
+                framePlainSize, frameCount, chunkPlainSize, fileNonce);
+    }
+
+    /**
+     * 构造 12 字节 frame header。
+     */
+    public static byte[] buildFrameHeader(int frameIndex, int plainLength, int cipherLength) {
+        if (frameIndex < 0 || frameIndex >= MAX_FRAMES_PER_PART
+                || plainLength <= 0 || plainLength > MAX_FRAME_PLAIN_SIZE
+                || cipherLength <= 0
+                || (long) cipherLength != (long) plainLength + TAG_SIZE) {
+            throw new IllegalArgumentException("frame header values are invalid");
+        }
+        return ByteBuffer.allocate(FRAME_HEADER_SIZE)
+                .order(ByteOrder.BIG_ENDIAN)
+                .putInt(frameIndex)
+                .putInt(plainLength)
+                .putInt(cipherLength)
+                .array();
+    }
+
+    /**
+     * 解析并校验 12 字节 frame header。
+     */
+    public static FrameHeader parseFrameHeader(byte[] header) {
+        if (header == null || header.length != FRAME_HEADER_SIZE) {
+            throw new IllegalArgumentException("frame header length is invalid");
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN);
+        int frameIndex = buffer.getInt();
+        int plainLength = buffer.getInt();
+        int cipherLength = buffer.getInt();
+        if (frameIndex < 0 || frameIndex >= MAX_FRAMES_PER_PART
+                || plainLength <= 0 || plainLength > MAX_FRAME_PLAIN_SIZE
+                || cipherLength <= 0
+                || (long) cipherLength != (long) plainLength + TAG_SIZE) {
+            throw new IllegalArgumentException("frame header values are invalid");
+        }
+        return new FrameHeader(frameIndex, plainLength, cipherLength);
+    }
+
+    /**
+     * 使用 RFC 5869 HKDF-SHA-256 派生当前 frame 的 AES key。
+     */
+    public static byte[] deriveFrameKey(byte[] fileDek, byte[] fileNonce, int chunkIndex, int frameIndex) {
+        validateKeyInputs(fileDek, fileNonce, chunkIndex, frameIndex);
+        byte[] prk = hkdfExtract(fileNonce, fileDek);
+        return hkdfExpand(prk, info(KEY_INFO_PREFIX, chunkIndex, frameIndex), FILE_DEK_SIZE);
+    }
+
+    /**
+     * 使用 RFC 5869 HKDF-SHA-256 派生当前 frame 的 96-bit nonce。
+     */
+    public static byte[] deriveFrameNonce(byte[] fileDek, byte[] fileNonce, int chunkIndex, int frameIndex) {
+        validateKeyInputs(fileDek, fileNonce, chunkIndex, frameIndex);
+        byte[] prk = hkdfExtract(fileNonce, fileDek);
+        return hkdfExpand(prk, info(NONCE_INFO_PREFIX, chunkIndex, frameIndex), FRAME_NONCE_SIZE);
+    }
+
+    /**
+     * 构造与 TypeScript reader 共享的 framed AES-GCM AAD 字节串。
+     */
+    public static byte[] buildAad(
+            byte[] fileNonce,
+            int chunkIndex,
+            int chunkCount,
+            int frameIndex,
+            int frameCount,
+            int plainLength,
+            long chunkPlainSize
+    ) {
+        if (fileNonce == null || fileNonce.length != FILE_NONCE_SIZE
+                || chunkIndex < 0 || chunkCount <= 0 || chunkIndex >= chunkCount
+                || frameIndex < 0 || frameCount <= 0 || frameIndex >= frameCount
+                || plainLength <= 0 || chunkPlainSize <= 0 || chunkPlainSize > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("AAD values are invalid");
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(
+                        AAD_PREFIX.getBytes(StandardCharsets.UTF_8).length + 2 + FILE_NONCE_SIZE + 4 * 6)
+                .order(ByteOrder.BIG_ENDIAN);
+        buffer.put(AAD_PREFIX.getBytes(StandardCharsets.UTF_8))
+                .put((byte) FORMAT_VERSION)
+                .put((byte) ALGORITHM_ID_AES_256_GCM)
+                .put(fileNonce.clone())
+                .putInt(chunkIndex)
+                .putInt(chunkCount)
+                .putInt(frameIndex)
+                .putInt(frameCount)
+                .putInt(plainLength)
+                .putInt((int) chunkPlainSize);
+        return buffer.array();
+    }
+
+    /**
+     * 执行 HKDF-Extract，供协议实现和 RFC 向量测试复用。
+     */
+    public static byte[] hkdfExtract(byte[] salt, byte[] inputKeyMaterial) {
+        if (salt == null || inputKeyMaterial == null) {
+            throw new IllegalArgumentException("HKDF inputs are required");
+        }
+        return hmac(salt, inputKeyMaterial);
+    }
+
+    /**
+     * 执行 HKDF-Expand，限制输出长度避免不受控内存分配。
+     */
+    public static byte[] hkdfExpand(byte[] prk, byte[] info, int length) {
+        if (prk == null || prk.length != 32 || info == null || length < 0 || length > 255 * 32) {
+            throw new IllegalArgumentException("HKDF expand inputs are invalid");
+        }
+        byte[] output = new byte[length];
+        byte[] previous = new byte[0];
+        int offset = 0;
+        for (int counter = 1; offset < length; counter++) {
+            ByteBuffer input = ByteBuffer.allocate(previous.length + info.length + 1);
+            input.put(previous).put(info).put((byte) counter);
+            previous = hmac(prk, input.array());
+            int copyLength = Math.min(previous.length, length - offset);
+            System.arraycopy(previous, 0, output, offset, copyLength);
+            offset += copyLength;
+        }
+        return output;
+    }
+
+    /**
+     * 规范化 hash 比较，避免长度和大小写差异绕过完整性校验。
+     */
+    public static boolean constantTimeEquals(byte[] left, byte[] right) {
+        if (left == null || right == null || left.length != right.length) {
+            return false;
+        }
+        int difference = 0;
+        for (int i = 0; i < left.length; i++) {
+            difference |= left[i] ^ right[i];
+        }
+        return difference == 0;
+    }
+
+    private static byte[] info(String prefix, int chunkIndex, int frameIndex) {
+        byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.allocate(prefixBytes.length + 8)
+                .order(ByteOrder.BIG_ENDIAN)
+                .put(prefixBytes)
+                .putInt(chunkIndex)
+                .putInt(frameIndex)
+                .array();
+    }
+
+    private static byte[] hmac(byte[] key, byte[] value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new javax.crypto.spec.SecretKeySpec(key, "HmacSHA256"));
+            return mac.doFinal(value);
+        } catch (java.security.GeneralSecurityException e) {
+            throw new IllegalStateException("HmacSHA256 unavailable", e);
+        }
+    }
+
+    private static void validateKeyInputs(byte[] fileDek, byte[] fileNonce, int chunkIndex, int frameIndex) {
+        if (fileDek == null || fileDek.length != FILE_DEK_SIZE
+                || fileNonce == null || fileNonce.length != FILE_NONCE_SIZE
+                || chunkIndex < 0 || frameIndex < 0) {
+            throw new IllegalArgumentException("framed AEAD key inputs are invalid");
+        }
+    }
+
+    private static void validateChunkCoordinates(
+            int chunkIndex,
+            int chunkCount,
+            int framePlainSize,
+            int frameCount,
+            long chunkPlainSize,
+            byte[] fileNonce
+    ) {
+        if (fileNonce == null || fileNonce.length != FILE_NONCE_SIZE
+                || chunkIndex < 0 || chunkCount <= 0 || chunkIndex >= chunkCount
+                || framePlainSize < MIN_FRAME_PLAIN_SIZE || framePlainSize > MAX_FRAME_PLAIN_SIZE
+                || frameCount <= 0 || frameCount > MAX_FRAMES_PER_PART
+                || chunkPlainSize <= 0 || chunkPlainSize > Integer.MAX_VALUE
+                || frameCount != calculateFrameCount(chunkPlainSize, framePlainSize)) {
+            throw new IllegalArgumentException("chunk header values are invalid");
+        }
+    }
+
+    /**
+     * 以不溢出的商/余数计算分片需要的 frame 数，并应用数量上限。
+     */
+    public static int calculateFrameCount(long chunkPlainSize, int framePlainSize) {
+        if (chunkPlainSize <= 0 || framePlainSize <= 0) {
+            throw new IllegalArgumentException("frame count inputs are invalid");
+        }
+        long quotient = chunkPlainSize / framePlainSize;
+        long remainder = chunkPlainSize % framePlainSize;
+        long count = quotient + (remainder == 0 ? 0 : 1);
+        if (count <= 0 || count > MAX_FRAMES_PER_PART) {
+            throw new IllegalArgumentException("frame count exceeds bounded limit");
+        }
+        return Math.toIntExact(count);
+    }
+
+    /**
+     * 已验证的 chunk header 字段。
+     */
+    public record ChunkHeader(
+            int version,
+            int algorithmId,
+            int flags,
+            int chunkIndex,
+            int chunkCount,
+            int framePlainSize,
+            int frameCount,
+            long chunkPlainSize,
+            byte[] fileNonce
+    ) {
+        public ChunkHeader {
+            fileNonce = fileNonce.clone();
+        }
+    }
+
+    /**
+     * 已验证的 frame header 字段。
+     */
+    public record FrameHeader(int frameIndex, int plainLength, int cipherLength) {
+    }
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/encryption/FramedAeadWriter.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/encryption/FramedAeadWriter.java
@@ -1,0 +1,311 @@
+package cn.flying.service.encryption;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 以固定 frame 内存预算生成和验证 framed AES-GCM v2 对象。
+ */
+@Component
+public class FramedAeadWriter {
+
+    private static final String HASH_PREFIX = "sha256:";
+    private static final int IO_BUFFER_SIZE = 64 * 1024;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    /**
+     * 生成稳定长度的文件级 DEK；调用方负责将其写入受控会话检查点。
+     */
+    public byte[] generateFileDek() {
+        byte[] dek = new byte[FramedAeadCrypto.FILE_DEK_SIZE];
+        secureRandom.nextBytes(dek);
+        return dek;
+    }
+
+    /**
+     * 生成稳定长度的文件级 nonce；调用方负责将其写入受控会话检查点。
+     */
+    public byte[] generateFileNonce() {
+        byte[] nonce = new byte[FramedAeadCrypto.FILE_NONCE_SIZE];
+        secureRandom.nextBytes(nonce);
+        return nonce;
+    }
+
+    /**
+     * 将一个明文分片按 1MiB 默认、有界 frame 写成 v2 对象。
+     */
+    public WriteResult write(
+            Path plainPath,
+            Path encryptedPath,
+            byte[] fileDek,
+            byte[] fileNonce,
+            int chunkIndex,
+            int chunkCount,
+            int framePlainSize
+    ) throws IOException {
+        validatePathsAndKeys(plainPath, encryptedPath, fileDek, fileNonce, framePlainSize);
+        long plainSize = Files.size(plainPath);
+        if (plainSize <= 0 || plainSize > Integer.MAX_VALUE) {
+            throw new IOException("framed chunk plaintext size is invalid");
+        }
+        int frameCount = FramedAeadCrypto.calculateFrameCount(plainSize, framePlainSize);
+        byte[] header = FramedAeadCrypto.buildChunkHeader(
+                chunkIndex, chunkCount, framePlainSize, frameCount, plainSize, fileNonce);
+        MessageDigest plainDigest = sha256();
+        MessageDigest cipherDigest = sha256();
+        byte[] frameBuffer = new byte[framePlainSize];
+        long remaining = plainSize;
+        int frameIndex = 0;
+
+        Path parent = encryptedPath.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        try (InputStream input = Files.newInputStream(plainPath);
+             OutputStream output = Files.newOutputStream(encryptedPath)) {
+            output.write(header);
+            cipherDigest.update(header);
+            while (remaining > 0) {
+                int expectedLength = (int) Math.min(framePlainSize, remaining);
+                readFully(input, frameBuffer, expectedLength);
+                plainDigest.update(frameBuffer, 0, expectedLength);
+                byte[] ciphertext = encryptFrame(
+                        frameBuffer, expectedLength, fileDek, fileNonce,
+                        chunkIndex, chunkCount, frameIndex, frameCount, plainSize);
+                byte[] frameHeader = FramedAeadCrypto.buildFrameHeader(
+                        frameIndex, expectedLength, ciphertext.length);
+                output.write(frameHeader);
+                output.write(ciphertext);
+                cipherDigest.update(frameHeader);
+                cipherDigest.update(ciphertext);
+                remaining -= expectedLength;
+                frameIndex++;
+            }
+            if (input.read() != -1) {
+                throw new IOException("framed chunk contains unexpected trailing plaintext");
+            }
+            output.flush();
+        }
+        return new WriteResult(
+                plainSize,
+                Files.size(encryptedPath),
+                frameCount,
+                HASH_PREFIX + HexFormat.of().formatHex(plainDigest.digest()),
+                HASH_PREFIX + HexFormat.of().formatHex(cipherDigest.digest()));
+    }
+
+    /**
+     * 在不产生明文输出的情况下完整验证 v2 对象的 header、frame 顺序、tag、长度和 hash。
+     */
+    public WriteResult verify(
+            Path encryptedPath,
+            byte[] fileDek,
+            byte[] fileNonce,
+            int chunkIndex,
+            int chunkCount,
+            int framePlainSize
+    ) throws IOException {
+        if (encryptedPath == null || !Files.isRegularFile(encryptedPath)) {
+            throw new IOException("framed encrypted chunk does not exist");
+        }
+        validateKeys(fileDek, fileNonce, framePlainSize);
+        MessageDigest plainDigest = sha256();
+        MessageDigest cipherDigest = sha256();
+        try (InputStream input = Files.newInputStream(encryptedPath)) {
+            byte[] header = readExact(input, FramedAeadCrypto.CHUNK_HEADER_SIZE);
+            cipherDigest.update(header);
+            FramedAeadCrypto.ChunkHeader parsed = FramedAeadCrypto.parseChunkHeader(header);
+            if (parsed.chunkIndex() != chunkIndex
+                    || parsed.chunkCount() != chunkCount
+                    || parsed.framePlainSize() != framePlainSize
+                    || !FramedAeadCrypto.constantTimeEquals(parsed.fileNonce(), fileNonce)) {
+                throw new IOException("framed chunk header does not match upload state");
+            }
+            long plainSize = parsed.chunkPlainSize();
+            int expectedFrameCount = FramedAeadCrypto.calculateFrameCount(plainSize, framePlainSize);
+            if (parsed.frameCount() != expectedFrameCount) {
+                throw new IOException("framed frame count does not match plaintext size");
+            }
+            long plainBytes = 0;
+            for (int frameIndex = 0; frameIndex < parsed.frameCount(); frameIndex++) {
+                byte[] frameHeader = readExact(input, FramedAeadCrypto.FRAME_HEADER_SIZE);
+                cipherDigest.update(frameHeader);
+                FramedAeadCrypto.FrameHeader frame = FramedAeadCrypto.parseFrameHeader(frameHeader);
+                if (frame.frameIndex() != frameIndex
+                        || frame.plainLength() > framePlainSize
+                        || (frameIndex < parsed.frameCount() - 1 && frame.plainLength() != framePlainSize)
+                        || (frameIndex == parsed.frameCount() - 1 && frame.plainLength() <= 0)) {
+                    throw new IOException("framed frame coordinate or length is invalid");
+                }
+                if (frame.cipherLength() > framePlainSize + FramedAeadCrypto.TAG_SIZE) {
+                    throw new IOException("framed ciphertext exceeds configured bound");
+                }
+                byte[] ciphertext = readExact(input, frame.cipherLength());
+                cipherDigest.update(ciphertext);
+                byte[] plaintext = decryptFrame(
+                        ciphertext, fileDek, parsed.fileNonce(), parsed.chunkIndex(), parsed.chunkCount(),
+                        frameIndex, parsed.frameCount(), frame.plainLength(), plainSize);
+                plainDigest.update(plaintext);
+                plainBytes = Math.addExact(plainBytes, plaintext.length);
+            }
+            if (plainBytes != plainSize || input.read() != -1) {
+                throw new IOException("framed object has truncated or trailing bytes");
+            }
+        } catch (SecurityException e) {
+            throw new IOException("framed frame authentication failed", e);
+        }
+        return new WriteResult(
+                Files.size(encryptedPath) == 0 ? 0 : readPlainSize(encryptedPath),
+                Files.size(encryptedPath),
+                countFrames(encryptedPath),
+                HASH_PREFIX + HexFormat.of().formatHex(plainDigest.digest()),
+                HASH_PREFIX + HexFormat.of().formatHex(cipherDigest.digest()));
+    }
+
+    /**
+     * 将二进制文件级 nonce 编码为 manifest 使用的 Base64URL 无填充文本。
+     */
+    public String encodeFileNonce(byte[] fileNonce) {
+        if (fileNonce == null || fileNonce.length != FramedAeadCrypto.FILE_NONCE_SIZE) {
+            throw new IllegalArgumentException("file nonce length is invalid");
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(fileNonce);
+    }
+
+    private byte[] encryptFrame(
+            byte[] plain,
+            int plainLength,
+            byte[] fileDek,
+            byte[] fileNonce,
+            int chunkIndex,
+            int chunkCount,
+            int frameIndex,
+            int frameCount,
+            long chunkPlainSize
+    ) throws IOException {
+        try {
+            byte[] nonce = FramedAeadCrypto.deriveFrameNonce(fileDek, fileNonce, chunkIndex, frameIndex);
+            byte[] key = FramedAeadCrypto.deriveFrameKey(fileDek, fileNonce, chunkIndex, frameIndex);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(128, nonce));
+            cipher.updateAAD(FramedAeadCrypto.buildAad(
+                    fileNonce, chunkIndex, chunkCount, frameIndex, frameCount, plainLength, chunkPlainSize));
+            return cipher.doFinal(plain, 0, plainLength);
+        } catch (java.security.GeneralSecurityException e) {
+            throw new IOException("framed AES-GCM encryption failed", e);
+        }
+    }
+
+    private byte[] decryptFrame(
+            byte[] ciphertext,
+            byte[] fileDek,
+            byte[] fileNonce,
+            int chunkIndex,
+            int chunkCount,
+            int frameIndex,
+            int frameCount,
+            int plainLength,
+            long chunkPlainSize
+    ) throws IOException {
+        try {
+            byte[] nonce = FramedAeadCrypto.deriveFrameNonce(fileDek, fileNonce, chunkIndex, frameIndex);
+            byte[] key = FramedAeadCrypto.deriveFrameKey(fileDek, fileNonce, chunkIndex, frameIndex);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(128, nonce));
+            cipher.updateAAD(FramedAeadCrypto.buildAad(
+                    fileNonce, chunkIndex, chunkCount, frameIndex, frameCount, plainLength, chunkPlainSize));
+            return cipher.doFinal(ciphertext);
+        } catch (java.security.GeneralSecurityException e) {
+            throw new IOException("framed frame authentication failed", e);
+        }
+    }
+
+    private void validatePathsAndKeys(
+            Path plainPath,
+            Path encryptedPath,
+            byte[] fileDek,
+            byte[] fileNonce,
+            int framePlainSize
+    ) throws IOException {
+        if (plainPath == null || !Files.isRegularFile(plainPath)) {
+            throw new IOException("framed plaintext chunk does not exist");
+        }
+        validateKeys(fileDek, fileNonce, framePlainSize);
+    }
+
+    private void validateKeys(byte[] fileDek, byte[] fileNonce, int framePlainSize) {
+        if (fileDek == null || fileDek.length != FramedAeadCrypto.FILE_DEK_SIZE
+                || fileNonce == null || fileNonce.length != FramedAeadCrypto.FILE_NONCE_SIZE
+                || framePlainSize < 64 * 1024 || framePlainSize > 4 * 1024 * 1024) {
+            throw new IllegalArgumentException("framed AEAD state is invalid");
+        }
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    private static void readFully(InputStream input, byte[] target, int length) throws IOException {
+        int offset = 0;
+        while (offset < length) {
+            int read = input.read(target, offset, length - offset);
+            if (read < 0) {
+                throw new EOFException("framed plaintext ended unexpectedly");
+            }
+            offset += read;
+        }
+    }
+
+    private static byte[] readExact(InputStream input, int length) throws IOException {
+        byte[] value = new byte[length];
+        readFully(input, value, length);
+        return value;
+    }
+
+    private static long readPlainSize(Path encryptedPath) throws IOException {
+        byte[] header;
+        try (InputStream input = Files.newInputStream(encryptedPath)) {
+            header = readExact(input, FramedAeadCrypto.CHUNK_HEADER_SIZE);
+        }
+        return FramedAeadCrypto.parseChunkHeader(header).chunkPlainSize();
+    }
+
+    private static int countFrames(Path encryptedPath) throws IOException {
+        // verify() 已完成完整解析；这里只返回 header 中的声明数量，避免再次分配对象。
+        try (InputStream input = Files.newInputStream(encryptedPath)) {
+            return FramedAeadCrypto.parseChunkHeader(
+                    readExact(input, FramedAeadCrypto.CHUNK_HEADER_SIZE)).frameCount();
+        }
+    }
+
+    /**
+     * v2 writer/validator 输出的完整 hash 和尺寸证据。
+     */
+    public record WriteResult(
+            long plainSize,
+            long cipherSize,
+            int frameCount,
+            String plainHash,
+            String cipherHash
+    ) {
+    }
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileQueryServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileQueryServiceImpl.java
@@ -18,6 +18,7 @@ import cn.flying.dao.mapper.AccountMapper;
 import cn.flying.dao.mapper.FileMapper;
 import cn.flying.dao.mapper.FileShareMapper;
 import cn.flying.dao.vo.file.FileDecryptInfoVO;
+import cn.flying.dao.vo.file.FileDownloadEncryptionVO;
 import cn.flying.dao.vo.file.FileDownloadMetadataVO;
 import cn.flying.dao.vo.file.FileDownloadPartVO;
 import cn.flying.dao.vo.file.FileShareVO;
@@ -29,8 +30,12 @@ import cn.flying.platformapi.response.FileDetailVO;
 import cn.flying.platformapi.response.TransactionVO;
 import cn.flying.service.FileQueryService;
 import cn.flying.service.FriendFileShareService;
+import cn.flying.service.encryption.FramedAeadCrypto;
 import cn.flying.service.key.FileKeyEnvelopeService;
+import cn.flying.service.manifest.ChunkManifestCanonicalizer;
 import cn.flying.service.manifest.ChunkManifestChunk;
+import cn.flying.service.manifest.ChunkManifestDraft;
+import cn.flying.service.manifest.ChunkManifestEncryption;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
 import cn.flying.service.remote.FileRemoteClient;
@@ -58,8 +63,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * 文件查询服务实现类（CQRS Query Side）
@@ -97,6 +103,9 @@ public class FileQueryServiceImpl implements FileQueryService {
 
     private static final long MAX_IN_MEMORY_TRANSFER_BYTES = 80L * 1024 * 1024;
     private static final long DOWNLOAD_URL_TTL_SECONDS = 24L * 60L * 60L;
+    private static final String ENCRYPTION_NONE = "NONE";
+    private static final String FRAMED_ENCRYPTION_ALGORITHM = "FRAMED_AEAD_V2";
+    private static final Pattern CANONICAL_SHA256_PATTERN = Pattern.compile("sha256:[0-9a-f]{64}");
 
     private final FileMapper fileMapper;
     private final AccountMapper accountMapper;
@@ -277,6 +286,22 @@ public class FileQueryServiceImpl implements FileQueryService {
             throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "文件分片 manifest 为空");
         }
 
+        Long fileSizeValue = resolveDownloadFileSize(file, decryptInfo);
+        long responseChunkSize = validateDownloadManifest(
+                file, fileHash, decryptInfo, manifest, fileSizeValue);
+        ChunkManifestDraft downloadDraft = new ChunkManifestDraft(
+                manifest.schemaId(),
+                manifest.fileHash(),
+                manifest.hashAlgorithm(),
+                manifest.chunkSize(),
+                manifest.totalSize(),
+                manifest.merkleRoot(),
+                manifest.encryptionAlgorithm(),
+                manifest.storageBackend(),
+                manifest.encryption(),
+                manifest.chunks());
+        String canonicalManifestJson = chunkManifestService.calculateCanonicalJson(downloadDraft);
+
         List<String> storagePaths = manifest.chunks().stream()
                 .map(ChunkManifestChunk::storagePath)
                 .toList();
@@ -292,10 +317,6 @@ public class FileQueryServiceImpl implements FileQueryService {
 
         long expiresAtEpochSeconds = System.currentTimeMillis() / 1000L + DOWNLOAD_URL_TTL_SECONDS;
         List<FileDownloadPartVO> parts = buildDownloadParts(manifest, downloadUrls, expiresAtEpochSeconds);
-        Long fileSizeValue = decryptInfo.fileSize() != null ? decryptInfo.fileSize() : file.getFileSize();
-        if (fileSizeValue == null) {
-            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "文件大小缺失");
-        }
 
         return new FileDownloadMetadataVO(
                 IdUtils.toExternalId(file.getId()),
@@ -306,13 +327,252 @@ public class FileQueryServiceImpl implements FileQueryService {
                 decryptInfo.initialKey(),
                 manifest.schemaId(),
                 manifest.manifestHash(),
+                canonicalManifestJson,
                 manifest.hashAlgorithm(),
                 manifest.encryptionAlgorithm(),
                 manifest.storageBackend(),
-                manifest.chunkSize(),
+                responseChunkSize,
                 parts.size(),
+                toDownloadEncryption(manifest.encryption()),
                 parts
         );
+    }
+
+    /**
+     * 解析并核对数据库与 fileParam 中的文件明文大小，避免返回相互冲突的下载合同。
+     */
+    private Long resolveDownloadFileSize(File file, FileDecryptInfoVO decryptInfo) {
+        Long persistedSize = file.getFileSize();
+        Long parameterSize = decryptInfo.fileSize();
+        if (persistedSize != null && parameterSize != null && !persistedSize.equals(parameterSize)) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "文件大小与 fileParam 不一致");
+        }
+        Long resolved = parameterSize != null ? parameterSize : persistedSize;
+        if (resolved == null || resolved <= 0) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "文件大小缺失或无效");
+        }
+        return resolved;
+    }
+
+    /**
+     * 在请求预签名 URL 前校验 manifest 哈希、格式、连续索引和 v2 明密文尺寸合同。
+     */
+    private long validateDownloadManifest(
+            File file,
+            String requestedFileHash,
+            FileDecryptInfoVO decryptInfo,
+            ChunkManifestView manifest,
+            long fileSize
+    ) {
+        List<ChunkManifestChunk> chunks = manifest.chunks();
+        if (!Objects.equals(manifest.fileId(), file.getId())
+                || !Objects.equals(manifest.fileHash(), requestedFileHash)
+                || !Objects.equals(manifest.fileHash(), file.getFileHash())
+                || !ChunkManifestCanonicalizer.SCHEMA_ID.equals(manifest.schemaId())
+                || !ChunkManifestCanonicalizer.HASH_ALGORITHM.equals(manifest.hashAlgorithm())
+                || manifest.chunkSize() <= 0
+                || manifest.totalSize() <= 0
+                || manifest.chunkCount() == null
+                || manifest.chunkCount() != chunks.size()
+                || !StringUtils.hasText(manifest.storageBackend())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest 顶层合同无效");
+        }
+        if (decryptInfo.chunkCount() != null
+                && !Objects.equals(decryptInfo.chunkCount(), manifest.chunkCount())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "fileParam 分片数量与 manifest 不一致");
+        }
+
+        ChunkManifestEncryption encryption = manifest.encryption();
+        boolean framedV2 = encryption != null
+                && Objects.equals(encryption.formatVersion(), ChunkManifestEncryption.FORMAT_FRAMED_V2);
+        boolean unencrypted = ENCRYPTION_NONE.equalsIgnoreCase(manifest.encryptionAlgorithm());
+        validateEncryptionCoherence(manifest, framedV2, unencrypted);
+
+        long aggregateLogicalSize = 0L;
+        Set<String> storagePaths = new HashSet<>();
+        for (int index = 0; index < chunks.size(); index++) {
+            ChunkManifestChunk chunk = chunks.get(index);
+            if (chunk == null
+                    || chunk.index() != index
+                    || chunk.size() <= 0
+                    || !StringUtils.hasText(chunk.plainHash())
+                    || !StringUtils.hasText(chunk.cipherHash())
+                    || !StringUtils.hasText(chunk.storagePath())
+                    || !storagePaths.add(chunk.storagePath())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest 分片顺序或证据无效");
+            }
+            long logicalSize = framedV2
+                    ? validateFramedChunk(manifest, chunk, index)
+                    : chunk.size();
+            try {
+                aggregateLogicalSize = Math.addExact(aggregateLogicalSize, logicalSize);
+            } catch (ArithmeticException overflow) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest 分片大小溢出");
+            }
+        }
+        if (aggregateLogicalSize != manifest.totalSize()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest 分片总量不一致");
+        }
+        if ((framedV2 || unencrypted) && manifest.totalSize() != fileSize) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest 明文总量与文件大小不一致");
+        }
+
+        long responseChunkSize = manifest.chunkSize();
+        if (decryptInfo.chunkSize() != null) {
+            if (decryptInfo.chunkSize() <= 0
+                    || ((framedV2 || unencrypted) && decryptInfo.chunkSize() != manifest.chunkSize())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "fileParam 分片大小与 manifest 不一致");
+            }
+            responseChunkSize = decryptInfo.chunkSize();
+        }
+
+        validateV2FileParam(file, manifest, framedV2);
+        ChunkManifestDraft draft = new ChunkManifestDraft(
+                manifest.schemaId(),
+                manifest.fileHash(),
+                manifest.hashAlgorithm(),
+                manifest.chunkSize(),
+                manifest.totalSize(),
+                manifest.merkleRoot(),
+                manifest.encryptionAlgorithm(),
+                manifest.storageBackend(),
+                manifest.encryption(),
+                manifest.chunks());
+        String calculatedManifestHash;
+        try {
+            calculatedManifestHash = chunkManifestService.calculateManifestHash(draft);
+        } catch (GeneralException | ArithmeticException invalidManifest) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest canonical 合同无效");
+        }
+        if (!CANONICAL_SHA256_PATTERN.matcher(Objects.toString(manifest.manifestHash(), "")).matches()
+                || !Objects.equals(manifest.manifestHash(), calculatedManifestHash)) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "下载 manifest hash 不一致");
+        }
+        return responseChunkSize;
+    }
+
+    /**
+     * 校验 encryptionAlgorithm 与版本化 descriptor 的组合，拒绝未知或冲突的格式声明。
+     */
+    private void validateEncryptionCoherence(
+            ChunkManifestView manifest,
+            boolean framedV2,
+            boolean unencrypted
+    ) {
+        ChunkManifestEncryption encryption = manifest.encryption();
+        if (framedV2 && !FRAMED_ENCRYPTION_ALGORITHM.equalsIgnoreCase(manifest.encryptionAlgorithm())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest 加密算法声明不一致");
+        }
+        if (FRAMED_ENCRYPTION_ALGORITHM.equalsIgnoreCase(manifest.encryptionAlgorithm()) && !framedV2) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest 缺少加密描述");
+        }
+        if (encryption == null) {
+            return;
+        }
+        if (Objects.equals(encryption.formatVersion(), ChunkManifestEncryption.FORMAT_NONE) && !unencrypted) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "NONE descriptor 与加密算法冲突");
+        }
+        if (Objects.equals(encryption.formatVersion(), ChunkManifestEncryption.FORMAT_LEGACY_V1)
+                && (unencrypted || framedV2)) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "legacy descriptor 与加密算法冲突");
+        }
+        if (unencrypted && !Objects.equals(
+                encryption.formatVersion(), ChunkManifestEncryption.FORMAT_NONE)) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "NONE manifest formatVersion 无效");
+        }
+    }
+
+    /**
+     * 校验单个 framed v2 分片的明文大小、frame 数量和密文字节公式。
+     */
+    private long validateFramedChunk(ChunkManifestView manifest, ChunkManifestChunk chunk, int index) {
+        ChunkManifestEncryption encryption = manifest.encryption();
+        Long plainSize = chunk.plainSize();
+        Integer frameCount = chunk.frameCount();
+        if (plainSize == null || plainSize <= 0 || frameCount == null || frameCount <= 0
+                || encryption == null
+                || encryption.framePlainSize() == null
+                || encryption.tagSize() == null
+                || !CANONICAL_SHA256_PATTERN.matcher(chunk.plainHash()).matches()
+                || !CANONICAL_SHA256_PATTERN.matcher(chunk.cipherHash()).matches()
+                || plainSize > manifest.chunkSize()
+                || (index < manifest.chunks().size() - 1 && plainSize != manifest.chunkSize())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest 分片明文或 hash 合同无效");
+        }
+        long expectedFrameCount = (plainSize + encryption.framePlainSize() - 1L)
+                / encryption.framePlainSize();
+        long expectedCipherSize;
+        try {
+            expectedCipherSize = Math.addExact(
+                    Math.addExact(FramedAeadCrypto.CHUNK_HEADER_SIZE, plainSize),
+                    Math.multiplyExact(expectedFrameCount,
+                            FramedAeadCrypto.FRAME_HEADER_SIZE + (long) encryption.tagSize()));
+        } catch (ArithmeticException overflow) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest 密文大小溢出");
+        }
+        if (frameCount.longValue() != expectedFrameCount || chunk.size() != expectedCipherSize) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest frame 或密文大小不一致");
+        }
+        return plainSize;
+    }
+
+    /**
+     * 对 v2 文件核对持久化 fileParam 与 active manifest descriptor，防止 key/nonce 合同漂移。
+     */
+    private void validateV2FileParam(File file, ChunkManifestView manifest, boolean framedV2) {
+        if (!framedV2) {
+            return;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> params = JsonConverter.parse(file.getFileParam(), Map.class);
+            ChunkManifestEncryption encryption = manifest.encryption();
+            if (params == null
+                    || !FRAMED_ENCRYPTION_ALGORITHM.equalsIgnoreCase(Objects.toString(
+                    params.get("encryptionAlgorithm"), ""))
+                    || !Objects.equals(params.get("algorithmSuite"), encryption.algorithmSuite())
+                    || !Objects.equals(params.get("fileNonce"), encryption.fileNonce())
+                    || !Objects.equals(params.get("keyDerivation"), encryption.keyDerivation())
+                    || !Objects.equals(params.get("nonceDerivation"), encryption.nonceDerivation())
+                    || !Objects.equals(params.get("aadSchema"), encryption.aadSchema())
+                    || !numericEquals(params.get("formatVersion"), encryption.formatVersion())
+                    || !numericEquals(params.get("framePlainSize"), encryption.framePlainSize())
+                    || !numericEquals(params.get("tagSize"), encryption.tagSize())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "v2 fileParam 与 manifest 加密描述不一致");
+            }
+        } catch (GeneralException e) {
+            throw e;
+        } catch (RuntimeException parseError) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 fileParam 格式无效");
+        }
+    }
+
+    /**
+     * 以 long 语义比较 JSON 数值和 descriptor 整数，兼容 Jackson 的 Integer/Long 表示。
+     */
+    private boolean numericEquals(Object actual, Number expected) {
+        return actual instanceof Number actualNumber
+                && expected != null
+                && actualNumber.longValue() == expected.longValue();
+    }
+
+    /**
+     * 将内部 manifest descriptor 映射为对外下载合同。
+     */
+    private FileDownloadEncryptionVO toDownloadEncryption(ChunkManifestEncryption encryption) {
+        if (encryption == null) {
+            return null;
+        }
+        return new FileDownloadEncryptionVO(
+                encryption.formatVersion(),
+                encryption.algorithmSuite(),
+                encryption.fileNonce(),
+                encryption.framePlainSize(),
+                encryption.keyDerivation(),
+                encryption.nonceDerivation(),
+                encryption.aadSchema(),
+                encryption.tagSize());
     }
 
     /**
@@ -325,15 +585,23 @@ public class FileQueryServiceImpl implements FileQueryService {
         List<FileDownloadPartVO> parts = new ArrayList<>(chunks.size());
         for (int i = 0; i < chunks.size(); i++) {
             ChunkManifestChunk chunk = chunks.get(i);
+            String downloadUrl = downloadUrls.get(i);
+            if (!StringUtils.hasText(downloadUrl)) {
+                throw new GeneralException(ResultEnum.FILE_SERVICE_ERROR, "对象存储返回空下载 URL");
+            }
             parts.add(new FileDownloadPartVO(
                     chunk.index(),
                     chunk.size(),
-                    downloadUrls.get(i),
+                    downloadUrl,
                     expiresAtEpochSeconds,
                     chunk.storagePath(),
+                    chunk.storageBackend(),
+                    chunk.etag(),
                     chunk.plainHash(),
                     chunk.cipherHash(),
-                    chunk.checksumAlgorithm()
+                    chunk.checksumAlgorithm(),
+                    chunk.plainSize(),
+                    chunk.frameCount()
             ));
         }
         return parts;
@@ -509,6 +777,8 @@ public class FileQueryServiceImpl implements FileQueryService {
             String contentType = (String) params.get("contentType");
             Integer chunkCount = params.get("chunkCount") instanceof Number
                     ? ((Number) params.get("chunkCount")).intValue() : null;
+            Long chunkSize = params.get("chunkSize") instanceof Number
+                    ? ((Number) params.get("chunkSize")).longValue() : null;
 
             return new FileDecryptInfoVO(
                     initialKey,
@@ -516,7 +786,8 @@ public class FileQueryServiceImpl implements FileQueryService {
                     fileSize,
                     contentType,
                     chunkCount,
-                    fileHash
+                    fileHash,
+                    chunkSize
             );
 
         } catch (GeneralException e) {

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileServiceImpl.java
@@ -2401,6 +2401,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             String contentType = (String) params.get("contentType");
             Integer chunkCount = params.get("chunkCount") instanceof Number
                     ? ((Number) params.get("chunkCount")).intValue() : null;
+            Long chunkSize = params.get("chunkSize") instanceof Number
+                    ? ((Number) params.get("chunkSize")).longValue() : null;
 
             return new FileDecryptInfoVO(
                     initialKey,
@@ -2408,7 +2410,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
                     fileSize,
                     contentType,
                     chunkCount,
-                    fileHash
+                    fileHash,
+                    chunkSize
             );
 
         } catch (GeneralException e) {
@@ -2457,6 +2460,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
             String contentType = (String) params.get("contentType");
             Integer chunkCount = params.get("chunkCount") instanceof Number
                     ? ((Number) params.get("chunkCount")).intValue() : null;
+            Long chunkSize = params.get("chunkSize") instanceof Number
+                    ? ((Number) params.get("chunkSize")).longValue() : null;
 
             return new FileDecryptInfoVO(
                     initialKey,
@@ -2464,7 +2469,8 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, File> implements Fi
                     fileSize,
                     contentType,
                     chunkCount,
-                    fileHash
+                    fileHash,
+                    chunkSize
             );
 
         } catch (GeneralException e) {

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
@@ -21,8 +21,10 @@ import cn.flying.service.encryption.*;
 import cn.flying.service.manifest.ChunkManifestCanonicalizer;
 import cn.flying.service.manifest.ChunkManifestChunk;
 import cn.flying.service.manifest.ChunkManifestDraft;
+import cn.flying.service.manifest.ChunkManifestEncryption;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
+import cn.flying.service.manifest.FramedManifestFinalizationService;
 import cn.flying.service.remote.FileRemoteClient;
 import cn.flying.platformapi.request.AbortDirectMultipartUploadRequest;
 import cn.flying.platformapi.request.CompleteDirectMultipartUploadRequest;
@@ -107,6 +109,10 @@ public class FileUploadServiceImpl implements FileUploadService {
     private static final long QUOTA_COMPLETE_LOCK_WAIT_SECONDS = 5L;
     private static final int MAX_CLEANUP_RETRIES = 3;
     private static final int CURRENT_RECOVERY_SCHEMA_VERSION = 1;
+    private static final int CURRENT_ENCRYPTION_RECOVERY_VERSION = 2;
+    private static final String FRAMED_WRITER_FORMAT = "v2";
+    private static final String LEGACY_WRITER_FORMAT = "v1";
+    private static final String FRAMED_ENCRYPTION_ALGORITHM = "FRAMED_AEAD_V2";
     private static final String UPLOAD_SESSION_STATUS_CLEANUP_MANUAL_REQUIRED =
             "cleanup_manual_required";
     private static final String UPLOAD_SESSION_STATUS_FINALIZATION_RECOVERY_PENDING =
@@ -146,11 +152,14 @@ public class FileUploadServiceImpl implements FileUploadService {
     private final FileUploadRedisStateManager redisStateManager;
     // 加密策略工厂
     private final EncryptionStrategyFactory encryptionStrategyFactory;
+    private final EncryptionProperties encryptionProperties;
+    private final FramedAeadWriter framedAeadWriter;
     private final FileService fileService;
     private final QuotaService quotaService;
     private final RedissonClient redissonClient;
     private final FileRemoteClient fileRemoteClient;
     private final ChunkManifestService chunkManifestService;
+    private final FramedManifestFinalizationService framedManifestFinalizationService;
 
     @PostConstruct
     public void initialize() {
@@ -1002,6 +1011,7 @@ public class FileUploadServiceImpl implements FileUploadService {
             );
             newState.setTenantId(tenantId);
             newState.setRecoverySchemaVersion(CURRENT_RECOVERY_SCHEMA_VERSION);
+            initializeEncryptionState(newState);
 
             // 确保客户端和会话的目录存在
             Path uploadDir = getUploadSessionDir(SUID, clientId);
@@ -1084,6 +1094,7 @@ public class FileUploadServiceImpl implements FileUploadService {
             state.setTenantId(tenantId);
             state.setSuid(suid);
             state.setRecoverySchemaVersion(CURRENT_RECOVERY_SCHEMA_VERSION);
+            state.setEncryptionRecoveryVersion(1);
             state.setDirectUpload(true);
             state.setDirectUploadParts(directUploadParts);
             state.setDirectFinalizationStage(DIRECT_STAGE_SESSION_CREATED);
@@ -1947,6 +1958,7 @@ public class FileUploadServiceImpl implements FileUploadService {
         params.put("contentType", state.getContentType());
         params.put("uploadTime", state.getStartTime());
         params.put("chunkCount", state.getTotalChunks());
+        params.put("chunkSize", state.getChunkSize());
         params.put("uploadMode", "DIRECT_MULTIPART");
         params.put("encryptionAlgorithm", "NONE");
         params.put("contentHash", requireContentHash(state.getContentHash()));
@@ -2300,6 +2312,72 @@ public class FileUploadServiceImpl implements FileUploadService {
             log.warn("无法确认上传证据是否提交，保留原始分片供重试: clientId={}, chunk={}",
                     clientId, chunkNumber, readError);
         }
+    }
+
+    /**
+     * 初始化普通代理上传的稳定加密检查点；重试只复用该检查点，不重新生成 DEK 或 nonce。
+     *
+     * @param state 新建的上传会话状态
+     */
+    private void initializeEncryptionState(FileUploadState state) {
+        if (state == null) {
+            throw new GeneralException(ResultEnum.FILE_UPLOAD_ERROR, "上传会话状态不能为空");
+        }
+        // 单元测试或旧手工构造未注入新配置时回退 legacy，生产 Spring Bean 仍默认使用 v2。
+        String configuredFormat = encryptionProperties == null
+                ? LEGACY_WRITER_FORMAT
+                : encryptionProperties.getWriterFormat();
+        String format = configuredFormat == null || configuredFormat.isBlank()
+                ? FRAMED_WRITER_FORMAT
+                : configuredFormat.trim().toLowerCase(Locale.ROOT);
+        if (FRAMED_WRITER_FORMAT.equals(format)) {
+            int framePlainSize = encryptionProperties.getFramePlainSize();
+            if (framePlainSize < ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE
+                    || framePlainSize > ChunkManifestEncryption.MAX_FRAME_PLAIN_SIZE) {
+                throw new GeneralException(ResultEnum.PARAM_ERROR,
+                        "framed v2 framePlainSize 超出有界范围");
+            }
+            byte[] fileDek = framedAeadWriter.generateFileDek();
+            byte[] fileNonce = framedAeadWriter.generateFileNonce();
+            state.setEncryptionRecoveryVersion(CURRENT_ENCRYPTION_RECOVERY_VERSION);
+            state.setEncryptionFormatVersion(FramedAeadCrypto.FORMAT_VERSION);
+            state.setEncryptionAlgorithmSuite(ChunkManifestEncryption.SUITE_FRAMED_V2);
+            state.setFileDataKey(fileDek);
+            state.setFileNonce(fileNonce);
+            state.setFramePlainSize(framePlainSize);
+            state.setKeyDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setNonceDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setAadSchema(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2);
+            state.setTagSize(FramedAeadCrypto.TAG_SIZE);
+            return;
+        }
+        if (LEGACY_WRITER_FORMAT.equals(format) || "legacy".equals(format)) {
+            state.setEncryptionRecoveryVersion(1);
+            state.setEncryptionFormatVersion(ChunkManifestEncryption.FORMAT_LEGACY_V1);
+            state.setEncryptionAlgorithmSuite(null);
+            state.setFileDataKey(null);
+            state.setFileNonce(null);
+            state.setFramePlainSize(null);
+            state.setKeyDerivation(null);
+            state.setNonceDerivation(null);
+            state.setAadSchema(null);
+            state.setTagSize(null);
+            return;
+        }
+        throw new GeneralException(ResultEnum.PARAM_ERROR,
+                "不支持的普通上传 writer-format: " + configuredFormat);
+    }
+
+    /**
+     * 判断上传会话是否使用 framed AEAD v2 对象格式。
+     *
+     * @param state 上传会话状态
+     * @return 使用 v2 时返回 true
+     */
+    private boolean isFramedV2(FileUploadState state) {
+        return state != null
+                && Objects.equals(state.getEncryptionFormatVersion(), FramedAeadCrypto.FORMAT_VERSION)
+                && Objects.equals(state.getEncryptionAlgorithmSuite(), ChunkManifestEncryption.SUITE_FRAMED_V2);
     }
 
 
@@ -3290,6 +3368,22 @@ public class FileUploadServiceImpl implements FileUploadService {
                 && Objects.equals(
                     expectedState.getRecoverySchemaVersion(),
                     latestState.getRecoverySchemaVersion())
+                && Objects.equals(
+                    expectedState.getEncryptionRecoveryVersion(),
+                    latestState.getEncryptionRecoveryVersion())
+                && Objects.equals(
+                    expectedState.getEncryptionFormatVersion(),
+                    latestState.getEncryptionFormatVersion())
+                && Objects.equals(
+                    expectedState.getEncryptionAlgorithmSuite(),
+                    latestState.getEncryptionAlgorithmSuite())
+                && Arrays.equals(expectedState.getFileDataKey(), latestState.getFileDataKey())
+                && Arrays.equals(expectedState.getFileNonce(), latestState.getFileNonce())
+                && Objects.equals(expectedState.getFramePlainSize(), latestState.getFramePlainSize())
+                && Objects.equals(expectedState.getKeyDerivation(), latestState.getKeyDerivation())
+                && Objects.equals(expectedState.getNonceDerivation(), latestState.getNonceDerivation())
+                && Objects.equals(expectedState.getAadSchema(), latestState.getAadSchema())
+                && Objects.equals(expectedState.getTagSize(), latestState.getTagSize())
                 && hasSameDirectUploadPlan(expectedState, latestState);
     }
 
@@ -3381,6 +3475,31 @@ public class FileUploadServiceImpl implements FileUploadService {
         Set<Integer> processedChunks = state.getProcessedChunks();
         Map<String, String> chunkHashes = state.getChunkHashes();
         Map<Integer, byte[]> keys = state.getKeys();
+        if (isFramedV2(state)) {
+            if (uploadedChunks == null
+                    || processedChunks == null
+                    || chunkHashes == null
+                    || uploadedChunks.size() != expectedChunks
+                    || processedChunks.size() != expectedChunks
+                    || chunkHashes.size() != expectedChunks
+                    || state.getFileDataKey() == null
+                    || state.getFileDataKey().length != FramedAeadCrypto.FILE_DEK_SIZE
+                    || state.getFileNonce() == null
+                    || state.getFileNonce().length != FramedAeadCrypto.FILE_NONCE_SIZE
+                    || state.getFramePlainSize() == null) {
+                throw incompleteCompletionState(state, expectedChunks);
+            }
+            for (int index = 0; index < expectedChunks; index++) {
+                String hash = chunkHashes.get("chunk_" + index);
+                if (!uploadedChunks.contains(index)
+                        || !processedChunks.contains(index)
+                        || hash == null
+                        || hash.isBlank()) {
+                    throw incompleteCompletionState(state, expectedChunks);
+                }
+            }
+            return;
+        }
         if (uploadedChunks == null
                 || processedChunks == null
                 || chunkHashes == null
@@ -3491,6 +3610,24 @@ public class FileUploadServiceImpl implements FileUploadService {
 
         validateLegacySuccessEvidence(userId, state, persistedFile);
         try {
+            if (isFramedV2(state)) {
+                List<File> processedFiles = collectProcessedFiles(suid, state.getClientId());
+                List<String> cipherHashes = processedFiles == null
+                        ? List.of()
+                        : collectCipherFileHashes(state, processedFiles);
+                Optional<ChunkManifestView> manifest = framedManifestFinalizationService.ensureManifest(
+                        userId,
+                        persistedFile,
+                        state,
+                        processedFiles == null ? List.of() : processedFiles,
+                        cipherHashes == null ? List.of() : cipherHashes);
+                if (manifest.isEmpty()) {
+                    throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                            "普通 v2 上传缺少 active manifest");
+                }
+                state.setManifestHash(manifest.get().manifestHash());
+                redisStateManager.updateState(state);
+            }
             cleanupLegacyTemporaryFilesStrict(state);
             redisStateManager.markCompleted(state.getClientId(), suid, 300);
         } catch (IOException | RuntimeException completionStateError) {
@@ -3987,39 +4124,67 @@ public class FileUploadServiceImpl implements FileUploadService {
                 throw new GeneralException(ResultEnum.FILE_UPLOAD_ERROR, "原始分片与 Redis 哈希证据不一致");
             }
 
-            ChunkEncryptionStrategy strategy = encryptionStrategyFactory.getStrategy();
-            SecretKey candidateKey = strategy.generateKey();
-            byte[] stableKeyBytes = redisStateManager.getOrCreateChunkKey(
-                    clientId, chunkNumber, candidateKey.getEncoded());
-            SecretKey stableKey = new SecretKeySpec(
-                    stableKeyBytes, resolveSecretKeyAlgorithm(strategy));
-            byte[] iv = strategy.generateIv();
-            EncryptionContext encryptionContext = strategy.createEncryptionContext(stableKey, iv);
-
+            // legacy v1 在 getOrCreateChunkKey 中完成原子持久化；后续直接复用同一返回值，
+            // 避免再次读取辅助 hash 时遭遇过期快照或与本次处理不一致。
+            byte[] stableKeyBytes = null;
             Files.createDirectories(processedChunkPath.getParent());
-            try (InputStream input = Files.newInputStream(chunkPath);
-                 FileChannel tempChannel = FileChannel.open(
-                         taskTempPath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
-                 OutputStream output = Channels.newOutputStream(tempChannel)) {
-                output.write(ChunkFileHeader.createHeader(strategy));
-                output.write(iv);
-                byte[] buffer = new byte[BUFFER_SIZE];
-                int bytesRead;
-                while ((bytesRead = input.read(buffer)) != -1) {
-                    byte[] encryptedBytes = strategy.encryptUpdate(
-                            encryptionContext, buffer, 0, bytesRead);
-                    if (encryptedBytes.length > 0) {
-                        output.write(encryptedBytes);
+            if (isFramedV2(latestState)) {
+                byte[] fileDek = latestState.getFileDataKey();
+                byte[] fileNonce = latestState.getFileNonce();
+                Integer framePlainSize = latestState.getFramePlainSize();
+                if (fileDek == null || fileNonce == null || framePlainSize == null) {
+                    throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                            "framed v2 上传检查点不完整");
+                }
+                FramedAeadWriter.WriteResult result = framedAeadWriter.write(
+                        chunkPath,
+                        taskTempPath,
+                        fileDek,
+                        fileNonce,
+                        chunkNumber,
+                        latestState.getTotalChunks(),
+                        framePlainSize);
+                long expectedPlainSize = expectedChunkSize(latestState, chunkNumber);
+                if (result.plainSize() != expectedPlainSize
+                        || !Objects.equals(
+                                result.plainHash(), canonicalSha256FromBase64Url(trustedHash))) {
+                    throw new GeneralException(ResultEnum.FILE_UPLOAD_ERROR,
+                            "framed v2 分片明文证据不一致");
+                }
+            } else {
+                ChunkEncryptionStrategy strategy = encryptionStrategyFactory.getStrategy();
+                SecretKey candidateKey = strategy.generateKey();
+                stableKeyBytes = redisStateManager.getOrCreateChunkKey(
+                        clientId, chunkNumber, candidateKey.getEncoded());
+                SecretKey stableKey = new SecretKeySpec(
+                        stableKeyBytes, resolveSecretKeyAlgorithm(strategy));
+                byte[] iv = strategy.generateIv();
+                EncryptionContext encryptionContext = strategy.createEncryptionContext(stableKey, iv);
+
+                try (InputStream input = Files.newInputStream(chunkPath);
+                     FileChannel tempChannel = FileChannel.open(
+                             taskTempPath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+                     OutputStream output = Channels.newOutputStream(tempChannel)) {
+                    output.write(ChunkFileHeader.createHeader(strategy));
+                    output.write(iv);
+                    byte[] buffer = new byte[BUFFER_SIZE];
+                    int bytesRead;
+                    while ((bytesRead = input.read(buffer)) != -1) {
+                        byte[] encryptedBytes = strategy.encryptUpdate(
+                                encryptionContext, buffer, 0, bytesRead);
+                        if (encryptedBytes.length > 0) {
+                            output.write(encryptedBytes);
+                        }
                     }
+                    byte[] finalBytes = strategy.encryptFinal(encryptionContext);
+                    if (finalBytes.length > 0) {
+                        output.write(finalBytes);
+                    }
+                    output.write(HASH_SEPARATOR.getBytes(StandardCharsets.UTF_8));
+                    output.write(trustedHash.getBytes(StandardCharsets.UTF_8));
+                    output.flush();
+                    tempChannel.force(true);
                 }
-                byte[] finalBytes = strategy.encryptFinal(encryptionContext);
-                if (finalBytes.length > 0) {
-                    output.write(finalBytes);
-                }
-                output.write(HASH_SEPARATOR.getBytes(StandardCharsets.UTF_8));
-                output.write(trustedHash.getBytes(StandardCharsets.UTF_8));
-                output.flush();
-                tempChannel.force(true);
             }
 
             Files.move(
@@ -4030,7 +4195,14 @@ public class FileUploadServiceImpl implements FileUploadService {
             if (!Files.isRegularFile(processedChunkPath)) {
                 throw new IOException("原子发布后的处理分片不存在");
             }
-            latestState.getKeys().put(chunkNumber, stableKeyBytes);
+            if (!isFramedV2(latestState)) {
+                if (stableKeyBytes == null || stableKeyBytes.length == 0) {
+                    throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                            "legacy 分片稳定密钥缺失");
+                }
+                // v1 使用环形分片密钥；v2 仅持久化文件级 DEK/nonce，不写入分片密钥。
+                latestState.getKeys().put(chunkNumber, stableKeyBytes);
+            }
             redisStateManager.addProcessedChunk(clientId, chunkNumber);
             FileUploadState updatedState = redisStateManager.getState(clientId);
             if (updatedState != null) {
@@ -4049,6 +4221,12 @@ public class FileUploadServiceImpl implements FileUploadService {
             int chunkNumber,
             Path processedChunkPath
     ) {
+        if (isFramedV2(state)) {
+            if (!Files.isRegularFile(processedChunkPath)) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "framed v2 processed 证据缺失");
+            }
+            return;
+        }
         byte[] stableKey = state.getKeys().get(chunkNumber);
         if (stableKey == null || stableKey.length == 0 || !Files.isRegularFile(processedChunkPath)) {
             throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "processed 证据缺少密钥或最终密文");
@@ -4084,6 +4262,27 @@ public class FileUploadServiceImpl implements FileUploadService {
             return Base64.getUrlEncoder().withoutPadding().encodeToString(digest.digest());
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 算法不可用", e);
+        }
+    }
+
+    /**
+     * 将 Redis 中的 Base64URL SHA-256 检查点规范化为 manifest 使用的 sha256: 十六进制形式。
+     *
+     * @param value Base64URL 摘要
+     * @return 规范 sha256: 摘要
+     */
+    private String canonicalSha256FromBase64Url(String value) {
+        if (value == null || value.length() > 128) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "分片哈希检查点无效");
+        }
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(value);
+            if (decoded.length != 32) {
+                throw new IllegalArgumentException("digest length");
+            }
+            return CONTENT_HASH_PREFIX + HexFormat.of().formatHex(decoded);
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "分片哈希检查点无效");
         }
     }
 
@@ -4140,6 +4339,10 @@ public class FileUploadServiceImpl implements FileUploadService {
      * 该步骤支持幂等重入，避免 completeUpload 重试时重复追加 NEXT_KEY 元数据。
      */
     private void completeFileProcessing(String SUID, FileUploadState state) throws IOException {
+        if (isFramedV2(state)) {
+            verifyFramedProcessedChunks(SUID, state);
+            return;
+        }
         log.info("------------开始最终处理步骤 (追加下一个分片密钥): 客户端ID={}--------------", state.getClientId());
         int totalChunks = state.getTotalChunks();
         Map<Integer, byte[]> keys = redisStateManager.getChunkKeys(state.getClientId());
@@ -4184,6 +4387,39 @@ public class FileUploadServiceImpl implements FileUploadService {
         }
 
         log.info("最终处理步骤 (追加下一个分片密钥) 完成: 客户端ID={}", state.getClientId());
+    }
+
+    /**
+     * 在发布存储事件前重新认证全部 v2 对象，确保恢复/重试不会绕过 frame 标签校验。
+     *
+     * @param suid 用户隔离目录标识
+     * @param state 上传会话状态
+     * @throws IOException 认证、长度或对象顺序不一致
+     */
+    private void verifyFramedProcessedChunks(String suid, FileUploadState state) throws IOException {
+        byte[] fileDek = state.getFileDataKey();
+        byte[] fileNonce = state.getFileNonce();
+        Integer framePlainSize = state.getFramePlainSize();
+        if (fileDek == null || fileNonce == null || framePlainSize == null) {
+            throw new IOException("framed v2 加密检查点不完整");
+        }
+        for (int index = 0; index < state.getTotalChunks(); index++) {
+            Path processedPath = getChunkProcessedPath(suid, state.getClientId(), index);
+            FramedAeadWriter.WriteResult result = framedAeadWriter.verify(
+                    processedPath,
+                    fileDek,
+                    fileNonce,
+                    index,
+                    state.getTotalChunks(),
+                    framePlainSize);
+            long expectedPlainSize = expectedChunkSize(state, index);
+            String expectedPlainHash = canonicalSha256FromBase64Url(
+                    requirePlainChunkHash(state, index));
+            if (result.plainSize() != expectedPlainSize
+                    || !Objects.equals(result.plainHash(), expectedPlainHash)) {
+                throw new IOException("framed v2 分片认证结果与上传证据不一致: " + index);
+            }
+        }
     }
 
     /**
@@ -4494,7 +4730,36 @@ public class FileUploadServiceImpl implements FileUploadService {
         params.put("contentType", state.getContentType());
         params.put("uploadTime", state.getStartTime());
         params.put("chunkCount", state.getTotalChunks());
+        params.put("chunkSize", state.getChunkSize());
         params.put("contentHash", requireContentHash(state.getContentHash()));
+
+        if (isFramedV2(state)) {
+            byte[] fileDek = state.getFileDataKey();
+            byte[] fileNonce = state.getFileNonce();
+            if (fileDek == null || fileDek.length != FramedAeadCrypto.FILE_DEK_SIZE
+                    || fileNonce == null || fileNonce.length != FramedAeadCrypto.FILE_NONCE_SIZE
+                    || state.getFramePlainSize() == null) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "framed v2 文件参数缺少稳定加密检查点");
+            }
+            params.put("encryptionAlgorithm", FRAMED_ENCRYPTION_ALGORITHM);
+            params.put("algorithmSuite", ChunkManifestEncryption.SUITE_FRAMED_V2);
+            params.put("formatVersion", FramedAeadCrypto.FORMAT_VERSION);
+            params.put("fileNonce", Base64.getUrlEncoder().withoutPadding().encodeToString(fileNonce));
+            params.put("framePlainSize", state.getFramePlainSize());
+            params.put("keyDerivation", ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            params.put("nonceDerivation", ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            params.put("aadSchema", ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2);
+            params.put("tagSize", FramedAeadCrypto.TAG_SIZE);
+            // v2 的 initialKey 合同承载 file-level DEK，而不是 v1 的最后分片密钥。
+            params.put("initialKey", Base64.getEncoder().encodeToString(fileDek));
+            try {
+                return JsonConverter.toJson(params);
+            } catch (Exception e) {
+                log.error("生成 framed v2 文件参数失败: clientId={}", state.getClientId(), e);
+                throw new GeneralException(ResultEnum.JSON_PARSE_ERROR, "生成文件参数失败");
+            }
+        }
 
         // 存储初始密钥（最后一个分片的密钥）用于前端解密
         // 密钥链设计：chunk[i] 末尾包含 chunk[i+1] 的密钥，最后一个包含 chunk[0] 的密钥

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/integrity/IntegrityCheckService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/integrity/IntegrityCheckService.java
@@ -493,6 +493,9 @@ public class IntegrityCheckService {
         if (manifest.chunkCount() == null || manifest.chunkCount() != chunks.size()) {
             return manifestInvalid("chunk_count_mismatch", manifest.chunkCount(), chunks.size(), null);
         }
+        boolean framedV2 = manifest.encryption() != null
+                && Objects.equals(manifest.encryption().formatVersion(),
+                cn.flying.service.manifest.ChunkManifestEncryption.FORMAT_FRAMED_V2);
         long aggregateSize = 0;
         for (int position = 0; position < chunks.size(); position++) {
             ChunkManifestChunk chunk = chunks.get(position);
@@ -504,7 +507,13 @@ public class IntegrityCheckService {
                         chunk.plainHash(), chunk.index());
             }
             try {
-                aggregateSize = Math.addExact(aggregateSize, chunk.size());
+                if (framedV2 && (chunk.plainSize() == null || chunk.plainSize() <= 0)) {
+                    return manifestInvalid("chunk_plain_size_invalid", ">0",
+                            chunk.plainSize(), chunk.index());
+                }
+                aggregateSize = Math.addExact(
+                        aggregateSize,
+                        framedV2 ? chunk.plainSize() : chunk.size());
             } catch (ArithmeticException e) {
                 return manifestInvalid("chunk_size_overflow", "signed-long", "overflow", chunk.index());
             }
@@ -579,6 +588,7 @@ public class IntegrityCheckService {
                 manifest.merkleRoot(),
                 manifest.encryptionAlgorithm(),
                 manifest.storageBackend(),
+                manifest.encryption(),
                 manifest.chunks());
     }
 

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/key/CryptoSuitePolicyService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/key/CryptoSuitePolicyService.java
@@ -51,6 +51,16 @@ public class CryptoSuitePolicyService {
     }
 
     /**
+     * 校验文件元数据显式声明的算法套件，允许受控回滚下的 v1/v2 allowlist。
+     */
+    public void validateAlgorithmSuite(String algorithmSuite) {
+        validateSuite("algorithmSuite", algorithmSuite, properties.getSupportedAlgorithmSuites());
+        if (properties.getDeprecatedAfter() != null && !properties.getDeprecatedAfter().isAfter(Instant.now())) {
+            throw new GeneralException(ResultEnum.PARAM_ERROR, "当前密码套件已废弃");
+        }
+    }
+
+    /**
      * Rejects blank, unsupported, or explicitly deprecated suite identifiers.
      */
     private void validateSuite(String field, String value, Set<String> supportedValues) {

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/key/FileKeyEnvelopeService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/key/FileKeyEnvelopeService.java
@@ -108,7 +108,12 @@ public class FileKeyEnvelopeService {
 
         Integer keyVersion = properties.getKeyVersion();
         CryptoSuiteMetadata suiteMetadata = suitePolicy.currentMetadata(keyVersion);
-        String algorithmSuite = suiteMetadata.algorithmSuite();
+        String explicitAlgorithmSuite = resolveExplicitAlgorithmSuite(sanitized);
+        if (explicitAlgorithmSuite != null) {
+            suitePolicy.validateAlgorithmSuite(explicitAlgorithmSuite);
+        }
+        String algorithmSuite = explicitAlgorithmSuite != null
+                ? explicitAlgorithmSuite : suiteMetadata.algorithmSuite();
         sanitized.put(FIELD_KEY_ENVELOPE_STATUS, ENVELOPE_STATUS_ENVELOPED);
         sanitized.put(FIELD_ALGORITHM_SUITE, algorithmSuite);
         sanitized.put(FIELD_SIGNATURE_SUITE, suiteMetadata.signatureSuite());
@@ -920,6 +925,14 @@ public class FileKeyEnvelopeService {
             return algorithm;
         }
         return properties.getEncryptionAlgorithm();
+    }
+
+    /**
+     * 读取并规范化 file_param 中显式声明的算法套件，未知值交由策略服务拒绝。
+     */
+    private String resolveExplicitAlgorithmSuite(Map<String, Object> params) {
+        Object value = params.get(FIELD_ALGORITHM_SUITE);
+        return value instanceof String suite && StringUtils.hasText(suite) ? suite.trim() : null;
     }
 
     /**

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestCanonicalizer.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestCanonicalizer.java
@@ -16,10 +16,12 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 /**
@@ -61,12 +63,18 @@ public class ChunkManifestCanonicalizer {
             throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "chunks cannot be empty");
         }
 
-        List<ChunkManifestChunk> chunks = normalizeChunks(draft);
+        ChunkManifestEncryption encryption = normalizeEncryption(draft.encryption());
+        List<ChunkManifestChunk> chunks = normalizeChunks(draft, encryption);
+        boolean framedV2 = encryption != null
+                && encryption.formatVersion() == ChunkManifestEncryption.FORMAT_FRAMED_V2;
         long totalChunkSize = chunks.stream()
-                .mapToLong(ChunkManifestChunk::size)
+                .mapToLong(chunk -> framedV2 ? chunk.plainSize() : chunk.size())
                 .reduce(0L, Math::addExact);
         if (totalChunkSize != draft.totalSize()) {
-            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "totalSize must equal the sum of chunk sizes");
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID,
+                    framedV2
+                            ? "v2 totalSize must equal the sum of chunk plain sizes"
+                            : "totalSize must equal the sum of chunk sizes");
         }
 
         return new ChunkManifestDraft(
@@ -78,6 +86,7 @@ public class ChunkManifestCanonicalizer {
                 trimToNull(draft.merkleRoot()),
                 trimToNull(draft.encryptionAlgorithm()),
                 trimOrDefault(draft.storageBackend(), DEFAULT_STORAGE_BACKEND),
+                encryption,
                 chunks
         );
     }
@@ -108,9 +117,43 @@ public class ChunkManifestCanonicalizer {
     }
 
     /**
+     * 序列化并校验加密描述，作为数据库 encryption_metadata 的稳定副本。
+     */
+    public String encryptionJson(ChunkManifestEncryption encryption) {
+        ChunkManifestEncryption normalized = normalizeEncryption(encryption);
+        if (normalized == null) {
+            return null;
+        }
+        try {
+            return CANONICAL_OBJECT_MAPPER.writeValueAsString(toCanonicalEncryptionPayload(normalized));
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ResultEnum.JSON_PARSE_ERROR, "加密描述 JSON 序列化失败");
+        }
+    }
+
+    /**
+     * 解析数据库中的加密描述，并复用同一套 allowlist 校验。
+     */
+    public ChunkManifestEncryption parseEncryptionJson(String encryptionJson) {
+        if (!StringUtils.hasText(encryptionJson)) {
+            return null;
+        }
+        try {
+            ChunkManifestEncryption parsed = CANONICAL_OBJECT_MAPPER.readValue(
+                    encryptionJson, ChunkManifestEncryption.class);
+            return normalizeEncryption(parsed);
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "manifest 加密描述格式无效");
+        }
+    }
+
+    /**
      * Validates chunk-level fields, applies chunk defaults, and returns chunks ordered by index.
      */
-    private List<ChunkManifestChunk> normalizeChunks(ChunkManifestDraft draft) {
+    private List<ChunkManifestChunk> normalizeChunks(
+            ChunkManifestDraft draft,
+            ChunkManifestEncryption encryption
+    ) {
         List<ChunkManifestChunk> chunks = new ArrayList<>(draft.chunks().size());
         for (ChunkManifestChunk chunk : draft.chunks()) {
             if (chunk == null) {
@@ -131,6 +174,28 @@ public class ChunkManifestCanonicalizer {
             if (!StringUtils.hasText(chunk.storagePath())) {
                 throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "chunk storagePath is required");
             }
+            Long plainSize = chunk.plainSize();
+            Integer frameCount = chunk.frameCount();
+            if (plainSize != null && plainSize <= 0) {
+                throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "chunk plainSize must be positive");
+            }
+            if (frameCount != null && frameCount <= 0) {
+                throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "chunk frameCount must be positive");
+            }
+            if (encryption != null && encryption.formatVersion() == ChunkManifestEncryption.FORMAT_FRAMED_V2) {
+                if (plainSize == null || frameCount == null) {
+                    throw new GeneralException(ResultEnum.PARAM_IS_INVALID,
+                            "v2 chunk plainSize and frameCount are required");
+                }
+                long expectedFrameCount = (plainSize + encryption.framePlainSize() - 1L)
+                        / encryption.framePlainSize();
+                long expectedCipherSize = 44L + plainSize
+                        + expectedFrameCount * (12L + encryption.tagSize());
+                if (frameCount.longValue() != expectedFrameCount || chunk.size() != expectedCipherSize) {
+                    throw new GeneralException(ResultEnum.PARAM_IS_INVALID,
+                            "v2 chunk plain/cipher size or frame count is inconsistent");
+                }
+            }
             chunks.add(new ChunkManifestChunk(
                     chunk.index(),
                     chunk.plainHash().trim(),
@@ -139,7 +204,9 @@ public class ChunkManifestCanonicalizer {
                     chunk.storagePath().trim(),
                     trimOrDefault(chunk.storageBackend(), trimOrDefault(draft.storageBackend(), DEFAULT_STORAGE_BACKEND)),
                     trimToNull(chunk.etag()),
-                    trimOrDefault(chunk.checksumAlgorithm(), HASH_ALGORITHM)
+                    trimOrDefault(chunk.checksumAlgorithm(), HASH_ALGORITHM),
+                    plainSize,
+                    frameCount
             ));
         }
 
@@ -165,6 +232,8 @@ public class ChunkManifestCanonicalizer {
         payload.put("merkleRoot", draft.merkleRoot());
         payload.put("encryptionAlgorithm", draft.encryptionAlgorithm());
         payload.put("storageBackend", draft.storageBackend());
+        payload.put("encryption", draft.encryption() == null
+                ? null : toCanonicalEncryptionPayload(draft.encryption()));
         payload.put("chunks", draft.chunks().stream()
                 .map(this::toCanonicalChunkPayload)
                 .toList());
@@ -184,7 +253,94 @@ public class ChunkManifestCanonicalizer {
         payload.put("storageBackend", chunk.storageBackend());
         payload.put("etag", chunk.etag());
         payload.put("checksumAlgorithm", chunk.checksumAlgorithm());
+        payload.put("plainSize", chunk.plainSize());
+        payload.put("frameCount", chunk.frameCount());
         return payload;
+    }
+
+    /**
+     * Builds the sorted encryption descriptor map used by canonical JSON and persistence.
+     */
+    private Map<String, Object> toCanonicalEncryptionPayload(ChunkManifestEncryption encryption) {
+        Map<String, Object> payload = new TreeMap<>();
+        payload.put("formatVersion", encryption.formatVersion());
+        payload.put("algorithmSuite", encryption.algorithmSuite());
+        payload.put("fileNonce", encryption.fileNonce());
+        payload.put("framePlainSize", encryption.framePlainSize());
+        payload.put("keyDerivation", encryption.keyDerivation());
+        payload.put("nonceDerivation", encryption.nonceDerivation());
+        payload.put("aadSchema", encryption.aadSchema());
+        payload.put("tagSize", encryption.tagSize());
+        return payload;
+    }
+
+    /**
+     * 校验并规范化 encryption descriptor，拒绝未知格式、套件和危险长度。
+     */
+    private ChunkManifestEncryption normalizeEncryption(ChunkManifestEncryption encryption) {
+        if (encryption == null) {
+            return null;
+        }
+        Integer formatVersion = encryption.formatVersion();
+        if (formatVersion == null
+                || (formatVersion != ChunkManifestEncryption.FORMAT_NONE
+                && formatVersion != ChunkManifestEncryption.FORMAT_LEGACY_V1
+                && formatVersion != ChunkManifestEncryption.FORMAT_FRAMED_V2)) {
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "不支持的 manifest encryption formatVersion");
+        }
+        if (formatVersion != ChunkManifestEncryption.FORMAT_FRAMED_V2) {
+            if (encryption.algorithmSuite() != null
+                    || encryption.fileNonce() != null
+                    || encryption.framePlainSize() != null
+                    || encryption.keyDerivation() != null
+                    || encryption.nonceDerivation() != null
+                    || encryption.aadSchema() != null
+                    || encryption.tagSize() != null) {
+                throw new GeneralException(ResultEnum.PARAM_IS_INVALID,
+                        "legacy/none manifest encryption descriptor must not contain v2 fields");
+            }
+            return new ChunkManifestEncryption(formatVersion, null, null, null, null, null, null, null);
+        }
+
+        if (!ChunkManifestEncryption.SUITE_FRAMED_V2.equals(encryption.algorithmSuite())
+                || !ChunkManifestEncryption.DERIVATION_HKDF_SHA256.equals(encryption.keyDerivation())
+                || !ChunkManifestEncryption.DERIVATION_HKDF_SHA256.equals(encryption.nonceDerivation())
+                || !ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2.equals(encryption.aadSchema())
+                || !Objects.equals(encryption.tagSize(), ChunkManifestEncryption.TAG_SIZE_BYTES)) {
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "v2 manifest encryption descriptor 不在 allowlist");
+        }
+        if (encryption.framePlainSize() == null
+                || encryption.framePlainSize() < ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE
+                || encryption.framePlainSize() > ChunkManifestEncryption.MAX_FRAME_PLAIN_SIZE) {
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "v2 framePlainSize 超出有界范围");
+        }
+        if (!StringUtils.hasText(encryption.fileNonce())
+                || encryption.fileNonce().contains("=")
+                || !isExactBase64Url(encryption.fileNonce(), ChunkManifestEncryption.FILE_NONCE_SIZE_BYTES)) {
+            throw new GeneralException(ResultEnum.PARAM_IS_INVALID, "v2 fileNonce 必须是 16 字节 Base64URL");
+        }
+        return new ChunkManifestEncryption(
+                formatVersion,
+                encryption.algorithmSuite(),
+                encryption.fileNonce(),
+                encryption.framePlainSize(),
+                encryption.keyDerivation(),
+                encryption.nonceDerivation(),
+                encryption.aadSchema(),
+                encryption.tagSize());
+    }
+
+    /**
+     * 验证 Base64URL 字符串解码后长度和无填充规范化结果。
+     */
+    private boolean isExactBase64Url(String value, int expectedBytes) {
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(value);
+            return decoded.length == expectedBytes
+                    && Base64.getUrlEncoder().withoutPadding().encodeToString(decoded).equals(value);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     /**

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestChunk.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestChunk.java
@@ -11,6 +11,25 @@ public record ChunkManifestChunk(
         String storagePath,
         String storageBackend,
         String etag,
-        String checksumAlgorithm
+        String checksumAlgorithm,
+        Long plainSize,
+        Integer frameCount
 ) {
+
+    /**
+     * 保留旧分片构造调用，历史 manifest 不写入明文尺寸和 frame 数量。
+     */
+    public ChunkManifestChunk(
+            int index,
+            String plainHash,
+            String cipherHash,
+            long size,
+            String storagePath,
+            String storageBackend,
+            String etag,
+            String checksumAlgorithm
+    ) {
+        this(index, plainHash, cipherHash, size, storagePath, storageBackend,
+                etag, checksumAlgorithm, null, null);
+    }
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestDraft.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestDraft.java
@@ -14,6 +14,25 @@ public record ChunkManifestDraft(
         String merkleRoot,
         String encryptionAlgorithm,
         String storageBackend,
+        ChunkManifestEncryption encryption,
         List<ChunkManifestChunk> chunks
 ) {
+
+    /**
+     * 保留旧 manifest 构造调用，新增字段为空时维持既有 canonical hash。
+     */
+    public ChunkManifestDraft(
+            String schemaId,
+            String fileHash,
+            String hashAlgorithm,
+            long chunkSize,
+            long totalSize,
+            String merkleRoot,
+            String encryptionAlgorithm,
+            String storageBackend,
+            List<ChunkManifestChunk> chunks
+    ) {
+        this(schemaId, fileHash, hashAlgorithm, chunkSize, totalSize, merkleRoot,
+                encryptionAlgorithm, storageBackend, null, chunks);
+    }
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestEncryption.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestEncryption.java
@@ -1,0 +1,36 @@
+package cn.flying.service.manifest;
+
+/**
+ * 分片 manifest 的版本化加密描述，用于绑定 framed AEAD 的跨端解析合同。
+ *
+ * @param formatVersion 加密格式版本
+ * @param algorithmSuite 算法套件
+ * @param fileNonce 文件级随机 nonce，Base64URL 无填充
+ * @param framePlainSize 单帧明文大小
+ * @param keyDerivation 帧密钥派生算法
+ * @param nonceDerivation 帧 nonce 派生算法
+ * @param aadSchema AAD 字节合同标识
+ * @param tagSize AEAD 标签字节数
+ */
+public record ChunkManifestEncryption(
+        Integer formatVersion,
+        String algorithmSuite,
+        String fileNonce,
+        Integer framePlainSize,
+        String keyDerivation,
+        String nonceDerivation,
+        String aadSchema,
+        Integer tagSize
+) {
+
+    public static final int FORMAT_NONE = 0;
+    public static final int FORMAT_LEGACY_V1 = 1;
+    public static final int FORMAT_FRAMED_V2 = 2;
+    public static final String SUITE_FRAMED_V2 = "RP-AES256-GCM-FRAMED-V2";
+    public static final String DERIVATION_HKDF_SHA256 = "HKDF-SHA256";
+    public static final String AAD_SCHEMA_FRAMED_V2 = "cn.flying.framed-aead.aad.v2";
+    public static final int TAG_SIZE_BYTES = 16;
+    public static final int FILE_NONCE_SIZE_BYTES = 16;
+    public static final int MIN_FRAME_PLAIN_SIZE = 64 * 1024;
+    public static final int MAX_FRAME_PLAIN_SIZE = 4 * 1024 * 1024;
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestService.java
@@ -44,4 +44,12 @@ public interface ChunkManifestService {
      * @return sha256-prefixed canonical manifest hash
      */
     String calculateManifestHash(ChunkManifestDraft draft);
+
+    /**
+     * 计算不包含密钥材料的 canonical manifest JSON，供下载端独立重算哈希。
+     *
+     * @param draft manifest draft
+     * @return canonical JSON without manifestHash or initialKey
+     */
+    String calculateCanonicalJson(ChunkManifestDraft draft);
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestServiceImpl.java
@@ -164,6 +164,14 @@ public class ChunkManifestServiceImpl implements ChunkManifestService {
     }
 
     /**
+     * 返回与 manifestHash 使用同一规范化器生成的 JSON，不携带任何密钥材料。
+     */
+    @Override
+    public String calculateCanonicalJson(ChunkManifestDraft draft) {
+        return canonicalizer.canonicalJson(draft);
+    }
+
+    /**
      * Removes nulls and duplicates and enforces the database IN-clause safety limit.
      */
     private List<Long> normalizeBatchFileIds(List<Long> fileIds) {
@@ -247,6 +255,7 @@ public class ChunkManifestServiceImpl implements ChunkManifestService {
                 .setMerkleRoot(draft.merkleRoot())
                 .setEncryptionAlgorithm(draft.encryptionAlgorithm())
                 .setStorageBackend(draft.storageBackend())
+                .setEncryptionMetadata(canonicalizer.encryptionJson(draft.encryption()))
                 .setManifestJson(canonicalJson)
                 .setStatus(STATUS_ACTIVE)
                 .setDeleted(0);
@@ -268,6 +277,8 @@ public class ChunkManifestServiceImpl implements ChunkManifestService {
                     .setPlainHash(chunk.plainHash())
                     .setCipherHash(chunk.cipherHash())
                     .setSize(chunk.size())
+                    .setPlainSize(chunk.plainSize())
+                    .setFrameCount(chunk.frameCount())
                     .setStoragePath(chunk.storagePath())
                     .setStorageBackend(chunk.storageBackend())
                     .setEtag(chunk.etag())
@@ -309,6 +320,7 @@ public class ChunkManifestServiceImpl implements ChunkManifestService {
                 manifest.getMerkleRoot(),
                 manifest.getEncryptionAlgorithm(),
                 manifest.getStorageBackend(),
+                canonicalizer.parseEncryptionJson(manifest.getEncryptionMetadata()),
                 List.copyOf(chunks)
         );
     }
@@ -325,7 +337,9 @@ public class ChunkManifestServiceImpl implements ChunkManifestService {
                 item.getStoragePath(),
                 item.getStorageBackend(),
                 item.getEtag(),
-                item.getChecksumAlgorithm()
+                item.getChecksumAlgorithm(),
+                item.getPlainSize(),
+                item.getFrameCount()
         );
     }
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestView.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/ChunkManifestView.java
@@ -19,6 +19,31 @@ public record ChunkManifestView(
         String merkleRoot,
         String encryptionAlgorithm,
         String storageBackend,
+        ChunkManifestEncryption encryption,
         List<ChunkManifestChunk> chunks
 ) {
+
+    /**
+     * 保留旧 manifest view 构造调用，兼容尚未携带 encryption descriptor 的历史数据。
+     */
+    public ChunkManifestView(
+            Long manifestId,
+            Long fileId,
+            Integer fileVersion,
+            String schemaId,
+            String fileHash,
+            String manifestHash,
+            String hashAlgorithm,
+            long chunkSize,
+            Integer chunkCount,
+            long totalSize,
+            String merkleRoot,
+            String encryptionAlgorithm,
+            String storageBackend,
+            List<ChunkManifestChunk> chunks
+    ) {
+        this(manifestId, fileId, fileVersion, schemaId, fileHash, manifestHash,
+                hashAlgorithm, chunkSize, chunkCount, totalSize, merkleRoot,
+                encryptionAlgorithm, storageBackend, null, chunks);
+    }
 }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/FramedManifestFinalizationService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/manifest/FramedManifestFinalizationService.java
@@ -1,0 +1,564 @@
+package cn.flying.service.manifest;
+
+import cn.flying.api.utils.ResultUtils;
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.common.util.JsonConverter;
+import cn.flying.dao.dto.File;
+import cn.flying.dao.vo.file.FileUploadState;
+import cn.flying.platformapi.response.FileDetailVO;
+import cn.flying.service.encryption.FramedAeadCrypto;
+import cn.flying.service.encryption.FramedAeadWriter;
+import cn.flying.service.remote.FileRemoteClient;
+import cn.flying.service.support.StoredObjectReference;
+import cn.flying.service.support.StoredObjectReferenceCodec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 在普通代理存储成功后解析链上对象引用并幂等保存 framed v2 manifest。
+ */
+@Service
+@RequiredArgsConstructor
+public class FramedManifestFinalizationService {
+
+    private static final String FRAMED_ENCRYPTION_ALGORITHM = "FRAMED_AEAD_V2";
+    private static final String STORAGE_BACKEND = "S3";
+    private static final int MAX_REFERENCE_TEXT_LENGTH = 2048;
+    private static final int ENCRYPTION_RECOVERY_VERSION = 2;
+
+    private final FileRemoteClient fileRemoteClient;
+    private final ChunkManifestService chunkManifestService;
+    private final FramedAeadWriter framedAeadWriter;
+
+    /**
+     * 为已成功写入链和数据库的普通 v2 上传创建或恢复 active manifest。
+     *
+     * @param userId 上传用户
+     * @param file 已持久化的 SUCCESS 文件
+     * @param state Redis 中的稳定加密检查点
+     * @param processedFiles 已生成的 v2 对象文件
+     * @param cipherHashes 本地计算的对象密文摘要
+     * @return active manifest；非 v2 会话返回空
+     */
+    public Optional<ChunkManifestView> ensureManifest(
+            Long userId,
+            File file,
+            FileUploadState state,
+            List<java.io.File> processedFiles,
+            List<String> cipherHashes
+    ) {
+        if (!isFramedV2(state)) {
+            if (declaresFramedV2(state) || declaresFramedV2(file)) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "显式 v2 文件缺少完整上传加密检查点");
+            }
+            return Optional.empty();
+        }
+
+        // DB SUCCESS 后重试时临时目录可能已经清理；已有 active manifest 是唯一可复用的完成证据。
+        validateFramedState(state);
+        validateFileIdentity(userId, file, state);
+        validateFileParam(file, state);
+        Optional<ChunkManifestView> active = chunkManifestService.findActiveManifest(userId, file.getId());
+        if (active.isPresent()) {
+            validateActiveManifest(active.get(), file, state);
+            return active;
+        }
+
+        validateFileAndState(userId, file, state, processedFiles, cipherHashes);
+
+        List<StoredObjectReference> references = resolveChainReferences(userId, file);
+        validateReferences(file, state, references, cipherHashes);
+
+        ChunkManifestEncryption encryption = buildEncryptionDescriptor(state);
+        List<ChunkManifestChunk> chunks = buildChunks(state, processedFiles, cipherHashes, references, encryption);
+        ChunkManifestDraft draft = new ChunkManifestDraft(
+                ChunkManifestCanonicalizer.SCHEMA_ID,
+                file.getFileHash(),
+                ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                state.getChunkSize(),
+                state.getFileSize(),
+                null,
+                FRAMED_ENCRYPTION_ALGORITHM,
+                STORAGE_BACKEND,
+                encryption,
+                chunks
+        );
+
+        String expectedManifestHash = state.getManifestHash();
+        String calculatedManifestHash = chunkManifestService.calculateManifestHash(draft);
+        if (StringUtils.hasText(expectedManifestHash)
+                && !expectedManifestHash.equals(calculatedManifestHash)) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                    "v2 manifest 检查点与当前对象证据不一致");
+        }
+
+        if (active.isPresent()) {
+            if (!Objects.equals(active.get().manifestHash(), calculatedManifestHash)) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "已有 active manifest 与 v2 对象证据不一致");
+            }
+            return active;
+        }
+        return Optional.of(chunkManifestService.saveManifest(userId, file.getId(), draft));
+    }
+
+    /**
+     * 判断检查点是否完整声明 framed v2。
+     */
+    private boolean isFramedV2(FileUploadState state) {
+        return state != null
+                && Objects.equals(state.getEncryptionFormatVersion(), FramedAeadCrypto.FORMAT_VERSION)
+                && Objects.equals(state.getEncryptionAlgorithmSuite(), ChunkManifestEncryption.SUITE_FRAMED_V2);
+    }
+
+    /**
+     * 判断残缺 state 是否已经声明 v2，避免将字段缺失的显式 v2 会话误当 legacy 跳过。
+     */
+    private boolean declaresFramedV2(FileUploadState state) {
+        return state != null
+                && (Objects.equals(state.getEncryptionFormatVersion(), FramedAeadCrypto.FORMAT_VERSION)
+                || Objects.equals(state.getEncryptionAlgorithmSuite(), ChunkManifestEncryption.SUITE_FRAMED_V2));
+    }
+
+    /**
+     * 从已持久化 fileParam 识别显式 v2；解析失败且包含 v2 标识时同样失败关闭。
+     */
+    private boolean declaresFramedV2(File file) {
+        if (file == null || !StringUtils.hasText(file.getFileParam())) {
+            return false;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> params = JsonConverter.parse(file.getFileParam(), Map.class);
+            return params != null
+                    && (FRAMED_ENCRYPTION_ALGORITHM.equalsIgnoreCase(
+                    Objects.toString(params.get("encryptionAlgorithm"), ""))
+                    || numericEquals(params.get("formatVersion"), FramedAeadCrypto.FORMAT_VERSION)
+                    || Objects.equals(params.get("algorithmSuite"), ChunkManifestEncryption.SUITE_FRAMED_V2));
+        } catch (RuntimeException parseError) {
+            if (file.getFileParam().toUpperCase(Locale.ROOT).contains(FRAMED_ENCRYPTION_ALGORITHM)) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "显式 v2 fileParam 格式无效");
+            }
+            return false;
+        }
+    }
+
+    /**
+     * 校验 Redis 中所有 v2 不可变字段，统一转换为结构化业务异常而不是空指针。
+     */
+    private void validateFramedState(FileUploadState state) {
+        if (state == null
+                || !Objects.equals(state.getEncryptionRecoveryVersion(), ENCRYPTION_RECOVERY_VERSION)
+                || !Objects.equals(state.getEncryptionFormatVersion(), FramedAeadCrypto.FORMAT_VERSION)
+                || !Objects.equals(state.getEncryptionAlgorithmSuite(), ChunkManifestEncryption.SUITE_FRAMED_V2)
+                || state.getFileDataKey() == null
+                || state.getFileDataKey().length != FramedAeadCrypto.FILE_DEK_SIZE
+                || state.getFileNonce() == null
+                || state.getFileNonce().length != FramedAeadCrypto.FILE_NONCE_SIZE
+                || state.getFramePlainSize() == null
+                || state.getFramePlainSize() < ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE
+                || state.getFramePlainSize() > ChunkManifestEncryption.MAX_FRAME_PLAIN_SIZE
+                || !Objects.equals(state.getKeyDerivation(), ChunkManifestEncryption.DERIVATION_HKDF_SHA256)
+                || !Objects.equals(state.getNonceDerivation(), ChunkManifestEncryption.DERIVATION_HKDF_SHA256)
+                || !Objects.equals(state.getAadSchema(), ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2)
+                || !Objects.equals(state.getTagSize(), FramedAeadCrypto.TAG_SIZE)
+                || state.getFileSize() <= 0
+                || state.getChunkSize() <= 0
+                || state.getTotalChunks() <= 0) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 上传加密检查点不完整");
+        }
+        long expectedChunks = (state.getFileSize() + state.getChunkSize() - 1L) / state.getChunkSize();
+        if (expectedChunks != state.getTotalChunks()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 上传分片计划与文件大小不一致");
+        }
+        if (StringUtils.hasText(state.getManifestHash())
+                && !state.getManifestHash().matches("sha256:[0-9a-f]{64}")) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest hash 检查点格式无效");
+        }
+    }
+
+    /**
+     * 校验文件、会话身份和输入数量，避免将其他会话对象写入 manifest。
+     */
+    private void validateFileAndState(
+            Long userId,
+            File file,
+            FileUploadState state,
+            List<java.io.File> processedFiles,
+            List<String> cipherHashes
+    ) {
+        validateFileIdentity(userId, file, state);
+        if (state.getTotalChunks() <= 0
+                || processedFiles == null
+                || processedFiles.size() != state.getTotalChunks()
+                || cipherHashes == null
+                || cipherHashes.size() != state.getTotalChunks()
+                || !Objects.equals(file.getFileSize(), state.getFileSize())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest 输入证据不完整");
+        }
+    }
+
+    /**
+     * 校验文件与上传检查点的稳定身份字段。
+     */
+    private void validateFileIdentity(Long userId, File file, FileUploadState state) {
+        if (userId == null || file == null || file.getId() == null
+                || state == null
+                || !StringUtils.hasText(file.getFileHash())
+                || file.getTenantId() == null
+                || state.getTenantId() == null
+                || state.getUserId() == null
+                || state.getPreparedFileId() == null
+                || !Objects.equals(file.getFileSize(), state.getFileSize())
+                || !Objects.equals(file.getTenantId(), state.getTenantId())
+                || !Objects.equals(state.getUserId(), userId)
+                || !Objects.equals(state.getPreparedFileId(), file.getId())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 manifest 文件身份证据不完整");
+        }
+        if (file.getUid() != null && !Objects.equals(file.getUid(), userId)) {
+            throw new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED, "v2 manifest 用户不匹配");
+        }
+    }
+
+    /**
+     * 校验持久化 fileParam 与稳定 v2 state 的格式、nonce、派生和分片计划完全一致。
+     */
+    private void validateFileParam(File file, FileUploadState state) {
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> params = JsonConverter.parse(file.getFileParam(), Map.class);
+            String expectedNonce = Base64.getUrlEncoder().withoutPadding().encodeToString(state.getFileNonce());
+            if (params == null
+                    || !FRAMED_ENCRYPTION_ALGORITHM.equalsIgnoreCase(
+                    Objects.toString(params.get("encryptionAlgorithm"), ""))
+                    || !Objects.equals(params.get("algorithmSuite"), state.getEncryptionAlgorithmSuite())
+                    || !Objects.equals(params.get("fileNonce"), expectedNonce)
+                    || !Objects.equals(params.get("keyDerivation"), state.getKeyDerivation())
+                    || !Objects.equals(params.get("nonceDerivation"), state.getNonceDerivation())
+                    || !Objects.equals(params.get("aadSchema"), state.getAadSchema())
+                    || !numericEquals(params.get("formatVersion"), state.getEncryptionFormatVersion())
+                    || !numericEquals(params.get("framePlainSize"), state.getFramePlainSize())
+                    || !numericEquals(params.get("tagSize"), state.getTagSize())
+                    || !numericEquals(params.get("fileSize"), state.getFileSize())
+                    || !numericEquals(params.get("chunkSize"), state.getChunkSize())
+                    || !numericEquals(params.get("chunkCount"), state.getTotalChunks())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "v2 fileParam 与上传检查点不一致");
+            }
+        } catch (GeneralException e) {
+            throw e;
+        } catch (RuntimeException parseError) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 fileParam 格式无效");
+        }
+    }
+
+    /**
+     * 验证已存在 active manifest 的 descriptor、明文总量和 canonical hash 后再作为恢复证据复用。
+     */
+    private void validateActiveManifest(
+            ChunkManifestView manifest,
+            File file,
+            FileUploadState state
+    ) {
+        ChunkManifestEncryption expectedEncryption = buildEncryptionDescriptor(state);
+        if (manifest == null
+                || !Objects.equals(manifest.fileId(), file.getId())
+                || !Objects.equals(manifest.fileVersion(), file.getVersion())
+                || !Objects.equals(manifest.fileHash(), file.getFileHash())
+                || !ChunkManifestCanonicalizer.SCHEMA_ID.equals(manifest.schemaId())
+                || !ChunkManifestCanonicalizer.HASH_ALGORITHM.equals(manifest.hashAlgorithm())
+                || manifest.chunkSize() != state.getChunkSize()
+                || !Objects.equals(manifest.chunkCount(), state.getTotalChunks())
+                || manifest.totalSize() != state.getFileSize()
+                || !FRAMED_ENCRYPTION_ALGORITHM.equalsIgnoreCase(manifest.encryptionAlgorithm())
+                || !STORAGE_BACKEND.equalsIgnoreCase(manifest.storageBackend())
+                || !Objects.equals(manifest.encryption(), expectedEncryption)
+                || manifest.chunks() == null
+                || manifest.chunks().size() != state.getTotalChunks()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                    "已有 active manifest 与 v2 上传检查点不一致");
+        }
+
+        long aggregatePlainSize = 0L;
+        Set<String> storagePaths = new HashSet<>();
+        for (int index = 0; index < manifest.chunks().size(); index++) {
+            ChunkManifestChunk chunk = manifest.chunks().get(index);
+            if (chunk == null) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "已有 active v2 manifest 分片证据无效: " + index);
+            }
+            long expectedPlainSize = expectedPlainChunkSize(state, index);
+            long expectedFrameCount = (expectedPlainSize + state.getFramePlainSize() - 1L)
+                    / state.getFramePlainSize();
+            long expectedCipherSize;
+            try {
+                expectedCipherSize = Math.addExact(
+                        Math.addExact(FramedAeadCrypto.CHUNK_HEADER_SIZE, expectedPlainSize),
+                        Math.multiplyExact(expectedFrameCount,
+                                FramedAeadCrypto.FRAME_HEADER_SIZE + (long) FramedAeadCrypto.TAG_SIZE));
+                aggregatePlainSize = Math.addExact(aggregatePlainSize, expectedPlainSize);
+            } catch (ArithmeticException overflow) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "active v2 manifest 分片大小溢出");
+            }
+            if (chunk.index() != index
+                    || !Objects.equals(chunk.plainSize(), expectedPlainSize)
+                    || !Objects.equals(chunk.frameCount(), Math.toIntExact(expectedFrameCount))
+                    || chunk.size() != expectedCipherSize
+                    || !isCanonicalSha256(chunk.plainHash())
+                    || !isCanonicalSha256(chunk.cipherHash())
+                    || !ChunkManifestCanonicalizer.HASH_ALGORITHM.equals(chunk.checksumAlgorithm())
+                    || !STORAGE_BACKEND.equalsIgnoreCase(chunk.storageBackend())
+                    || !StringUtils.hasText(chunk.storagePath())
+                    || !storagePaths.add(chunk.storagePath())
+                    || !isTenantStoragePath(file.getTenantId(), chunk.storagePath(), chunk.cipherHash())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "已有 active v2 manifest 分片证据无效: " + index);
+            }
+        }
+        if (aggregatePlainSize != state.getFileSize()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "active v2 manifest 明文总量不一致");
+        }
+
+        ChunkManifestDraft draft = new ChunkManifestDraft(
+                manifest.schemaId(),
+                manifest.fileHash(),
+                manifest.hashAlgorithm(),
+                manifest.chunkSize(),
+                manifest.totalSize(),
+                manifest.merkleRoot(),
+                manifest.encryptionAlgorithm(),
+                manifest.storageBackend(),
+                manifest.encryption(),
+                manifest.chunks());
+        String calculatedHash = chunkManifestService.calculateManifestHash(draft);
+        if (!Objects.equals(manifest.manifestHash(), calculatedHash)
+                || (StringUtils.hasText(state.getManifestHash())
+                && !Objects.equals(state.getManifestHash(), manifest.manifestHash()))) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "active v2 manifest canonical hash 不一致");
+        }
+    }
+
+    /**
+     * 从已确认的链记录读取对象引用，不接受客户端或本地路径作为权威来源。
+     */
+    private List<StoredObjectReference> resolveChainReferences(Long userId, File file) {
+        FileDetailVO detail = ResultUtils.getData(
+                fileRemoteClient.getFile(String.valueOf(userId), file.getFileHash()));
+        if (detail == null || !StringUtils.hasText(detail.content())) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上存储引用缺失");
+        }
+        try {
+            return StoredObjectReferenceCodec.parseChainContent(detail.content());
+        } catch (RuntimeException parseError) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上存储引用格式无效");
+        }
+    }
+
+    /**
+     * 校验链引用的连续索引、数量、密文摘要和租户绑定路径。
+     */
+    private void validateReferences(
+            File file,
+            FileUploadState state,
+            List<StoredObjectReference> references,
+            List<String> cipherHashes
+    ) {
+        if (references == null || references.size() != state.getTotalChunks()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上存储引用数量不一致");
+        }
+        Long tenantId = file.getTenantId();
+        String expectedPrefix = tenantId == null ? null : "storage/tenant/" + tenantId + "/chunk/";
+        Set<String> paths = new HashSet<>();
+        for (int index = 0; index < references.size(); index++) {
+            StoredObjectReference reference = references.get(index);
+            if (reference == null
+                    || reference.index() != index
+                    || !StringUtils.hasText(reference.cipherHash())
+                    || !StringUtils.hasText(reference.storagePath())
+                    || reference.cipherHash().length() > MAX_REFERENCE_TEXT_LENGTH
+                    || reference.storagePath().length() > MAX_REFERENCE_TEXT_LENGTH
+                    || containsUnsafePathText(reference.storagePath())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上存储引用索引或路径无效");
+            }
+            String expectedHash = normalizeDigest(cipherHashes.get(index));
+            String actualHash = normalizeDigest(reference.cipherHash());
+            if (!Objects.equals(expectedHash, actualHash)) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上密文摘要与本地证据不一致");
+            }
+            if (expectedPrefix != null && !reference.storagePath().startsWith(expectedPrefix)) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上 storagePath 租户不匹配");
+            }
+            String pathSuffix = reference.storagePath().substring(
+                    reference.storagePath().lastIndexOf('/') + 1);
+            if (!Objects.equals(normalizeDigest(pathSuffix), actualHash)
+                    || !paths.add(reference.storagePath())) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "链上 storagePath 与密文摘要不匹配");
+            }
+        }
+    }
+
+    /**
+     * 逐个重新认证对象文件并构造 manifest chunk，避免只相信文件名或 Redis 数量。
+     */
+    private List<ChunkManifestChunk> buildChunks(
+            FileUploadState state,
+            List<java.io.File> processedFiles,
+            List<String> cipherHashes,
+            List<StoredObjectReference> references,
+            ChunkManifestEncryption encryption
+    ) {
+        List<ChunkManifestChunk> chunks = new ArrayList<>(processedFiles.size());
+        long aggregatePlainSize = 0L;
+        for (int index = 0; index < processedFiles.size(); index++) {
+            java.io.File processedFile = processedFiles.get(index);
+            if (processedFile == null) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 processed 文件为空");
+            }
+            try {
+                FramedAeadWriter.WriteResult result = framedAeadWriter.verify(
+                        processedFile.toPath(),
+                        state.getFileDataKey(),
+                        state.getFileNonce(),
+                        index,
+                        state.getTotalChunks(),
+                        state.getFramePlainSize());
+                String expectedCipherHash = normalizeDigest(cipherHashes.get(index));
+                if (!Objects.equals(expectedCipherHash, normalizeDigest(result.cipherHash()))) {
+                    throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 对象密文摘要不一致");
+                }
+                long expectedPlainSize = expectedPlainChunkSize(state, index);
+                if (result.plainSize() != expectedPlainSize) {
+                    throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 对象明文大小不一致");
+                }
+                aggregatePlainSize = Math.addExact(aggregatePlainSize, result.plainSize());
+                chunks.add(new ChunkManifestChunk(
+                        index,
+                        result.plainHash(),
+                        result.cipherHash(),
+                        result.cipherSize(),
+                        references.get(index).storagePath(),
+                        STORAGE_BACKEND,
+                        null,
+                        ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                        result.plainSize(),
+                        result.frameCount()
+                ));
+            } catch (IOException | ArithmeticException | IllegalArgumentException verificationError) {
+                throw new GeneralException(ResultEnum.FILE_RECORD_ERROR,
+                        "v2 对象认证或长度校验失败: " + index);
+            }
+        }
+        if (aggregatePlainSize != state.getFileSize()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 对象明文总量与文件大小不一致");
+        }
+        return List.copyOf(chunks);
+    }
+
+    /**
+     * 从稳定 Redis 检查点构造并验证 v2 manifest encryption descriptor。
+     */
+    private ChunkManifestEncryption buildEncryptionDescriptor(FileUploadState state) {
+        String fileNonce = Base64.getUrlEncoder().withoutPadding().encodeToString(state.getFileNonce());
+        return new ChunkManifestEncryption(
+                FramedAeadCrypto.FORMAT_VERSION,
+                state.getEncryptionAlgorithmSuite(),
+                fileNonce,
+                state.getFramePlainSize(),
+                state.getKeyDerivation(),
+                state.getNonceDerivation(),
+                state.getAadSchema(),
+                state.getTagSize()
+        );
+    }
+
+    /**
+     * 计算上传计划中指定分片的精确明文长度。
+     */
+    private long expectedPlainChunkSize(FileUploadState state, int index) {
+        if (index < 0 || index >= state.getTotalChunks()) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "v2 分片索引超出上传计划");
+        }
+        return index == state.getTotalChunks() - 1
+                ? state.getFileSize() - ((long) state.getChunkSize() * index)
+                : state.getChunkSize();
+    }
+
+    /**
+     * 校验 active manifest 路径同时绑定租户前缀和规范密文摘要。
+     */
+    private boolean isTenantStoragePath(Long tenantId, String storagePath, String cipherHash) {
+        if (tenantId == null || !StringUtils.hasText(storagePath) || containsUnsafePathText(storagePath)) {
+            return false;
+        }
+        String expectedPrefix = "storage/tenant/" + tenantId + "/chunk/";
+        String pathSuffix = storagePath.substring(storagePath.lastIndexOf('/') + 1);
+        return storagePath.startsWith(expectedPrefix)
+                && Objects.equals(normalizeDigest(pathSuffix), normalizeDigest(cipherHash));
+    }
+
+    /**
+     * 判断摘要是否为 manifest 使用的规范 sha256 小写十六进制格式。
+     */
+    private boolean isCanonicalSha256(String value) {
+        return value != null && value.matches("sha256:[0-9a-f]{64}");
+    }
+
+    /**
+     * 以 long 语义比较 JSON 数值和预期整数。
+     */
+    private boolean numericEquals(Object actual, Number expected) {
+        return actual instanceof Number actualNumber
+                && expected != null
+                && actualNumber.longValue() == expected.longValue();
+    }
+
+    /**
+     * 将摘要统一为 sha256: 小写十六进制，兼容链上历史 Base64URL 表示。
+     */
+    private String normalizeDigest(String value) {
+        if (!StringUtils.hasText(value) || value.length() > MAX_REFERENCE_TEXT_LENGTH) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "密文摘要格式无效");
+        }
+        String trimmed = value.trim();
+        String hex = trimmed.toLowerCase(Locale.ROOT);
+        if (hex.startsWith("sha256:")) {
+            hex = hex.substring("sha256:".length());
+        }
+        if (hex.matches("[0-9a-f]{64}")) {
+            return "sha256:" + hex;
+        }
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(trimmed);
+            if (decoded.length != 32) {
+                throw new IllegalArgumentException("digest length");
+            }
+            return "sha256:" + java.util.HexFormat.of().formatHex(decoded);
+        } catch (IllegalArgumentException decodeError) {
+            throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "密文摘要格式无效");
+        }
+    }
+
+    /**
+     * 拒绝控制字符、绝对路径和路径穿越片段。
+     */
+    private boolean containsUnsafePathText(String value) {
+        return value.startsWith("/")
+                || value.contains("..")
+                || value.chars().anyMatch(Character::isISOControl)
+                || value.contains("\\");
+    }
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/proof/signed/SignedProofArchiveServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/proof/signed/SignedProofArchiveServiceImpl.java
@@ -708,6 +708,7 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
                 manifest.merkleRoot(),
                 manifest.encryptionAlgorithm(),
                 manifest.storageBackend(),
+                manifest.encryption(),
                 manifest.chunks());
         String calculated = chunkManifestService.calculateManifestHash(draft);
         if (!manifest.manifestHash().equals(calculated)) {
@@ -729,15 +730,22 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
                 || !hasBoundedText(manifest.storageBackend(), 128)) {
             throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "chunk manifest 算法或顶层字段不合法");
         }
+        boolean framedV2 = manifest.encryption() != null
+                && Objects.equals(manifest.encryption().formatVersion(),
+                cn.flying.service.manifest.ChunkManifestEncryption.FORMAT_FRAMED_V2);
         long aggregateSize = 0L;
         for (int position = 0; position < manifest.chunks().size(); position++) {
             ChunkManifestChunk chunk = manifest.chunks().get(position);
             boolean finalChunk = position == manifest.chunks().size() - 1;
+            Long logicalChunkSize = framedV2 && chunk != null ? chunk.plainSize() : null;
             if (chunk == null
                     || chunk.index() != position
                     || chunk.size() <= 0
-                    || chunk.size() > manifest.chunkSize()
-                    || (!finalChunk && chunk.size() != manifest.chunkSize())
+                    || (framedV2 && (logicalChunkSize == null || logicalChunkSize <= 0))
+                    || (!framedV2 && chunk.size() > manifest.chunkSize())
+                    || (!framedV2 && !finalChunk && chunk.size() != manifest.chunkSize())
+                    || (framedV2 && logicalChunkSize > manifest.chunkSize())
+                    || (framedV2 && !finalChunk && logicalChunkSize != manifest.chunkSize())
                     || !hasBoundedText(chunk.storagePath(), 2048)
                     || chunk.storagePath().chars().anyMatch(Character::isISOControl)
                     || !ProofHashes.HASH_ALGORITHM.equals(chunk.checksumAlgorithm())) {
@@ -746,7 +754,9 @@ public class SignedProofArchiveServiceImpl implements SignedProofArchiveService 
             requireCanonicalSha256(chunk.plainHash(), "分片 plainHash 不合法");
             requireCanonicalSha256(chunk.cipherHash(), "分片 cipherHash 不合法");
             try {
-                aggregateSize = Math.addExact(aggregateSize, chunk.size());
+                aggregateSize = Math.addExact(
+                        aggregateSize,
+                        framedV2 ? logicalChunkSize : chunk.size());
             } catch (ArithmeticException e) {
                 throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "chunk manifest 分片大小溢出");
             }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/encryption/FramedAeadCryptoTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/encryption/FramedAeadCryptoTest.java
@@ -1,0 +1,115 @@
+package cn.flying.service.encryption;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 验证 framed AEAD 的跨语言密码学、字节序和固定 wire 合同。
+ */
+@DisplayName("FramedAeadCrypto")
+class FramedAeadCryptoTest {
+
+    private static final HexFormat HEX = HexFormat.of();
+
+    /**
+     * 验证 RFC 5869 的 HKDF-SHA-256 官方测试向量，锁定 Extract/Expand 字节语义。
+     */
+    @Test
+    void hkdfSha256_shouldMatchRfc5869TestVector() {
+        byte[] ikm = HEX.parseHex("0b".repeat(22));
+        byte[] salt = HEX.parseHex("000102030405060708090a0b0c");
+        byte[] info = HEX.parseHex("f0f1f2f3f4f5f6f7f8f9");
+
+        byte[] prk = FramedAeadCrypto.hkdfExtract(salt, ikm);
+        byte[] okm = FramedAeadCrypto.hkdfExpand(prk, info, 42);
+
+        assertThat(HEX.formatHex(prk))
+                .isEqualTo("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+        assertThat(HEX.formatHex(okm)).isEqualTo(
+                "3cb25f25faacd57a90434f64d0362f2a"
+                        + "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+                        + "34007208d5b887185865");
+    }
+
+    /**
+     * 验证 Java 与 TypeScript 共享的固定 key、nonce、AAD、header 和 frame header 向量。
+     */
+    @Test
+    void fixedVector_shouldMatchJavaAndTypeScriptByteContract() {
+        byte[] fileDek = HEX.parseHex(
+                "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf");
+        byte[] fileNonce = HEX.parseHex("0102030405060708090a0b0c0d0e0f10");
+        byte[] key = FramedAeadCrypto.deriveFrameKey(fileDek, fileNonce, 0, 0);
+        byte[] nonce = FramedAeadCrypto.deriveFrameNonce(fileDek, fileNonce, 0, 0);
+        byte[] plaintext = "RecordPlatform framed AEAD vector".getBytes(StandardCharsets.UTF_8);
+
+        byte[] aad = FramedAeadCrypto.buildAad(
+                fileNonce, 0, 1, 0, 1, plaintext.length, plaintext.length);
+        byte[] chunkHeader = FramedAeadCrypto.buildChunkHeader(
+                0, 1, 64 * 1024, 1, plaintext.length, fileNonce);
+        byte[] frameHeader = FramedAeadCrypto.buildFrameHeader(
+                0, plaintext.length, plaintext.length + FramedAeadCrypto.TAG_SIZE);
+
+        assertThat(HEX.formatHex(key))
+                .isEqualTo("15253164a5acfe1831702aa2747b7eb097187da0637b434d581894fb96bc43db");
+        assertThat(HEX.formatHex(nonce)).isEqualTo("a63a60144f5db28ef6545e19");
+        assertThat(HEX.formatHex(aad)).isEqualTo(
+                "636e2e666c79696e672e6672616d65642d616561642e6161642e7632"
+                        + "0201"
+                        + "0102030405060708090a0b0c0d0e0f10"
+                        + "000000000000000100000000000000010000002100000021");
+        assertThat(HEX.formatHex(chunkHeader)).isEqualTo(
+                "52504632020100000000000000000001000100000000000100000021"
+                        + "0102030405060708090a0b0c0d0e0f10");
+        assertThat(HEX.formatHex(frameHeader)).isEqualTo("000000000000002100000031");
+
+        FramedAeadCrypto.ChunkHeader parsedChunk = FramedAeadCrypto.parseChunkHeader(chunkHeader);
+        FramedAeadCrypto.FrameHeader parsedFrame = FramedAeadCrypto.parseFrameHeader(frameHeader);
+        assertThat(parsedChunk.chunkIndex()).isZero();
+        assertThat(parsedChunk.chunkCount()).isEqualTo(1);
+        assertThat(parsedChunk.framePlainSize()).isEqualTo(64 * 1024);
+        assertThat(parsedChunk.frameCount()).isEqualTo(1);
+        assertThat(parsedChunk.chunkPlainSize()).isEqualTo(plaintext.length);
+        assertThat(parsedFrame.frameIndex()).isZero();
+        assertThat(parsedFrame.plainLength()).isEqualTo(plaintext.length);
+        assertThat(parsedFrame.cipherLength()).isEqualTo(plaintext.length + 16);
+    }
+
+    /**
+     * 验证 header/parser 拒绝错误 magic、保留位和 frame 长度，避免大小端或边界漂移。
+     */
+    @Test
+    void parsers_shouldRejectTamperedWireHeaders() {
+        byte[] nonce = new byte[FramedAeadCrypto.FILE_NONCE_SIZE];
+        byte[] chunkHeader = FramedAeadCrypto.buildChunkHeader(0, 1, 64 * 1024, 1, 1, nonce);
+        chunkHeader[0] = 'X';
+        assertThatThrownBy(() -> FramedAeadCrypto.parseChunkHeader(chunkHeader))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        byte[] validHeader = FramedAeadCrypto.buildChunkHeader(0, 1, 64 * 1024, 1, 1, nonce);
+        validHeader[7] = 1;
+        assertThatThrownBy(() -> FramedAeadCrypto.parseChunkHeader(validHeader))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        byte[] invalidFrame = new byte[FramedAeadCrypto.FRAME_HEADER_SIZE];
+        invalidFrame[7] = 1;
+        assertThatThrownBy(() -> FramedAeadCrypto.parseFrameHeader(invalidFrame))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /**
+     * 验证固定时间比较同时拒绝长度不一致，避免截断值被误判为相等。
+     */
+    @Test
+    void constantTimeEquals_shouldRequireEqualLengthAndContent() {
+        assertThat(FramedAeadCrypto.constantTimeEquals(new byte[]{1, 2}, new byte[]{1, 2})).isTrue();
+        assertThat(FramedAeadCrypto.constantTimeEquals(new byte[]{1, 2}, new byte[]{1, 3})).isFalse();
+        assertThat(FramedAeadCrypto.constantTimeEquals(new byte[]{1, 2}, new byte[]{1})).isFalse();
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/encryption/FramedAeadWriterTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/encryption/FramedAeadWriterTest.java
@@ -1,0 +1,179 @@
+package cn.flying.service.encryption;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HexFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * 验证 framed AEAD writer 的固定向量、frame 公式和失败关闭语义。
+ */
+@DisplayName("FramedAeadWriter")
+class FramedAeadWriterTest {
+
+    private static final HexFormat HEX = HexFormat.of();
+    private static final int FRAME_SIZE = 64 * 1024;
+    private static final byte[] FILE_DEK = HEX.parseHex(
+            "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf");
+    private static final byte[] FILE_NONCE = HEX.parseHex("0102030405060708090a0b0c0d0e0f10");
+    private static final byte[] FIXED_PLAINTEXT = HEX.parseHex(
+            "5265636f7264506c6174666f726d206672616d6564204145414420766563746f72");
+    private static final String FIXED_ENCODED_HEX =
+            "52504632020100000000000000000001000100000000000100000021"
+                    + "0102030405060708090a0b0c0d0e0f10"
+                    + "000000000000002100000031"
+                    + "c98154d047fe1419102926ece729c8fa20d8e7ef26d91b2c5d8aa9091aed0c4524"
+                    + "8afe4ca36333045745d0e05b20259122";
+
+    private final FramedAeadWriter writer = new FramedAeadWriter();
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * 验证 Java writer 产生与 TypeScript/WebCrypto 相同的完整固定对象和摘要。
+     */
+    @Test
+    void write_shouldMatchJavaAndTypeScriptFixedVector() throws IOException {
+        Path plaintext = writeFile("fixed-plain.bin", FIXED_PLAINTEXT);
+        Path encrypted = tempDir.resolve("fixed-framed.bin");
+
+        FramedAeadWriter.WriteResult written = writer.write(
+                plaintext, encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE);
+        FramedAeadWriter.WriteResult verified = writer.verify(
+                encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE);
+
+        assertThat(HEX.formatHex(Files.readAllBytes(encrypted))).isEqualTo(FIXED_ENCODED_HEX);
+        assertThat(written.plainSize()).isEqualTo(33L);
+        assertThat(written.cipherSize()).isEqualTo(105L);
+        assertThat(written.frameCount()).isEqualTo(1);
+        assertThat(written.plainHash())
+                .isEqualTo("sha256:f4d4fdd1095424253ffe035d5678961df7b9e12da2b40511811841127c2659a4");
+        assertThat(written.cipherHash())
+                .isEqualTo("sha256:4a6ba4e73d425291fe80258fb057df70a88837a9783f466080d7bebea4c4b131");
+        assertThat(verified).isEqualTo(written);
+    }
+
+    /**
+     * 验证 frameCount 向上取整公式、最后短帧和对象密文字节公式保持一致。
+     */
+    @Test
+    void write_shouldUseCeilingFrameCountAndExactCipherSizeFormula() throws IOException {
+        byte[] plaintextBytes = new byte[FRAME_SIZE * 2 + 1];
+        for (int index = 0; index < plaintextBytes.length; index++) {
+            plaintextBytes[index] = (byte) (index % 251);
+        }
+        Path plaintext = writeFile("multi-plain.bin", plaintextBytes);
+        Path encrypted = tempDir.resolve("multi-framed.bin");
+
+        FramedAeadWriter.WriteResult written = writer.write(
+                plaintext, encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE);
+
+        long expectedCipherSize = FramedAeadCrypto.CHUNK_HEADER_SIZE
+                + plaintextBytes.length
+                + 3L * (FramedAeadCrypto.FRAME_HEADER_SIZE + FramedAeadCrypto.TAG_SIZE);
+        assertThat(written.frameCount()).isEqualTo(3);
+        assertThat(written.cipherSize()).isEqualTo(expectedCipherSize);
+        assertThat(Files.size(encrypted)).isEqualTo(expectedCipherSize);
+        assertThat(writer.verify(encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE))
+                .isEqualTo(written);
+    }
+
+    /**
+     * 验证 tag 篡改、错误 key 和 AAD 坐标变化全部认证失败，且异常不泄露 key/nonce。
+     */
+    @Test
+    void verify_shouldRejectTagTamperWrongKeyAndWrongAadWithoutSecretLeak() throws IOException {
+        Path encrypted = createFramedFile("authentication", FIXED_PLAINTEXT);
+        byte[] encoded = Files.readAllBytes(encrypted);
+
+        byte[] tagTampered = encoded.clone();
+        tagTampered[tagTampered.length - 1] ^= 0x01;
+        IOException tagFailure = verifyFailure(
+                writeFile("tag-tampered.bin", tagTampered), FILE_DEK, FILE_NONCE, 0, 1);
+
+        byte[] wrongKey = FILE_DEK.clone();
+        wrongKey[0] ^= 0x01;
+        IOException keyFailure = verifyFailure(encrypted, wrongKey, FILE_NONCE, 0, 1);
+
+        byte[] wrongAad = encoded.clone();
+        wrongAad[15] = 2;
+        IOException aadFailure = verifyFailure(
+                writeFile("wrong-aad.bin", wrongAad), FILE_DEK, FILE_NONCE, 0, 2);
+
+        String dekHex = HEX.formatHex(FILE_DEK);
+        String nonceHex = HEX.formatHex(FILE_NONCE);
+        assertThat(tagFailure.getMessage()).doesNotContain(dekHex, nonceHex);
+        assertThat(keyFailure.getMessage()).doesNotContain(dekHex, nonceHex);
+        assertThat(aadFailure.getMessage()).doesNotContain(dekHex, nonceHex);
+    }
+
+    /**
+     * 验证截断、EOF 后追加和 frame 重排均在验证阶段失败关闭。
+     */
+    @Test
+    void verify_shouldRejectTruncatedTrailingAndReorderedObjects() throws IOException {
+        byte[] twoFrames = new byte[FRAME_SIZE * 2];
+        for (int index = 0; index < twoFrames.length; index++) {
+            twoFrames[index] = (byte) (index % 239);
+        }
+        Path encrypted = createFramedFile("wire-errors", twoFrames);
+        byte[] encoded = Files.readAllBytes(encrypted);
+
+        byte[] truncated = Arrays.copyOf(encoded, encoded.length - 1);
+        verifyFailure(writeFile("truncated.bin", truncated), FILE_DEK, FILE_NONCE, 0, 1);
+
+        byte[] trailing = Arrays.copyOf(encoded, encoded.length + 1);
+        trailing[trailing.length - 1] = 0x7f;
+        verifyFailure(writeFile("trailing.bin", trailing), FILE_DEK, FILE_NONCE, 0, 1);
+
+        int recordSize = FramedAeadCrypto.FRAME_HEADER_SIZE + FRAME_SIZE + FramedAeadCrypto.TAG_SIZE;
+        byte[] reordered = encoded.clone();
+        System.arraycopy(encoded, FramedAeadCrypto.CHUNK_HEADER_SIZE + recordSize,
+                reordered, FramedAeadCrypto.CHUNK_HEADER_SIZE, recordSize);
+        System.arraycopy(encoded, FramedAeadCrypto.CHUNK_HEADER_SIZE,
+                reordered, FramedAeadCrypto.CHUNK_HEADER_SIZE + recordSize, recordSize);
+        verifyFailure(writeFile("reordered.bin", reordered), FILE_DEK, FILE_NONCE, 0, 1);
+    }
+
+    /**
+     * 写入测试文件并返回路径。
+     */
+    private Path writeFile(String name, byte[] content) throws IOException {
+        Path path = tempDir.resolve(name);
+        Files.write(path, content);
+        return path;
+    }
+
+    /**
+     * 使用固定协议参数生成一个 framed 对象。
+     */
+    private Path createFramedFile(String name, byte[] plaintext) throws IOException {
+        Path plainPath = writeFile(name + "-plain.bin", plaintext);
+        Path encryptedPath = tempDir.resolve(name + "-framed.bin");
+        writer.write(plainPath, encryptedPath, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE);
+        return encryptedPath;
+    }
+
+    /**
+     * 执行验证并返回预期的 IOException，供多个失败关闭场景复用。
+     */
+    private IOException verifyFailure(
+            Path encrypted,
+            byte[] fileDek,
+            byte[] fileNonce,
+            int chunkIndex,
+            int chunkCount
+    ) {
+        return assertThrows(IOException.class, () -> writer.verify(
+                encrypted, fileDek, fileNonce, chunkIndex, chunkCount, FRAME_SIZE));
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/encryption/FramedAeadWriterTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/encryption/FramedAeadWriterTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HexFormat;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,6 +143,81 @@ class FramedAeadWriterTest {
         System.arraycopy(encoded, FramedAeadCrypto.CHUNK_HEADER_SIZE,
                 reordered, FramedAeadCrypto.CHUNK_HEADER_SIZE + recordSize, recordSize);
         verifyFailure(writeFile("reordered.bin", reordered), FILE_DEK, FILE_NONCE, 0, 1);
+    }
+
+    /**
+     * 验证随机生成的文件级 DEK 和 nonce 始终使用协议固定长度且每次返回独立数组。
+     */
+    @Test
+    void generateFileMaterial_shouldUseProtocolLengthsAndIndependentArrays() {
+        byte[] firstDek = writer.generateFileDek();
+        byte[] secondDek = writer.generateFileDek();
+        byte[] firstNonce = writer.generateFileNonce();
+        byte[] secondNonce = writer.generateFileNonce();
+
+        assertThat(firstDek).hasSize(FramedAeadCrypto.FILE_DEK_SIZE).isNotSameAs(secondDek);
+        assertThat(secondDek).hasSize(FramedAeadCrypto.FILE_DEK_SIZE);
+        assertThat(firstNonce).hasSize(FramedAeadCrypto.FILE_NONCE_SIZE).isNotSameAs(secondNonce);
+        assertThat(secondNonce).hasSize(FramedAeadCrypto.FILE_NONCE_SIZE);
+    }
+
+    /**
+     * 验证 manifest nonce 使用 Base64URL 无填充编码，并拒绝空值和错误长度。
+     */
+    @Test
+    void encodeFileNonce_shouldUseBase64UrlWithoutPaddingAndRejectInvalidLength() {
+        String encoded = writer.encodeFileNonce(FILE_NONCE);
+
+        assertThat(encoded)
+                .isEqualTo(Base64.getUrlEncoder().withoutPadding().encodeToString(FILE_NONCE))
+                .doesNotContain("=");
+        assertThrows(IllegalArgumentException.class, () -> writer.encodeFileNonce(null));
+        assertThrows(IllegalArgumentException.class, () -> writer.encodeFileNonce(new byte[15]));
+    }
+
+    /**
+     * 验证 writer/validator 对空路径、缺失文件和零字节明文均失败关闭。
+     */
+    @Test
+    void writeAndVerify_shouldRejectMissingPathsAndEmptyPlaintext() throws IOException {
+        Path missing = tempDir.resolve("missing.bin");
+        Path encrypted = tempDir.resolve("invalid-framed.bin");
+        Path empty = writeFile("empty.bin", new byte[0]);
+
+        assertThrows(IOException.class, () -> writer.write(
+                null, encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE));
+        assertThrows(IOException.class, () -> writer.write(
+                missing, encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE));
+        assertThrows(IOException.class, () -> writer.write(
+                empty, encrypted, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE));
+        assertThrows(IOException.class, () -> writer.verify(
+                null, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE));
+        assertThrows(IOException.class, () -> writer.verify(
+                missing, FILE_DEK, FILE_NONCE, 0, 1, FRAME_SIZE));
+    }
+
+    /**
+     * 验证文件密钥、文件 nonce 和 frame 大小的每个边界都在分配 frame 缓冲区前被拒绝。
+     */
+    @Test
+    void write_shouldRejectInvalidKeyNonceAndFrameBounds() throws IOException {
+        Path plaintext = writeFile("invalid-state-plain.bin", FIXED_PLAINTEXT);
+        Path encrypted = tempDir.resolve("invalid-state-framed.bin");
+
+        assertThrows(IllegalArgumentException.class, () -> writer.write(
+                plaintext, encrypted, null, FILE_NONCE, 0, 1, FRAME_SIZE));
+        assertThrows(IllegalArgumentException.class, () -> writer.write(
+                plaintext, encrypted, new byte[31], FILE_NONCE, 0, 1, FRAME_SIZE));
+        assertThrows(IllegalArgumentException.class, () -> writer.write(
+                plaintext, encrypted, FILE_DEK, null, 0, 1, FRAME_SIZE));
+        assertThrows(IllegalArgumentException.class, () -> writer.write(
+                plaintext, encrypted, FILE_DEK, new byte[15], 0, 1, FRAME_SIZE));
+        assertThrows(IllegalArgumentException.class, () -> writer.write(
+                plaintext, encrypted, FILE_DEK, FILE_NONCE, 0, 1,
+                FramedAeadCrypto.MIN_FRAME_PLAIN_SIZE - 1));
+        assertThrows(IllegalArgumentException.class, () -> writer.write(
+                plaintext, encrypted, FILE_DEK, FILE_NONCE, 0, 1,
+                FramedAeadCrypto.MAX_FRAME_PLAIN_SIZE + 1));
     }
 
     /**

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
@@ -13,6 +13,7 @@ import cn.flying.dao.entity.FriendFileShare;
 import cn.flying.dao.mapper.AccountMapper;
 import cn.flying.dao.mapper.FileMapper;
 import cn.flying.dao.mapper.FileShareMapper;
+import cn.flying.dao.vo.file.FileDecryptInfoVO;
 import cn.flying.dao.vo.file.FileVersionVO;
 import cn.flying.dao.vo.file.ShareFileVO;
 import cn.flying.platformapi.constant.Result;
@@ -38,8 +39,11 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -466,6 +470,221 @@ class FileQueryServiceTest {
                 assertThat(failure.getData()).asString().contains("文件大小");
                 verify(fileRemoteClient, never()).getFileUrlListByHash(anyList(), anyList());
             }
+        }
+
+        /**
+         * 逐项验证下载 manifest 顶层、分片、尺寸和 canonical hash 的失败关闭分支。
+         */
+        @Test
+        @DisplayName("should reject every manifest contract drift")
+        void shouldRejectEveryManifestContractDrift() {
+            File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE));
+            FileDecryptInfoVO decryptInfo = framedDecryptInfo(V2_FILE_SIZE, 1, V2_FILE_SIZE);
+            ChunkManifestView valid = framedManifest(
+                    "FRAMED_AEAD_V2", framedEncryption(), framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2));
+
+            Map<String, Object> topLevelDrifts = new LinkedHashMap<>();
+            topLevelDrifts.put("fileId", FILE_ID + 1);
+            topLevelDrifts.put("fileHash", "other-hash");
+            topLevelDrifts.put("schemaId", "other-schema");
+            topLevelDrifts.put("hashAlgorithm", "SHA-512");
+            topLevelDrifts.put("chunkSize", 0L);
+            topLevelDrifts.put("totalSize", 0L);
+            topLevelDrifts.put("chunkCount", null);
+            topLevelDrifts.put("storageBackend", " ");
+            for (Map.Entry<String, Object> drift : topLevelDrifts.entrySet()) {
+                assertDownloadManifestFailure(
+                        file, FILE_HASH, decryptInfo,
+                        copyDownloadManifest(valid, drift.getKey(), drift.getValue()), V2_FILE_SIZE);
+            }
+
+            assertDownloadManifestFailure(
+                    file.setFileHash("persisted-other-hash"), FILE_HASH, decryptInfo, valid, V2_FILE_SIZE);
+            file.setFileHash(FILE_HASH);
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, framedDecryptInfo(V2_FILE_SIZE, 2, V2_FILE_SIZE), valid, V2_FILE_SIZE);
+
+            Map<String, Object> chunkDrifts = new LinkedHashMap<>();
+            chunkDrifts.put("index", 1);
+            chunkDrifts.put("size", 0L);
+            chunkDrifts.put("plainHash", " ");
+            chunkDrifts.put("cipherHash", " ");
+            chunkDrifts.put("storagePath", " ");
+            for (Map.Entry<String, Object> drift : chunkDrifts.entrySet()) {
+                ChunkManifestChunk chunk = copyDownloadChunk(
+                        valid.chunks().getFirst(), drift.getKey(), drift.getValue());
+                assertDownloadManifestFailure(
+                        file, FILE_HASH, decryptInfo,
+                        copyDownloadManifest(valid, "chunks", List.of(chunk)), V2_FILE_SIZE);
+            }
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, decryptInfo,
+                    copyDownloadManifest(valid, "chunks", java.util.Collections.singletonList(null)),
+                    V2_FILE_SIZE);
+
+            ChunkManifestView aggregateMismatch = new ChunkManifestView(
+                    10L, FILE_ID, 1, ChunkManifestCanonicalizer.SCHEMA_ID, FILE_HASH,
+                    "sha256:" + "a".repeat(64), ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                    512L, 1, 513L, null, "AES-GCM", "S3", null,
+                    List.of(new ChunkManifestChunk(
+                            0, "plain", "cipher", 512L, "chunks/0", "S3", null, "SHA-256")));
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, framedDecryptInfo(513L, 1, 512L), aggregateMismatch, 513L);
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, decryptInfo, valid, V2_FILE_SIZE + 1);
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, framedDecryptInfo(V2_FILE_SIZE, 1, 0L), valid, V2_FILE_SIZE);
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, framedDecryptInfo(V2_FILE_SIZE, 1, V2_FILE_SIZE - 1), valid, V2_FILE_SIZE);
+
+            when(chunkManifestService.calculateManifestHash(any()))
+                    .thenThrow(new GeneralException(ResultEnum.FILE_RECORD_ERROR, "invalid canonical draft"));
+            assertDownloadManifestFailure(file, FILE_HASH, decryptInfo, valid, V2_FILE_SIZE);
+            doReturn("sha256:" + "a".repeat(64))
+                    .when(chunkManifestService).calculateManifestHash(any());
+            assertDownloadManifestFailure(
+                    file, FILE_HASH, decryptInfo,
+                    copyDownloadManifest(valid, "manifestHash", "not-a-hash"), V2_FILE_SIZE);
+            when(chunkManifestService.calculateManifestHash(any())).thenReturn("sha256:" + "d".repeat(64));
+            assertDownloadManifestFailure(file, FILE_HASH, decryptInfo, valid, V2_FILE_SIZE);
+        }
+
+        /**
+         * 验证 framed descriptor、分片公式、fileParam 和文件大小辅助函数的每个分支。
+         */
+        @Test
+        @DisplayName("should reject every framed descriptor and fileParam drift")
+        void shouldRejectEveryFramedDescriptorAndFileParamDrift() {
+            File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE));
+            ChunkManifestView valid = framedManifest(
+                    "FRAMED_AEAD_V2", framedEncryption(), framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2));
+
+            assertThat((Long) ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "resolveDownloadFileSize", file, framedDecryptInfo(null, 1, V2_FILE_SIZE)))
+                    .isEqualTo(V2_FILE_SIZE);
+            File withoutPersistedSize = framedOwnedFile("{}").setFileSize(null);
+            assertThat((Long) ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "resolveDownloadFileSize", withoutPersistedSize,
+                    framedDecryptInfo(V2_FILE_SIZE, 1, V2_FILE_SIZE))).isEqualTo(V2_FILE_SIZE);
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "resolveDownloadFileSize", withoutPersistedSize,
+                    framedDecryptInfo(null, 1, V2_FILE_SIZE)));
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "resolveDownloadFileSize", withoutPersistedSize,
+                    framedDecryptInfo(0L, 1, V2_FILE_SIZE)));
+
+            ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateEncryptionCoherence", valid, true, false);
+            assertDownloadEncryptionFailure(
+                    framedManifest("FRAMED_AEAD_V2", null, valid.chunks().getFirst()), false, false);
+            ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateEncryptionCoherence",
+                    framedManifest("AES-GCM", null, valid.chunks().getFirst()), false, false);
+            assertDownloadEncryptionFailure(
+                    framedManifest("AES-GCM", encryptionWithFormat(ChunkManifestEncryption.FORMAT_NONE),
+                            valid.chunks().getFirst()), false, false);
+            assertDownloadEncryptionFailure(
+                    framedManifest("NONE", encryptionWithFormat(ChunkManifestEncryption.FORMAT_LEGACY_V1),
+                            valid.chunks().getFirst()), false, true);
+            assertDownloadEncryptionFailure(
+                    framedManifest("NONE", framedEncryption(), valid.chunks().getFirst()), true, true);
+
+            Map<String, Object> chunkDrifts = new LinkedHashMap<>();
+            chunkDrifts.put("plainSize", null);
+            chunkDrifts.put("frameCount", null);
+            chunkDrifts.put("plainHash", "not-a-hash");
+            chunkDrifts.put("cipherHash", "not-a-hash");
+            chunkDrifts.put("size", V2_CIPHER_SIZE + 1);
+            for (Map.Entry<String, Object> drift : chunkDrifts.entrySet()) {
+                ChunkManifestChunk chunk = copyDownloadChunk(
+                        valid.chunks().getFirst(), drift.getKey(), drift.getValue());
+                assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                        fileQueryService, "validateFramedChunk",
+                        copyDownloadManifest(valid, "chunks", List.of(chunk)), chunk, 0));
+            }
+            ChunkManifestChunk zeroPlain = copyDownloadChunk(valid.chunks().getFirst(), "plainSize", 0L);
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateFramedChunk",
+                    copyDownloadManifest(valid, "chunks", List.of(zeroPlain)), zeroPlain, 0));
+            ChunkManifestChunk zeroFrames = copyDownloadChunk(valid.chunks().getFirst(), "frameCount", 0);
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateFramedChunk",
+                    copyDownloadManifest(valid, "chunks", List.of(zeroFrames)), zeroFrames, 0));
+            ChunkManifestChunk oversizedPlain = copyDownloadChunk(
+                    valid.chunks().getFirst(), "plainSize", V2_FILE_SIZE + 1);
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateFramedChunk",
+                    copyDownloadManifest(valid, "chunks", List.of(oversizedPlain)), oversizedPlain, 0));
+            assertThat((Long) ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateFramedChunk", valid, valid.chunks().getFirst(), 0))
+                    .isEqualTo(V2_FILE_SIZE);
+
+            ChunkManifestEncryption missingFrameSize = new ChunkManifestEncryption(
+                    ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                    ChunkManifestEncryption.SUITE_FRAMED_V2,
+                    V2_FILE_NONCE,
+                    null,
+                    ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                    ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                    ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                    FramedAeadCrypto.TAG_SIZE);
+            ChunkManifestView missingFrameSizeManifest = framedManifest(
+                    "FRAMED_AEAD_V2", missingFrameSize, valid.chunks().getFirst());
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateFramedChunk",
+                    missingFrameSizeManifest, valid.chunks().getFirst(), 0));
+
+            ChunkManifestEncryption missingTagSize = new ChunkManifestEncryption(
+                    ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                    ChunkManifestEncryption.SUITE_FRAMED_V2,
+                    V2_FILE_NONCE,
+                    V2_FRAME_SIZE,
+                    ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                    ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                    ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                    null);
+            ChunkManifestView missingTagSizeManifest = framedManifest(
+                    "FRAMED_AEAD_V2", missingTagSize, valid.chunks().getFirst());
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateFramedChunk",
+                    missingTagSizeManifest, valid.chunks().getFirst(), 0));
+
+            Map<String, String> fileParamDrifts = new LinkedHashMap<>();
+            fileParamDrifts.put("null", "null");
+            fileParamDrifts.put("algorithm", framedFileParam(V2_FILE_NONCE)
+                    .replace("FRAMED_AEAD_V2", "NONE"));
+            fileParamDrifts.put("suite", framedFileParam(V2_FILE_NONCE)
+                    .replace("RP-AES256-GCM-FRAMED-V2", "OTHER-SUITE"));
+            fileParamDrifts.put("nonce", framedFileParam("ERITFBUWFxgZGhscHR4fIA"));
+            fileParamDrifts.put("keyDerivation", framedFileParam(V2_FILE_NONCE)
+                    .replace("\"keyDerivation\":\"HKDF-SHA256\"", "\"keyDerivation\":\"OTHER\""));
+            fileParamDrifts.put("nonceDerivation", framedFileParam(V2_FILE_NONCE)
+                    .replace("\"nonceDerivation\":\"HKDF-SHA256\"", "\"nonceDerivation\":\"OTHER\""));
+            fileParamDrifts.put("aad", framedFileParam(V2_FILE_NONCE)
+                    .replace("cn.flying.framed-aead.aad.v2", "other-aad"));
+            fileParamDrifts.put("format", framedFileParam(V2_FILE_NONCE)
+                    .replace("\"formatVersion\":2", "\"formatVersion\":1"));
+            fileParamDrifts.put("frameSize", framedFileParam(V2_FILE_NONCE)
+                    .replace("\"framePlainSize\":65536", "\"framePlainSize\":131072"));
+            fileParamDrifts.put("tag", framedFileParam(V2_FILE_NONCE)
+                    .replace("\"tagSize\":16", "\"tagSize\":12"));
+            fileParamDrifts.put("malformed", "{not-json");
+            for (String fileParam : fileParamDrifts.values()) {
+                assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                        fileQueryService, "validateV2FileParam",
+                        framedOwnedFile(fileParam), valid, true));
+            }
+            ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateV2FileParam", file, valid, true);
+            ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "validateV2FileParam", file, valid, false);
+
+            assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "numericEquals", 2L, 2)).isTrue();
+            assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "numericEquals", "2", 2)).isFalse();
+            assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                    fileQueryService, "numericEquals", 2, null)).isFalse();
         }
     }
 
@@ -1561,5 +1780,102 @@ class FileQueryServiceTest {
                 List.of(manifest.chunks().getFirst().storagePath()),
                 List.of(manifest.chunks().getFirst().cipherHash())))
                 .thenReturn(Result.success(urls));
+    }
+
+    /**
+     * 构造用于直接调用下载私有校验的解密信息。
+     */
+    private FileDecryptInfoVO framedDecryptInfo(Long fileSize, Integer chunkCount, Long chunkSize) {
+        return new FileDecryptInfoVO(
+                "file-dek", "framed.bin", fileSize, "application/octet-stream",
+                chunkCount, FILE_HASH, chunkSize);
+    }
+
+    /**
+     * 断言下载 manifest 私有校验失败。
+     */
+    private void assertDownloadManifestFailure(
+            File file,
+            String requestedHash,
+            FileDecryptInfoVO decryptInfo,
+            ChunkManifestView manifest,
+            long fileSize
+    ) {
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                fileQueryService,
+                "validateDownloadManifest",
+                file,
+                requestedHash,
+                decryptInfo,
+                manifest,
+                fileSize));
+    }
+
+    /**
+     * 断言 encryptionAlgorithm 与 descriptor 的组合校验失败。
+     */
+    private void assertDownloadEncryptionFailure(
+            ChunkManifestView manifest,
+            boolean framedV2,
+            boolean unencrypted
+    ) {
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                fileQueryService, "validateEncryptionCoherence", manifest, framedV2, unencrypted));
+    }
+
+    /**
+     * 构造只替换格式版本的加密描述。
+     */
+    private ChunkManifestEncryption encryptionWithFormat(Integer formatVersion) {
+        ChunkManifestEncryption source = framedEncryption();
+        return new ChunkManifestEncryption(
+                formatVersion,
+                source.algorithmSuite(),
+                source.fileNonce(),
+                source.framePlainSize(),
+                source.keyDerivation(),
+                source.nonceDerivation(),
+                source.aadSchema(),
+                source.tagSize());
+    }
+
+    /**
+     * 复制下载 manifest 并替换一个字段。
+     */
+    @SuppressWarnings("unchecked")
+    private ChunkManifestView copyDownloadManifest(ChunkManifestView source, String field, Object value) {
+        return new ChunkManifestView(
+                source.manifestId(),
+                "fileId".equals(field) ? (Long) value : source.fileId(),
+                source.fileVersion(),
+                "schemaId".equals(field) ? (String) value : source.schemaId(),
+                "fileHash".equals(field) ? (String) value : source.fileHash(),
+                "manifestHash".equals(field) ? (String) value : source.manifestHash(),
+                "hashAlgorithm".equals(field) ? (String) value : source.hashAlgorithm(),
+                "chunkSize".equals(field) ? ((Number) value).longValue() : source.chunkSize(),
+                "chunkCount".equals(field) ? (Integer) value : source.chunkCount(),
+                "totalSize".equals(field) ? ((Number) value).longValue() : source.totalSize(),
+                source.merkleRoot(),
+                source.encryptionAlgorithm(),
+                "storageBackend".equals(field) ? (String) value : source.storageBackend(),
+                source.encryption(),
+                "chunks".equals(field) ? (List<ChunkManifestChunk>) value : source.chunks());
+    }
+
+    /**
+     * 复制下载 manifest 分片并替换一个字段。
+     */
+    private ChunkManifestChunk copyDownloadChunk(ChunkManifestChunk source, String field, Object value) {
+        return new ChunkManifestChunk(
+                "index".equals(field) ? ((Number) value).intValue() : source.index(),
+                "plainHash".equals(field) ? (String) value : source.plainHash(),
+                "cipherHash".equals(field) ? (String) value : source.cipherHash(),
+                "size".equals(field) ? ((Number) value).longValue() : source.size(),
+                "storagePath".equals(field) ? (String) value : source.storagePath(),
+                source.storageBackend(),
+                source.etag(),
+                source.checksumAlgorithm(),
+                "plainSize".equals(field) ? (Long) value : source.plainSize(),
+                "frameCount".equals(field) ? (Integer) value : source.frameCount());
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
@@ -20,7 +20,9 @@ import cn.flying.platformapi.response.FileDetailVO;
 import cn.flying.platformapi.response.TransactionVO;
 import cn.flying.service.FriendFileShareService;
 import cn.flying.service.key.FileKeyEnvelopeService;
+import cn.flying.service.manifest.ChunkManifestCanonicalizer;
 import cn.flying.service.manifest.ChunkManifestChunk;
+import cn.flying.service.manifest.ChunkManifestDraft;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
 import cn.flying.service.remote.FileRemoteClient;
@@ -42,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
@@ -87,10 +90,17 @@ class FileQueryServiceTest {
     private static final Long FILE_ID = 1L;
     private static final String FILE_HASH = "sha256_test_hash";
     private static final String TRANSACTION_HASH = "0xtxhash";
+    private static final ChunkManifestCanonicalizer CANONICALIZER = new ChunkManifestCanonicalizer();
+
     @BeforeEach
     void setUp() {
         FileTestBuilder.resetIdCounter();
         AccountTestBuilder.resetIdCounter();
+        lenient().when(chunkManifestService.calculateManifestHash(any()))
+                .thenReturn("sha256:" + "a".repeat(64));
+        lenient().when(chunkManifestService.calculateCanonicalJson(any()))
+                .thenAnswer(invocation -> CANONICALIZER.canonicalJson(
+                        invocation.getArgument(0, ChunkManifestDraft.class)));
     }
 
     /**
@@ -131,7 +141,7 @@ class FileQueryServiceTest {
                         1,
                         "cn.flying.chunk-manifest.v1",
                         FILE_HASH,
-                        "sha256:manifest",
+                        "sha256:" + "a".repeat(64),
                         "SHA-256",
                         1024L,
                         2,
@@ -163,7 +173,10 @@ class FileQueryServiceTest {
 
                 assertEquals("ext-file-1", metadata.fileId());
                 assertEquals(FILE_HASH, metadata.fileHash());
-                assertEquals("sha256:manifest", metadata.manifestHash());
+                assertEquals("sha256:" + "a".repeat(64), metadata.manifestHash());
+                assertThat(metadata.canonicalManifestJson()).isNotBlank();
+                assertThat(metadata.canonicalManifestJson())
+                        .doesNotContain("initialKey", "fileDataKey");
                 assertEquals(2, metadata.totalChunks());
                 assertEquals("url-0", metadata.parts().get(0).downloadUrl());
                 assertEquals("chunks/1", metadata.parts().get(1).storagePath());
@@ -201,7 +214,7 @@ class FileQueryServiceTest {
                         1,
                         "cn.flying.chunk-manifest.v1",
                         FILE_HASH,
-                        "sha256:manifest",
+                        "sha256:" + "a".repeat(64),
                         "SHA-256",
                         512L,
                         1,
@@ -222,6 +235,9 @@ class FileQueryServiceTest {
 
                 assertNull(metadata.initialKey());
                 assertEquals("NONE", metadata.encryptionAlgorithm());
+                assertThat(metadata.canonicalManifestJson()).isNotBlank();
+                assertThat(metadata.canonicalManifestJson())
+                        .doesNotContain("initialKey", "fileDataKey");
                 assertEquals("url-0", metadata.parts().getFirst().downloadUrl());
                 verify(fileKeyEnvelopeService, never()).unwrapActiveOwnerInitialKey(
                         any(File.class),

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileQueryServiceTest.java
@@ -19,10 +19,12 @@ import cn.flying.platformapi.constant.Result;
 import cn.flying.platformapi.response.FileDetailVO;
 import cn.flying.platformapi.response.TransactionVO;
 import cn.flying.service.FriendFileShareService;
+import cn.flying.service.encryption.FramedAeadCrypto;
 import cn.flying.service.key.FileKeyEnvelopeService;
 import cn.flying.service.manifest.ChunkManifestCanonicalizer;
 import cn.flying.service.manifest.ChunkManifestChunk;
 import cn.flying.service.manifest.ChunkManifestDraft;
+import cn.flying.service.manifest.ChunkManifestEncryption;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
 import cn.flying.service.remote.FileRemoteClient;
@@ -90,6 +92,14 @@ class FileQueryServiceTest {
     private static final Long FILE_ID = 1L;
     private static final String FILE_HASH = "sha256_test_hash";
     private static final String TRANSACTION_HASH = "0xtxhash";
+    private static final int V2_FRAME_SIZE = 64 * 1024;
+    private static final long V2_FILE_SIZE = V2_FRAME_SIZE + 3L;
+    private static final long V2_CIPHER_SIZE = FramedAeadCrypto.CHUNK_HEADER_SIZE
+            + V2_FILE_SIZE
+            + 2L * (FramedAeadCrypto.FRAME_HEADER_SIZE + FramedAeadCrypto.TAG_SIZE);
+    private static final String V2_FILE_NONCE = "AQIDBAUGBwgJCgsMDQ4PEA";
+    private static final String V2_PLAIN_HASH = "sha256:" + "b".repeat(64);
+    private static final String V2_CIPHER_HASH = "sha256:" + "c".repeat(64);
     private static final ChunkManifestCanonicalizer CANONICALIZER = new ChunkManifestCanonicalizer();
 
     @BeforeEach
@@ -301,6 +311,159 @@ class FileQueryServiceTest {
 
                 assertEquals(ResultEnum.FILE_NOT_EXIST.getCode(), ex.getResultEnum().getCode());
                 verify(chunkManifestService, never()).findActiveManifest(any(), any());
+                verify(fileRemoteClient, never()).getFileUrlListByHash(anyList(), anyList());
+            }
+        }
+
+        /**
+         * 验证 framed v2 下载合同完整映射 descriptor、frame 证据和 file-level DEK。
+         */
+        @Test
+        @DisplayName("should build framed v2 download metadata from authenticated manifest")
+        void shouldBuildFramedV2DownloadMetadataFromAuthenticatedManifest() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class);
+                 MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                idUtilsMock.when(() -> IdUtils.toExternalId(FILE_ID)).thenReturn("ext-v2-file");
+                File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE));
+                ChunkManifestView manifest = framedManifest(
+                        "FRAMED_AEAD_V2",
+                        framedEncryption(),
+                        framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2));
+                stubOwnedDownload(file, manifest, List.of("https://storage.example/v2-part-0"));
+
+                var metadata = fileQueryService.getDownloadMetadata(USER_ID, FILE_HASH);
+
+                assertEquals("ext-v2-file", metadata.fileId());
+                assertEquals("file-dek", metadata.initialKey());
+                assertEquals(V2_FILE_SIZE, metadata.fileSize());
+                assertEquals(V2_FILE_SIZE, metadata.chunkSize());
+                assertThat(metadata.encryption()).isNotNull();
+                assertEquals(ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                        metadata.encryption().formatVersion());
+                assertEquals(V2_FILE_NONCE, metadata.encryption().fileNonce());
+                assertEquals(V2_FRAME_SIZE, metadata.encryption().framePlainSize());
+                assertEquals(V2_FILE_SIZE, metadata.parts().getFirst().plainSize());
+                assertEquals(2, metadata.parts().getFirst().frameCount());
+                assertEquals(V2_CIPHER_SIZE, metadata.parts().getFirst().size());
+            }
+        }
+
+        /**
+         * 验证持久化 fileParam 的 nonce 与 active manifest 不一致时不会签发 URL。
+         */
+        @Test
+        @DisplayName("should reject framed metadata when fileParam descriptor drifts")
+        void shouldRejectFramedMetadataWhenFileParamDescriptorDrifts() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class)) {
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                File file = framedOwnedFile(framedFileParam("ERITFBUWFxgZGhscHR4fIA"));
+                ChunkManifestView manifest = framedManifest(
+                        "FRAMED_AEAD_V2",
+                        framedEncryption(),
+                        framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2));
+                stubOwnedDownload(file, manifest, List.of("unused"));
+
+                GeneralException failure = assertThrows(GeneralException.class,
+                        () -> fileQueryService.getDownloadMetadata(USER_ID, FILE_HASH));
+
+                assertThat(failure.getData()).asString().contains("fileParam");
+                verify(fileRemoteClient, never()).getFileUrlListByHash(anyList(), anyList());
+            }
+        }
+
+        /**
+         * 验证 v2 分片的 frame 数量或密文字节公式不匹配时失败关闭。
+         */
+        @Test
+        @DisplayName("should reject framed chunk with inconsistent cipher size")
+        void shouldRejectFramedChunkWithInconsistentCipherSize() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class)) {
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE));
+                ChunkManifestView manifest = framedManifest(
+                        "FRAMED_AEAD_V2",
+                        framedEncryption(),
+                        framedChunk(V2_CIPHER_SIZE + 1, V2_FILE_SIZE, 2));
+                stubOwnedDownload(file, manifest, List.of("unused"));
+
+                GeneralException failure = assertThrows(GeneralException.class,
+                        () -> fileQueryService.getDownloadMetadata(USER_ID, FILE_HASH));
+
+                assertThat(failure.getData()).asString().contains("frame");
+                verify(fileRemoteClient, never()).getFileUrlListByHash(anyList(), anyList());
+            }
+        }
+
+        /**
+         * 验证 v2 descriptor 不得与 legacy encryptionAlgorithm 组合使用。
+         */
+        @Test
+        @DisplayName("should reject framed descriptor with conflicting algorithm")
+        void shouldRejectFramedDescriptorWithConflictingAlgorithm() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class)) {
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE));
+                ChunkManifestView manifest = framedManifest(
+                        "AES-GCM",
+                        framedEncryption(),
+                        framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2));
+                stubOwnedDownload(file, manifest, List.of("unused"));
+
+                GeneralException failure = assertThrows(GeneralException.class,
+                        () -> fileQueryService.getDownloadMetadata(USER_ID, FILE_HASH));
+
+                assertThat(failure.getData()).asString().contains("加密算法声明不一致");
+                verify(fileRemoteClient, never()).getFileUrlListByHash(anyList(), anyList());
+            }
+        }
+
+        /**
+         * 验证对象存储返回空 URL 时不会构造伪成功下载 part。
+         */
+        @Test
+        @DisplayName("should reject blank presigned url for framed part")
+        void shouldRejectBlankPresignedUrlForFramedPart() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class)) {
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE));
+                ChunkManifestView manifest = framedManifest(
+                        "FRAMED_AEAD_V2",
+                        framedEncryption(),
+                        framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2));
+                stubOwnedDownload(file, manifest, List.of(" "));
+
+                GeneralException failure = assertThrows(GeneralException.class,
+                        () -> fileQueryService.getDownloadMetadata(USER_ID, FILE_HASH));
+
+                assertThat(failure.getData()).asString().contains("空下载 URL");
+            }
+        }
+
+        /**
+         * 验证 DB 文件大小与 fileParam 明文大小冲突时在读取 manifest 前拒绝。
+         */
+        @Test
+        @DisplayName("should reject persisted and parameter file size mismatch")
+        void shouldRejectPersistedAndParameterFileSizeMismatch() {
+            try (MockedStatic<SecurityUtils> securityUtilsMock = mockStatic(SecurityUtils.class)) {
+                securityUtilsMock.when(SecurityUtils::isAdmin).thenReturn(false);
+                File file = framedOwnedFile(framedFileParam(V2_FILE_NONCE))
+                        .setFileSize(V2_FILE_SIZE + 1);
+                when(fileMapper.selectOne(any())).thenReturn(file);
+                when(fileKeyEnvelopeService.unwrapActiveOwnerInitialKey(
+                        file, FILE_HASH, USER_ID, USER_ID, "OWNER_DECRYPT"))
+                        .thenReturn(Optional.of("file-dek"));
+                when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID))
+                        .thenReturn(Optional.of(framedManifest(
+                                "FRAMED_AEAD_V2",
+                                framedEncryption(),
+                                framedChunk(V2_CIPHER_SIZE, V2_FILE_SIZE, 2))));
+
+                GeneralException failure = assertThrows(GeneralException.class,
+                        () -> fileQueryService.getDownloadMetadata(USER_ID, FILE_HASH));
+
+                assertThat(failure.getData()).asString().contains("文件大小");
                 verify(fileRemoteClient, never()).getFileUrlListByHash(anyList(), anyList());
             }
         }
@@ -1286,5 +1449,117 @@ class FileQueryServiceTest {
                 .setFileHashes("[\"" + FILE_HASH + "\"]")
                 .setStatus(FriendFileShare.STATUS_ACTIVE)
                 .setIsRead(0);
+    }
+
+    /**
+     * 构造 framed v2 owner 文件记录。
+     */
+    private File framedOwnedFile(String fileParam) {
+        return new File()
+                .setId(FILE_ID)
+                .setUid(USER_ID)
+                .setTenantId(1L)
+                .setVersion(1)
+                .setFileName("framed.bin")
+                .setFileHash(FILE_HASH)
+                .setFileSize(V2_FILE_SIZE)
+                .setContentType("application/octet-stream")
+                .setStatus(FileUploadStatus.SUCCESS.getCode())
+                .setFileParam(fileParam);
+    }
+
+    /**
+     * 构造与 framed descriptor 对齐的持久化 fileParam。
+     */
+    private String framedFileParam(String fileNonce) {
+        return "{"
+                + "\"fileName\":\"framed.bin\","
+                + "\"fileSize\":" + V2_FILE_SIZE + ","
+                + "\"contentType\":\"application/octet-stream\","
+                + "\"chunkCount\":1,"
+                + "\"chunkSize\":" + V2_FILE_SIZE + ","
+                + "\"encryptionAlgorithm\":\"FRAMED_AEAD_V2\","
+                + "\"algorithmSuite\":\"RP-AES256-GCM-FRAMED-V2\","
+                + "\"fileNonce\":\"" + fileNonce + "\","
+                + "\"keyDerivation\":\"HKDF-SHA256\","
+                + "\"nonceDerivation\":\"HKDF-SHA256\","
+                + "\"aadSchema\":\"cn.flying.framed-aead.aad.v2\","
+                + "\"formatVersion\":2,"
+                + "\"framePlainSize\":" + V2_FRAME_SIZE + ","
+                + "\"tagSize\":16"
+                + "}";
+    }
+
+    /**
+     * 构造 allowlist 内的 framed v2 descriptor。
+     */
+    private ChunkManifestEncryption framedEncryption() {
+        return new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                V2_FILE_NONCE,
+                V2_FRAME_SIZE,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                FramedAeadCrypto.TAG_SIZE);
+    }
+
+    /**
+     * 构造单分片 framed v2 manifest。
+     */
+    private ChunkManifestView framedManifest(
+            String encryptionAlgorithm,
+            ChunkManifestEncryption encryption,
+            ChunkManifestChunk chunk
+    ) {
+        return new ChunkManifestView(
+                10L,
+                FILE_ID,
+                1,
+                ChunkManifestCanonicalizer.SCHEMA_ID,
+                FILE_HASH,
+                "sha256:" + "a".repeat(64),
+                ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                V2_FILE_SIZE,
+                1,
+                V2_FILE_SIZE,
+                null,
+                encryptionAlgorithm,
+                "S3",
+                encryption,
+                List.of(chunk));
+    }
+
+    /**
+     * 构造精确 frame 证据的 manifest 分片。
+     */
+    private ChunkManifestChunk framedChunk(long cipherSize, long plainSize, int frameCount) {
+        return new ChunkManifestChunk(
+                0,
+                V2_PLAIN_HASH,
+                V2_CIPHER_HASH,
+                cipherSize,
+                "storage/tenant/1/chunk/" + V2_CIPHER_HASH,
+                "S3",
+                null,
+                ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                plainSize,
+                frameCount);
+    }
+
+    /**
+     * 配置 owner、manifest、DEK 与预签名 URL 的完整下载边界。
+     */
+    private void stubOwnedDownload(File file, ChunkManifestView manifest, List<String> urls) {
+        when(fileMapper.selectOne(any())).thenReturn(file);
+        when(fileKeyEnvelopeService.unwrapActiveOwnerInitialKey(
+                file, FILE_HASH, USER_ID, USER_ID, "OWNER_DECRYPT"))
+                .thenReturn(Optional.of("file-dek"));
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.of(manifest));
+        when(fileRemoteClient.getFileUrlListByHash(
+                List.of(manifest.chunks().getFirst().storagePath()),
+                List.of(manifest.chunks().getFirst().cipherHash())))
+                .thenReturn(Result.success(urls));
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
@@ -37,6 +37,9 @@ import cn.flying.service.encryption.EncryptionStrategyFactory;
 import cn.flying.service.manifest.ChunkManifestDraft;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
+import cn.flying.service.manifest.FramedManifestFinalizationService;
+import cn.flying.service.encryption.FramedAeadCrypto;
+import cn.flying.service.manifest.ChunkManifestEncryption;
 import cn.flying.service.remote.FileRemoteClient;
 import cn.flying.test.builders.FileUploadStateTestBuilder;
 import org.junit.jupiter.api.*;
@@ -123,6 +126,9 @@ class FileUploadServiceTest {
 
     @Mock
     private ChunkManifestService chunkManifestService;
+
+    @Mock
+    private FramedManifestFinalizationService framedManifestFinalizationService;
 
     @InjectMocks
     private FileUploadServiceImpl fileUploadService;
@@ -3492,6 +3498,103 @@ class FileUploadServiceTest {
             assertInstanceOf(GeneralException.class, thrown.getCause());
             assertEquals(ResultEnum.PARAM_IS_INVALID,
                     ((GeneralException) thrown.getCause()).getResultEnum());
+        }
+    }
+
+    @Nested
+    @DisplayName("Framed DB SUCCESS Recovery")
+    class FramedDbSuccessRecovery {
+
+        /**
+         * 验证 active manifest 校验或保存失败时，恢复流程不会先清理唯一临时证据或标记 completed。
+         */
+        @Test
+        void shouldValidateFramedManifestBeforeCleaningRecoveryEvidence() throws Exception {
+            String clientId = "framed-recovery-" + UUID.randomUUID();
+            long fileId = 9401L;
+            FileUploadState state = completionState(clientId, true);
+            state.setPrepareStored(true);
+            state.setPreparedFileId(fileId);
+            state.setContentHash(CONTENT_HASH);
+            state.setEncryptionRecoveryVersion(2);
+            state.setEncryptionFormatVersion(FramedAeadCrypto.FORMAT_VERSION);
+            state.setEncryptionAlgorithmSuite(ChunkManifestEncryption.SUITE_FRAMED_V2);
+            state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE]);
+            state.setFileNonce(new byte[FramedAeadCrypto.FILE_NONCE_SIZE]);
+            state.setFramePlainSize(64 * 1024);
+            state.setKeyDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setNonceDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setAadSchema(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2);
+            state.setTagSize(FramedAeadCrypto.TAG_SIZE);
+
+            Path uploadDir = Path.of("uploads").toAbsolutePath().normalize()
+                    .resolve(SUID).resolve(clientId);
+            Path processedDir = Path.of("processed").toAbsolutePath().normalize()
+                    .resolve(SUID).resolve(clientId);
+            Files.createDirectories(uploadDir);
+            Files.createDirectories(processedDir);
+            Path uploadEvidence = uploadDir.resolve("raw-evidence");
+            Path processedEvidence = processedDir.resolve("encrypted_chunk_0");
+            Files.writeString(uploadEvidence, "raw-evidence", StandardCharsets.UTF_8);
+            Files.write(processedEvidence, new byte[]{4, 5, 6});
+            state.setUploadTempPath(uploadDir.toString());
+            state.setProcessedTempPath(processedDir.toString());
+
+            File persistedFile = new File()
+                    .setId(fileId)
+                    .setUid(USER_ID)
+                    .setTenantId(77L)
+                    .setFileName(state.getFileName())
+                    .setFileSize(state.getFileSize())
+                    .setFileHash("persisted-file-hash")
+                    .setTransactionHash("tx-9401")
+                    .setContentHash(CONTENT_HASH)
+                    .setStatus(FileUploadStatus.SUCCESS.getCode());
+            when(fileService.getById(fileId)).thenReturn(persistedFile);
+            when(redisStateManager.getState(clientId)).thenReturn(state);
+            doThrow(new GeneralException(ResultEnum.FILE_RECORD_ERROR, "manifest evidence unavailable"))
+                    .when(framedManifestFinalizationService).ensureManifest(
+                            eq(USER_ID), eq(persistedFile), eq(state), anyList(), anyList());
+
+            try {
+                RetryableException failure = assertThrows(
+                        RetryableException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService,
+                                "recoverLegacySuccessFinalization",
+                                USER_ID,
+                                SUID,
+                                state));
+
+                assertEquals(ResultEnum.SERVICE_UNAVAILABLE, failure.getResultEnum());
+                assertTrue(Files.isRegularFile(uploadEvidence));
+                assertTrue(Files.isRegularFile(processedEvidence));
+                verify(framedManifestFinalizationService).ensureManifest(
+                        eq(USER_ID), eq(persistedFile), eq(state), anyList(), anyList());
+                verify(redisStateManager, never()).markCompleted(anyString(), anyString(), anyInt());
+            } finally {
+                deleteTree(uploadDir);
+                deleteTree(processedDir);
+            }
+        }
+
+        /**
+         * 递归清理本测试创建的隔离上传证据目录。
+         */
+        private void deleteTree(Path root) throws IOException {
+            if (!Files.exists(root)) {
+                return;
+            }
+            try (var paths = Files.walk(root)) {
+                paths.sorted(java.util.Comparator.reverseOrder())
+                        .forEach(path -> {
+                            try {
+                                Files.deleteIfExists(path);
+                            } catch (IOException exception) {
+                                throw new IllegalStateException(exception);
+                            }
+                        });
+            }
         }
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
@@ -33,7 +33,9 @@ import cn.flying.service.FileService;
 import cn.flying.service.QuotaService;
 import cn.flying.service.assistant.FileUploadRedisStateManager;
 import cn.flying.service.encryption.AesGcmEncryptionStrategy;
+import cn.flying.service.encryption.EncryptionProperties;
 import cn.flying.service.encryption.EncryptionStrategyFactory;
+import cn.flying.service.encryption.FramedAeadWriter;
 import cn.flying.service.manifest.ChunkManifestDraft;
 import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
@@ -69,13 +71,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -96,6 +102,12 @@ class FileUploadServiceTest {
 
     @Mock
     private EncryptionStrategyFactory encryptionStrategyFactory;
+
+    @Mock
+    private EncryptionProperties encryptionProperties;
+
+    @Mock
+    private FramedAeadWriter framedAeadWriter;
 
     @Mock
     private FileService fileService;
@@ -167,6 +179,7 @@ class FileUploadServiceTest {
     void setUp() throws InterruptedException {
         FileUploadStateTestBuilder.resetClientIdCounter();
         idUtilsMock.when(IdUtils::nextEntityId).thenReturn(7001L);
+        lenient().when(encryptionProperties.getWriterFormat()).thenReturn("v1");
         // Skip @PostConstruct initialization
         ReflectionTestUtils.setField(fileUploadService, "eventPublisher", eventPublisher);
         // 让异步分片处理在测试中同步执行，避免线程池/时序不稳定
@@ -3502,8 +3515,730 @@ class FileUploadServiceTest {
     }
 
     @Nested
+    @DisplayName("Framed Upload Encryption Contracts")
+    class FramedUploadEncryptionContracts {
+
+        /**
+         * 验证 framed v2 初始化会一次性持久化完整的文件级加密检查点。
+         */
+        @Test
+        void shouldInitializeFramedEncryptionCheckpoint() {
+            byte[] dek = new byte[FramedAeadCrypto.FILE_DEK_SIZE];
+            byte[] nonce = new byte[FramedAeadCrypto.FILE_NONCE_SIZE];
+            Arrays.fill(dek, (byte) 7);
+            Arrays.fill(nonce, (byte) 9);
+            when(encryptionProperties.getWriterFormat()).thenReturn(null);
+            when(encryptionProperties.getFramePlainSize())
+                    .thenReturn(ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE);
+            when(framedAeadWriter.generateFileDek()).thenReturn(dek);
+            when(framedAeadWriter.generateFileNonce()).thenReturn(nonce);
+
+            FileUploadState state = new FileUploadState(
+                    USER_ID, "framed.bin", 1024L, "application/octet-stream", "framed-init", 1024, 1);
+            ReflectionTestUtils.invokeMethod(fileUploadService, "initializeEncryptionState", state);
+
+            assertEquals(2, state.getEncryptionRecoveryVersion());
+            assertEquals(FramedAeadCrypto.FORMAT_VERSION, state.getEncryptionFormatVersion());
+            assertEquals(ChunkManifestEncryption.SUITE_FRAMED_V2, state.getEncryptionAlgorithmSuite());
+            assertSame(dek, state.getFileDataKey());
+            assertSame(nonce, state.getFileNonce());
+            assertEquals(ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE, state.getFramePlainSize());
+            assertEquals(ChunkManifestEncryption.DERIVATION_HKDF_SHA256, state.getKeyDerivation());
+            assertEquals(ChunkManifestEncryption.DERIVATION_HKDF_SHA256, state.getNonceDerivation());
+            assertEquals(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2, state.getAadSchema());
+            assertEquals(FramedAeadCrypto.TAG_SIZE, state.getTagSize());
+            verify(framedAeadWriter).generateFileDek();
+            verify(framedAeadWriter).generateFileNonce();
+        }
+
+        /**
+         * 验证 legacy 别名和未注入配置时都会清空 framed 检查点，保持旧格式兼容。
+         */
+        @Test
+        void shouldInitializeLegacyEncryptionCheckpointForAliasesAndMissingConfig() {
+            FileUploadState state = framedState("legacy-init", 1);
+            when(encryptionProperties.getWriterFormat()).thenReturn(" legacy ");
+            ReflectionTestUtils.invokeMethod(fileUploadService, "initializeEncryptionState", state);
+
+            assertEquals(1, state.getEncryptionRecoveryVersion());
+            assertEquals(ChunkManifestEncryption.FORMAT_LEGACY_V1, state.getEncryptionFormatVersion());
+            assertNull(state.getEncryptionAlgorithmSuite());
+            assertNull(state.getFileDataKey());
+            assertNull(state.getFileNonce());
+            assertNull(state.getFramePlainSize());
+            assertNull(state.getKeyDerivation());
+            assertNull(state.getNonceDerivation());
+            assertNull(state.getAadSchema());
+            assertNull(state.getTagSize());
+
+            ReflectionTestUtils.setField(fileUploadService, "encryptionProperties", null);
+            FileUploadState fallback = new FileUploadState(
+                    USER_ID, "legacy-fallback.bin", 1L, "text/plain", "legacy-fallback", 1, 1);
+            ReflectionTestUtils.invokeMethod(fileUploadService, "initializeEncryptionState", fallback);
+            assertEquals(ChunkManifestEncryption.FORMAT_LEGACY_V1, fallback.getEncryptionFormatVersion());
+            assertNull(fallback.getFileDataKey());
+        }
+
+        /**
+         * 验证初始化入口拒绝空状态、越界 frame 大小和未知 writer-format。
+         */
+        @Test
+        void shouldRejectInvalidEncryptionInitializationInputs() {
+            GeneralException nullState = assertThrows(
+                    GeneralException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            fileUploadService, "initializeEncryptionState", (FileUploadState) null));
+            assertEquals(ResultEnum.FILE_UPLOAD_ERROR, nullState.getResultEnum());
+
+            when(encryptionProperties.getWriterFormat()).thenReturn("v2");
+            when(encryptionProperties.getFramePlainSize())
+                    .thenReturn(ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE - 1);
+            GeneralException tooSmall = assertThrows(
+                    GeneralException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            fileUploadService, "initializeEncryptionState", new FileUploadState()));
+            assertEquals(ResultEnum.PARAM_ERROR, tooSmall.getResultEnum());
+
+            when(encryptionProperties.getFramePlainSize())
+                    .thenReturn(ChunkManifestEncryption.MAX_FRAME_PLAIN_SIZE + 1);
+            GeneralException tooLarge = assertThrows(
+                    GeneralException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            fileUploadService, "initializeEncryptionState", new FileUploadState()));
+            assertEquals(ResultEnum.PARAM_ERROR, tooLarge.getResultEnum());
+
+            when(encryptionProperties.getWriterFormat()).thenReturn("v3");
+            GeneralException unsupported = assertThrows(
+                    GeneralException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            fileUploadService, "initializeEncryptionState", new FileUploadState()));
+            assertEquals(ResultEnum.PARAM_ERROR, unsupported.getResultEnum());
+            verifyNoInteractions(framedAeadWriter);
+        }
+
+        /**
+         * 验证 framed 完成态通过所有顶层和逐分片证据检查，且不依赖 v1 分片密钥链。
+         */
+        @Test
+        void shouldAcceptCompleteFramedChunkState() {
+            FileUploadState state = framedState("complete-framed", 2);
+            assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "requireCompleteChunkState", state, 2));
+            assertTrue(state.getKeys().isEmpty());
+        }
+
+        /**
+         * 验证 framed 完成态的每个检查点缺失都会返回可重试服务不可用错误。
+         */
+        @Test
+        void shouldRejectMissingFramedCompletionEvidence() {
+            List<Consumer<FileUploadState>> topLevelMutations = List.of(
+                    state -> state.setUploadedChunks(null),
+                    state -> state.setProcessedChunks(null),
+                    state -> state.setChunkHashes(null),
+                    state -> state.getUploadedChunks().remove(1),
+                    state -> state.getProcessedChunks().remove(1),
+                    state -> state.getChunkHashes().remove("chunk_1"),
+                    state -> state.setFileDataKey(null),
+                    state -> state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE - 1]),
+                    state -> state.setFileNonce(null),
+                    state -> state.setFileNonce(new byte[FramedAeadCrypto.FILE_NONCE_SIZE - 1]),
+                    state -> state.setFramePlainSize(null)
+            );
+            for (Consumer<FileUploadState> mutation : topLevelMutations) {
+                FileUploadState state = framedState("framed-missing-" + UUID.randomUUID(), 2);
+                mutation.accept(state);
+                RetryableException error = assertThrows(
+                        RetryableException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService, "requireCompleteChunkState", state, 2));
+                assertEquals(ResultEnum.SERVICE_UNAVAILABLE, error.getResultEnum());
+            }
+
+            List<Consumer<FileUploadState>> indexedMutations = List.of(
+                    state -> {
+                        state.getUploadedChunks().clear();
+                        state.getUploadedChunks().add(9);
+                    },
+                    state -> {
+                        state.getProcessedChunks().clear();
+                        state.getProcessedChunks().add(9);
+                    },
+                    state -> {
+                        state.getChunkHashes().clear();
+                        state.getChunkHashes().put("chunk_9", zeroDigestBase64Url());
+                    },
+                    state -> state.getChunkHashes().put("chunk_0", " ")
+            );
+            for (Consumer<FileUploadState> mutation : indexedMutations) {
+                FileUploadState state = framedState("framed-index-" + UUID.randomUUID(), 2);
+                mutation.accept(state);
+                assertThrows(
+                        RetryableException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService, "requireCompleteChunkState", state, 2));
+            }
+        }
+
+        /**
+         * 验证 legacy 完成态仍要求每个分片同时具备 hash、processed 和稳定密钥。
+         */
+        @Test
+        void shouldRejectMissingLegacyCompletionEvidence() {
+            FileUploadState valid = completionState("legacy-complete", true);
+            assertDoesNotThrow(() -> ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "requireCompleteChunkState", valid, 1));
+
+            List<Consumer<FileUploadState>> mutations = List.of(
+                    state -> state.setUploadedChunks(null),
+                    state -> state.setProcessedChunks(null),
+                    state -> state.setChunkHashes(null),
+                    state -> state.setKeys(null),
+                    state -> state.getUploadedChunks().clear(),
+                    state -> state.getProcessedChunks().clear(),
+                    state -> state.getChunkHashes().clear(),
+                    state -> state.getKeys().clear()
+            );
+            for (Consumer<FileUploadState> mutation : mutations) {
+                FileUploadState state = completionState("legacy-missing-" + UUID.randomUUID(), true);
+                mutation.accept(state);
+                assertThrows(
+                        RetryableException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService, "requireCompleteChunkState", state, 1));
+            }
+
+            List<Consumer<FileUploadState>> indexedMutations = List.of(
+                    state -> {
+                        state.getUploadedChunks().clear();
+                        state.getUploadedChunks().add(9);
+                    },
+                    state -> {
+                        state.getProcessedChunks().clear();
+                        state.getProcessedChunks().add(9);
+                    },
+                    state -> {
+                        state.getChunkHashes().clear();
+                        state.getChunkHashes().put("chunk_9", "hash");
+                    },
+                    state -> state.getChunkHashes().put("chunk_0", " "),
+                    state -> {
+                        state.getKeys().clear();
+                        state.getKeys().put(9, new byte[]{1});
+                    },
+                    state -> state.getKeys().put(0, new byte[0])
+            );
+            for (Consumer<FileUploadState> mutation : indexedMutations) {
+                FileUploadState state = completionState("legacy-index-" + UUID.randomUUID(), true);
+                mutation.accept(state);
+                assertThrows(
+                        RetryableException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService, "requireCompleteChunkState", state, 1));
+            }
+        }
+
+        /**
+         * 验证 Base64URL 分片摘要能规范化为 manifest 的 sha256: 十六进制格式。
+         */
+        @Test
+        void shouldCanonicalizeBase64UrlChunkDigest() {
+            byte[] digest = new byte[32];
+            Arrays.fill(digest, (byte) 0x2a);
+            String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+            String expected = "sha256:" + HexFormat.of().formatHex(digest);
+            String actual = ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "canonicalSha256FromBase64Url", encoded);
+            assertEquals(expected, actual);
+        }
+
+        /**
+         * 验证缺失、过长、非法 Base64 或错误摘要长度均失败关闭。
+         */
+        @Test
+        void shouldRejectInvalidBase64UrlChunkDigest() {
+            List<String> invalidValues = List.of(
+                    "***not-base64***",
+                    Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[31]),
+                    "x".repeat(129)
+            );
+            for (String value : invalidValues) {
+                GeneralException error = assertThrows(
+                        GeneralException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService, "canonicalSha256FromBase64Url", value));
+                assertEquals(ResultEnum.FILE_RECORD_ERROR, error.getResultEnum());
+            }
+            GeneralException nullError = assertThrows(
+                    GeneralException.class,
+                    () -> ReflectionTestUtils.invokeMethod(
+                            fileUploadService, "canonicalSha256FromBase64Url", (String) null));
+            assertEquals(ResultEnum.FILE_RECORD_ERROR, nullError.getResultEnum());
+        }
+
+        /**
+         * 验证 framed v2 文件参数公开完整 descriptor，并使用 file-level DEK 作为 initialKey。
+         */
+        @Test
+        void shouldGenerateFramedFileParam() {
+            FileUploadState state = framedState("framed-param", 1);
+            state.setContentHash(CONTENT_HASH);
+            String fileParam = ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "generateFileParam", state);
+
+            assertTrue(fileParam.contains("\"encryptionAlgorithm\":\"FRAMED_AEAD_V2\""));
+            assertTrue(fileParam.contains(ChunkManifestEncryption.SUITE_FRAMED_V2));
+            assertTrue(fileParam.contains("\"formatVersion\":2"));
+            assertTrue(fileParam.contains("\"framePlainSize\":" + state.getFramePlainSize()));
+            assertTrue(fileParam.contains("\"keyDerivation\":\"HKDF-SHA256\""));
+            assertTrue(fileParam.contains("\"nonceDerivation\":\"HKDF-SHA256\""));
+            assertTrue(fileParam.contains(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2));
+            assertTrue(fileParam.contains("\"tagSize\":16"));
+            assertTrue(fileParam.contains(
+                    Base64.getEncoder().encodeToString(state.getFileDataKey())));
+            assertTrue(fileParam.contains(
+                    Base64.getUrlEncoder().withoutPadding().encodeToString(state.getFileNonce())));
+            assertTrue(fileParam.contains(CONTENT_HASH));
+        }
+
+        /**
+         * 验证 framed 文件参数不会接受缺失或错误长度的稳定加密检查点。
+         */
+        @Test
+        void shouldRejectFramedFileParamWithoutStableCheckpoint() {
+            List<Consumer<FileUploadState>> mutations = List.of(
+                    state -> state.setFileDataKey(null),
+                    state -> state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE - 1]),
+                    state -> state.setFileNonce(null),
+                    state -> state.setFileNonce(new byte[FramedAeadCrypto.FILE_NONCE_SIZE - 1]),
+                    state -> state.setFramePlainSize(null)
+            );
+            for (Consumer<FileUploadState> mutation : mutations) {
+                FileUploadState state = framedState("framed-param-invalid-" + UUID.randomUUID(), 1);
+                state.setContentHash(CONTENT_HASH);
+                mutation.accept(state);
+                GeneralException error = assertThrows(
+                        GeneralException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService, "generateFileParam", state));
+                assertEquals(ResultEnum.FILE_RECORD_ERROR, error.getResultEnum());
+            }
+        }
+
+        /**
+         * 验证 framed 分片处理会校验原文摘要、原子发布密文并提交 processed 证据。
+         */
+        @Test
+        void shouldProcessFramedChunkAndCommitEvidence() throws Exception {
+            String clientId = "framed-process-" + UUID.randomUUID();
+            FileUploadState state = framedState(clientId, 1);
+            state.getProcessedChunks().clear();
+            byte[] plain = new byte[1024];
+            Arrays.fill(plain, (byte) 4);
+            Path root = Files.createTempDirectory("framed-process-");
+            Path rawPath = root.resolve("raw/chunk_0");
+            Path processedPath = root.resolve("processed/encrypted_chunk_0");
+            Path taskPath = root.resolve("processed/task.tmp");
+            Files.createDirectories(rawPath.getParent());
+            Files.write(rawPath, plain);
+            String trustedHash = ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "calculateChunkHashBase64", rawPath);
+            state.getChunkHashes().put("chunk_0", trustedHash);
+            String plainHash = ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "canonicalSha256FromBase64Url", trustedHash);
+            when(redisStateManager.getState(clientId)).thenReturn(state);
+            doAnswer(invocation -> {
+                state.getProcessedChunks().add(0);
+                return null;
+            }).when(redisStateManager).addProcessedChunk(clientId, 0);
+            when(framedAeadWriter.write(
+                    eq(rawPath), eq(taskPath), same(state.getFileDataKey()), same(state.getFileNonce()),
+                    eq(0), eq(1), eq(state.getFramePlainSize())))
+                    .thenAnswer(invocation -> {
+                        Files.write(taskPath, new byte[]{8, 9, 10});
+                        return new FramedAeadWriter.WriteResult(
+                                1024L, 3L, 1, plainHash, "sha256:" + "11".repeat(32));
+                    });
+
+            try {
+                ReflectionTestUtils.invokeMethod(
+                        fileUploadService,
+                        "processChunkWithSessionAndChunkLocks",
+                        SUID,
+                        state,
+                        state,
+                        0,
+                        rawPath,
+                        processedPath,
+                        taskPath,
+                        trustedHash);
+
+                assertTrue(Files.isRegularFile(processedPath));
+                assertArrayEquals(new byte[]{8, 9, 10}, Files.readAllBytes(processedPath));
+                verify(redisStateManager).addProcessedChunk(clientId, 0);
+                verify(framedAeadWriter).write(
+                        eq(rawPath), eq(taskPath), any(byte[].class), any(byte[].class), eq(0), eq(1),
+                        eq(state.getFramePlainSize()));
+                assertTrue(state.getKeys().isEmpty());
+            } finally {
+                deleteTempTree(root);
+            }
+        }
+
+        /**
+         * 验证 framed 分片检查点缺失、摘要漂移和 writer IO 失败都不会发布最终文件。
+         */
+        @Test
+        void shouldFailClosedWhenProcessingFramedChunkEvidenceIsInvalid() throws Exception {
+            String clientId = "framed-process-invalid-" + UUID.randomUUID();
+            FileUploadState state = framedState(clientId, 1);
+            state.getProcessedChunks().clear();
+            Path root = Files.createTempDirectory("framed-process-invalid-");
+            Path rawPath = root.resolve("raw/chunk_0");
+            Path processedPath = root.resolve("processed/encrypted_chunk_0");
+            Path taskPath = root.resolve("processed/task.tmp");
+            Files.createDirectories(rawPath.getParent());
+            Files.write(rawPath, new byte[1024]);
+            String trustedHash = ReflectionTestUtils.invokeMethod(
+                    fileUploadService, "calculateChunkHashBase64", rawPath);
+            state.getChunkHashes().put("chunk_0", trustedHash);
+
+            try {
+                state.setFileDataKey(null);
+                GeneralException checkpointError = assertThrows(
+                        GeneralException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService,
+                                "processChunkWithSessionAndChunkLocks",
+                                SUID, state, state, 0, rawPath, processedPath, taskPath, trustedHash));
+                assertEquals(ResultEnum.FILE_RECORD_ERROR, checkpointError.getResultEnum());
+                state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE]);
+
+                String wrongHash = zeroDigestBase64Url();
+                state.getChunkHashes().put("chunk_0", wrongHash);
+                GeneralException hashError = assertThrows(
+                        GeneralException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService,
+                                "processChunkWithSessionAndChunkLocks",
+                                SUID, state, state, 0, rawPath, processedPath, taskPath, trustedHash));
+                assertEquals(ResultEnum.FILE_UPLOAD_ERROR, hashError.getResultEnum());
+                state.getChunkHashes().put("chunk_0", trustedHash);
+
+                when(framedAeadWriter.write(
+                        any(), any(), any(byte[].class), any(byte[].class), eq(0), eq(1), anyInt()))
+                        .thenThrow(new IOException("writer unavailable"));
+                assertThrows(
+                        java.io.UncheckedIOException.class,
+                        () -> ReflectionTestUtils.invokeMethod(
+                                fileUploadService,
+                                "processChunkWithSessionAndChunkLocks",
+                                SUID, state, state, 0, rawPath, processedPath, taskPath, trustedHash));
+                assertFalse(Files.exists(processedPath));
+            } finally {
+                deleteTempTree(root);
+            }
+        }
+
+        /**
+         * 验证 framed 完成处理会重新认证全部对象，并拒绝尺寸或摘要证据漂移。
+         */
+        @Test
+        void shouldVerifyFramedChunksDuringCompletion() throws Throwable {
+            FileUploadState state = framedState("framed-complete-processing", 1);
+            String plainHash = "sha256:" + "00".repeat(32);
+            when(framedAeadWriter.verify(
+                    any(Path.class), any(byte[].class), any(byte[].class), eq(0), eq(1),
+                    eq(state.getFramePlainSize())))
+                    .thenReturn(new FramedAeadWriter.WriteResult(
+                            1024L, 100L, 1, plainHash, "sha256:" + "22".repeat(32)));
+
+            assertDoesNotThrow(() -> invokeChecked(
+                    "completeFileProcessing",
+                    new Class<?>[]{String.class, FileUploadState.class},
+                    SUID,
+                    state));
+            verify(framedAeadWriter).verify(
+                    eq(Path.of("processed").toAbsolutePath().normalize()
+                            .resolve(SUID).resolve(state.getClientId()).resolve("encrypted_chunk_0")),
+                    same(state.getFileDataKey()), same(state.getFileNonce()), eq(0), eq(1),
+                    eq(state.getFramePlainSize()));
+            verify(redisStateManager, never()).getChunkKeys(anyString());
+
+            when(framedAeadWriter.verify(
+                    any(Path.class), any(byte[].class), any(byte[].class), eq(0), eq(1),
+                    eq(state.getFramePlainSize())))
+                    .thenReturn(new FramedAeadWriter.WriteResult(
+                            1L, 100L, 1, plainHash, "sha256:" + "22".repeat(32)));
+            Throwable mismatch = assertThrows(
+                    IOException.class,
+                    () -> invokeChecked(
+                            "completeFileProcessing",
+                            new Class<?>[]{String.class, FileUploadState.class},
+                            SUID,
+                            state));
+            assertTrue(mismatch.getMessage().contains("认证结果"));
+
+            state.setFileDataKey(null);
+            assertThrows(
+                    IOException.class,
+                    () -> invokeChecked(
+                            "completeFileProcessing",
+                            new Class<?>[]{String.class, FileUploadState.class},
+                            SUID,
+                            state));
+        }
+
+        /**
+         * 验证 legacy 完成处理仍按环形顺序追加 NEXT_KEY，并支持幂等重入。
+         */
+        @Test
+        void shouldCompleteLegacyFileProcessingIdempotently() throws Throwable {
+            String clientId = "legacy-complete-processing-" + UUID.randomUUID();
+            FileUploadState state = new FileUploadState(
+                    USER_ID, "legacy.bin", 2048L, "application/octet-stream", clientId, 1024, 2);
+            state.setSuid(SUID);
+            state.getChunkHashes().put("chunk_0", "plain-0");
+            state.getChunkHashes().put("chunk_1", "plain-1");
+            byte[] key0 = new byte[]{1, 2, 3};
+            byte[] key1 = new byte[]{4, 5, 6};
+            Map<Integer, byte[]> keys = new HashMap<>();
+            keys.put(0, key0);
+            keys.put(1, key1);
+            when(redisStateManager.getChunkKeys(clientId)).thenReturn(keys);
+            Path directory = Path.of("processed").toAbsolutePath().normalize()
+                    .resolve(SUID).resolve(clientId);
+            Path first = directory.resolve("encrypted_chunk_0");
+            Path second = directory.resolve("encrypted_chunk_1");
+            Files.createDirectories(directory);
+            Files.writeString(first, "cipher-0\n--HASH--\nplain-0", StandardCharsets.UTF_8);
+            Files.writeString(second, "cipher-1\n--HASH--\nplain-1", StandardCharsets.UTF_8);
+
+            try {
+                invokeChecked(
+                        "completeFileProcessing",
+                        new Class<?>[]{String.class, FileUploadState.class},
+                        SUID,
+                        state);
+                String firstContent = Files.readString(first, StandardCharsets.UTF_8);
+                String secondContent = Files.readString(second, StandardCharsets.UTF_8);
+                assertTrue(firstContent.endsWith(
+                        "\n--NEXT_KEY--\n" + Base64.getEncoder().encodeToString(key1)));
+                assertTrue(secondContent.endsWith(
+                        "\n--NEXT_KEY--\n" + Base64.getEncoder().encodeToString(key0)));
+                invokeChecked(
+                        "completeFileProcessing",
+                        new Class<?>[]{String.class, FileUploadState.class},
+                        SUID,
+                        state);
+                assertEquals(firstContent, Files.readString(first, StandardCharsets.UTF_8));
+                assertEquals(secondContent, Files.readString(second, StandardCharsets.UTF_8));
+            } finally {
+                deleteTempTree(directory);
+            }
+        }
+
+        /**
+         * 验证 legacy 完成处理在密钥证据为空、数量不足或索引缺失时失败关闭。
+         */
+        @Test
+        void shouldRejectIncompleteLegacyFileProcessingKeys() throws Throwable {
+            FileUploadState state = new FileUploadState(
+                    USER_ID, "legacy-errors.bin", 2048L, "application/octet-stream",
+                    "legacy-key-errors", 1024, 2);
+            state.setSuid(SUID);
+
+            when(redisStateManager.getChunkKeys(state.getClientId())).thenReturn(null);
+            assertThrows(IOException.class, () -> invokeChecked(
+                    "completeFileProcessing",
+                    new Class<?>[]{String.class, FileUploadState.class}, SUID, state));
+
+            when(redisStateManager.getChunkKeys(state.getClientId()))
+                    .thenReturn(Map.of(0, new byte[]{1}));
+            assertThrows(IOException.class, () -> invokeChecked(
+                    "completeFileProcessing",
+                    new Class<?>[]{String.class, FileUploadState.class}, SUID, state));
+
+            Map<Integer, byte[]> missing = new HashMap<>();
+            missing.put(0, null);
+            missing.put(1, new byte[]{2});
+            when(redisStateManager.getChunkKeys(state.getClientId())).thenReturn(missing);
+            assertThrows(IOException.class, () -> invokeChecked(
+                    "completeFileProcessing",
+                    new Class<?>[]{String.class, FileUploadState.class}, SUID, state));
+
+            state.setTotalChunks(0);
+            when(redisStateManager.getChunkKeys(state.getClientId())).thenReturn(Map.of());
+            assertDoesNotThrow(() -> invokeChecked(
+                    "completeFileProcessing",
+                    new Class<?>[]{String.class, FileUploadState.class}, SUID, state));
+        }
+
+        /**
+         * 直接调用私有方法并向测试暴露其原始 checked exception，避免反射包装掩盖失败原因。
+         */
+        private Object invokeChecked(String methodName, Class<?>[] parameterTypes, Object... arguments)
+                throws Throwable {
+            Method method = FileUploadServiceImpl.class.getDeclaredMethod(methodName, parameterTypes);
+            method.setAccessible(true);
+            try {
+                return method.invoke(fileUploadService, arguments);
+            } catch (InvocationTargetException invocationError) {
+                throw invocationError.getCause();
+            }
+        }
+
+        /**
+         * 递归删除本组测试创建的临时目录。
+         */
+        private void deleteTempTree(Path root) throws IOException {
+            if (!Files.exists(root)) {
+                return;
+            }
+            try (var paths = Files.walk(root)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException error) {
+                        throw new IllegalStateException(error);
+                    }
+                });
+            }
+        }
+
+        /**
+         * 构造包含稳定 framed v2 检查点和逐分片摘要的测试状态。
+         */
+        private FileUploadState framedState(String clientId, int totalChunks) {
+            int chunkSize = 1024;
+            FileUploadState state = new FileUploadState(
+                    USER_ID,
+                    "framed-" + clientId + ".bin",
+                    (long) chunkSize * totalChunks,
+                    "application/octet-stream",
+                    clientId,
+                    chunkSize,
+                    totalChunks);
+            state.setTenantId(77L);
+            state.setSuid(SUID);
+            state.setEncryptionRecoveryVersion(2);
+            state.setEncryptionFormatVersion(FramedAeadCrypto.FORMAT_VERSION);
+            state.setEncryptionAlgorithmSuite(ChunkManifestEncryption.SUITE_FRAMED_V2);
+            state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE]);
+            state.setFileNonce(new byte[FramedAeadCrypto.FILE_NONCE_SIZE]);
+            state.setFramePlainSize(ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE);
+            state.setKeyDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setNonceDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setAadSchema(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2);
+            state.setTagSize(FramedAeadCrypto.TAG_SIZE);
+            for (int index = 0; index < totalChunks; index++) {
+                state.getUploadedChunks().add(index);
+                state.getProcessedChunks().add(index);
+                state.getChunkHashes().put("chunk_" + index, zeroDigestBase64Url());
+            }
+            return state;
+        }
+
+        /**
+         * 返回固定的 32 字节摘要，供反射测试构造稳定的 Base64URL 检查点。
+         */
+        private String zeroDigestBase64Url() {
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[32]);
+        }
+    }
+
+    @Nested
     @DisplayName("Framed DB SUCCESS Recovery")
     class FramedDbSuccessRecovery {
+
+        /**
+         * 验证 DB 已成功且 active manifest 可确认时，恢复流程先保存 manifest 检查点再清理临时证据。
+         */
+        @Test
+        void shouldRecoverFramedDbSuccessAfterManifestConfirmation() throws Exception {
+            String clientId = "framed-recovery-success-" + UUID.randomUUID();
+            long fileId = 9400L;
+            FileUploadState state = completionState(clientId, true);
+            state.getKeys().clear();
+            state.setPrepareStored(true);
+            state.setPreparedFileId(fileId);
+            state.setContentHash(CONTENT_HASH);
+            state.setEncryptionRecoveryVersion(2);
+            state.setEncryptionFormatVersion(FramedAeadCrypto.FORMAT_VERSION);
+            state.setEncryptionAlgorithmSuite(ChunkManifestEncryption.SUITE_FRAMED_V2);
+            state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE]);
+            state.setFileNonce(new byte[FramedAeadCrypto.FILE_NONCE_SIZE]);
+            state.setFramePlainSize(64 * 1024);
+            state.setKeyDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setNonceDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+            state.setAadSchema(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2);
+            state.setTagSize(FramedAeadCrypto.TAG_SIZE);
+
+            Path uploadDir = Path.of("uploads").toAbsolutePath().normalize()
+                    .resolve(SUID).resolve(clientId);
+            Path processedDir = Path.of("processed").toAbsolutePath().normalize()
+                    .resolve(SUID).resolve(clientId);
+            Files.createDirectories(uploadDir);
+            Files.createDirectories(processedDir);
+            Files.writeString(uploadDir.resolve("raw-evidence"), "raw", StandardCharsets.UTF_8);
+            Files.write(processedDir.resolve("encrypted_chunk_0"), new byte[]{4, 5, 6});
+            state.setUploadTempPath(uploadDir.toString());
+            state.setProcessedTempPath(processedDir.toString());
+
+            File persistedFile = new File()
+                    .setId(fileId)
+                    .setUid(USER_ID)
+                    .setTenantId(77L)
+                    .setFileName(state.getFileName())
+                    .setFileSize(state.getFileSize())
+                    .setFileHash("persisted-file-hash")
+                    .setTransactionHash("tx-9400")
+                    .setContentHash(CONTENT_HASH)
+                    .setStatus(FileUploadStatus.SUCCESS.getCode());
+            ChunkManifestView manifest = new ChunkManifestView(
+                    1L,
+                    fileId,
+                    1,
+                    "cn.flying.chunk-manifest.v1",
+                    persistedFile.getFileHash(),
+                    "manifest-hash-9400",
+                    "SHA-256",
+                    state.getChunkSize(),
+                    state.getTotalChunks(),
+                    state.getFileSize(),
+                    null,
+                    "FRAMED_AEAD_V2",
+                    "S3",
+                    List.of());
+            when(fileService.getById(fileId)).thenReturn(persistedFile);
+            when(redisStateManager.getState(clientId)).thenReturn(state);
+            when(framedManifestFinalizationService.ensureManifest(
+                    eq(USER_ID), eq(persistedFile), eq(state), anyList(), anyList()))
+                    .thenReturn(Optional.of(manifest));
+
+            try {
+                Boolean recovered = ReflectionTestUtils.invokeMethod(
+                        fileUploadService,
+                        "recoverLegacySuccessFinalization",
+                        USER_ID,
+                        SUID,
+                        state);
+
+                assertTrue(recovered);
+                assertEquals("manifest-hash-9400", state.getManifestHash());
+                assertFalse(Files.exists(uploadDir));
+                assertFalse(Files.exists(processedDir));
+                verify(redisStateManager).updateState(state);
+                verify(redisStateManager).markCompleted(clientId, SUID, 300);
+                verify(framedManifestFinalizationService).ensureManifest(
+                        eq(USER_ID), eq(persistedFile), eq(state),
+                        argThat(files -> files.size() == 1),
+                        argThat(hashes -> hashes.size() == 1 && hashes.get(0).startsWith("sha256:")));
+            } finally {
+                deleteTree(uploadDir);
+                deleteTree(processedDir);
+            }
+        }
 
         /**
          * 验证 active manifest 校验或保存失败时，恢复流程不会先清理唯一临时证据或标记 completed。

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/key/CryptoSuitePolicyServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/key/CryptoSuitePolicyServiceTest.java
@@ -1,0 +1,98 @@
+package cn.flying.service.key;
+
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * 验证文件元数据显式算法套件的 allowlist 与废弃策略。
+ */
+@DisplayName("CryptoSuitePolicyService")
+class CryptoSuitePolicyServiceTest {
+
+    private static final String LEGACY_SUITE = "RP-AES256-GCM-CHUNK-CHAIN-V1";
+    private static final String FRAMED_SUITE = "RP-AES256-GCM-FRAMED-V2";
+
+    private FileKeyEnvelopeProperties properties;
+    private CryptoSuitePolicyService policyService;
+
+    /**
+     * 为每个用例创建独立的密码套件配置，避免废弃状态相互污染。
+     */
+    @BeforeEach
+    void setUp() {
+        properties = new FileKeyEnvelopeProperties();
+        properties.setSupportedAlgorithmSuites(
+                new LinkedHashSet<>(Set.of(LEGACY_SUITE, FRAMED_SUITE)));
+        policyService = new CryptoSuitePolicyService(properties);
+    }
+
+    /**
+     * 验证 allowlist 内的 legacy 和 framed 套件均可用于受控 writer 回滚与升级。
+     */
+    @Test
+    void validateAlgorithmSuite_shouldAcceptSupportedSuites() {
+        assertDoesNotThrow(() -> policyService.validateAlgorithmSuite(LEGACY_SUITE));
+        assertDoesNotThrow(() -> policyService.validateAlgorithmSuite(FRAMED_SUITE));
+    }
+
+    /**
+     * 验证空值和 allowlist 外的套件返回参数错误。
+     */
+    @Test
+    void validateAlgorithmSuite_shouldRejectBlankAndUnsupportedSuites() {
+        GeneralException nullSuite = assertThrows(
+                GeneralException.class,
+                () -> policyService.validateAlgorithmSuite(null));
+        GeneralException blankSuite = assertThrows(
+                GeneralException.class,
+                () -> policyService.validateAlgorithmSuite("  "));
+        GeneralException unsupportedSuite = assertThrows(
+                GeneralException.class,
+                () -> policyService.validateAlgorithmSuite("UNKNOWN-SUITE"));
+
+        assertThat(nullSuite.getResultEnum()).isEqualTo(ResultEnum.PARAM_ERROR);
+        assertThat(blankSuite.getResultEnum()).isEqualTo(ResultEnum.PARAM_ERROR);
+        assertThat(unsupportedSuite.getResultEnum()).isEqualTo(ResultEnum.PARAM_ERROR);
+    }
+
+    /**
+     * 验证显式废弃列表中的套件即使仍在 allowlist 中也必须被拒绝。
+     */
+    @Test
+    void validateAlgorithmSuite_shouldRejectExplicitlyDeprecatedSuite() {
+        properties.setDeprecatedSuites(new LinkedHashSet<>(Set.of(FRAMED_SUITE)));
+
+        GeneralException error = assertThrows(
+                GeneralException.class,
+                () -> policyService.validateAlgorithmSuite(FRAMED_SUITE));
+
+        assertThat(error.getResultEnum()).isEqualTo(ResultEnum.PARAM_ERROR);
+        assertThat(error.getData()).asString().contains("已废弃的密码套件");
+    }
+
+    /**
+     * 验证全局废弃时间到期后，当前显式算法套件也停止接受。
+     */
+    @Test
+    void validateAlgorithmSuite_shouldRejectSuiteAfterGlobalDeprecation() {
+        properties.setDeprecatedAfter(Instant.now().minusSeconds(1));
+
+        GeneralException error = assertThrows(
+                GeneralException.class,
+                () -> policyService.validateAlgorithmSuite(FRAMED_SUITE));
+
+        assertThat(error.getResultEnum()).isEqualTo(ResultEnum.PARAM_ERROR);
+        assertThat(error.getData()).asString().contains("当前密码套件已废弃");
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/ChunkManifestCanonicalizerTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/ChunkManifestCanonicalizerTest.java
@@ -116,15 +116,7 @@ class ChunkManifestCanonicalizerTest {
      */
     @Test
     void normalize_shouldUsePlainSizeForFramedV2Total() {
-        ChunkManifestEncryption encryption = new ChunkManifestEncryption(
-                ChunkManifestEncryption.FORMAT_FRAMED_V2,
-                ChunkManifestEncryption.SUITE_FRAMED_V2,
-                "AAAAAAAAAAAAAAAAAAAAAA",
-                64 * 1024,
-                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
-                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
-                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
-                ChunkManifestEncryption.TAG_SIZE_BYTES);
+        ChunkManifestEncryption encryption = framedEncryption();
         ChunkManifestDraft draft = new ChunkManifestDraft(
                 null,
                 "file-hash",
@@ -150,6 +142,168 @@ class ChunkManifestCanonicalizerTest {
         assertThat(canonicalizer.manifestHash(draft)).startsWith("sha256:");
     }
 
+    /**
+     * 验证 framed v2 descriptor 的持久化 JSON 能复用同一 allowlist 并无损往返。
+     */
+    @Test
+    void encryptionJson_shouldRoundTripValidatedFramedDescriptor() {
+        ChunkManifestEncryption encryption = framedEncryption();
+
+        String json = canonicalizer.encryptionJson(encryption);
+
+        assertThat(json).contains("\"formatVersion\":2", "\"algorithmSuite\":\"RP-AES256-GCM-FRAMED-V2\"");
+        assertThat(canonicalizer.parseEncryptionJson(json)).isEqualTo(encryption);
+        assertThat(canonicalizer.encryptionJson(null)).isNull();
+        assertThat(canonicalizer.parseEncryptionJson("  ")).isNull();
+    }
+
+    /**
+     * 验证数据库中的损坏 descriptor 会转换为稳定的文件记录错误。
+     */
+    @Test
+    void parseEncryptionJson_shouldRejectMalformedDescriptor() {
+        assertThatThrownBy(() -> canonicalizer.parseEncryptionJson("{not-json"))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("格式无效"));
+    }
+
+    /**
+     * 验证 NONE/legacy descriptor 不得夹带任何 framed v2 专属字段。
+     */
+    @Test
+    void normalize_shouldRejectLegacyDescriptorContainingFramedFields() {
+        ChunkManifestEncryption invalid = new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_NONE,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        assertThatThrownBy(() -> canonicalizer.encryptionJson(invalid))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("must not contain v2 fields"));
+    }
+
+    /**
+     * 验证未知格式、套件、frame 上限和非规范 nonce 均失败关闭。
+     */
+    @Test
+    void normalize_shouldRejectInvalidFramedDescriptorVariants() {
+        assertThatThrownBy(() -> canonicalizer.encryptionJson(new ChunkManifestEncryption(
+                99, null, null, null, null, null, null, null)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("formatVersion"));
+
+        assertThatThrownBy(() -> canonicalizer.encryptionJson(new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                "UNKNOWN-SUITE",
+                "AAAAAAAAAAAAAAAAAAAAAA",
+                64 * 1024,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                ChunkManifestEncryption.TAG_SIZE_BYTES)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("allowlist"));
+
+        assertThatThrownBy(() -> canonicalizer.encryptionJson(new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                "AAAAAAAAAAAAAAAAAAAAAA",
+                ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE - 1,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                ChunkManifestEncryption.TAG_SIZE_BYTES)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("framePlainSize"));
+
+        assertThatThrownBy(() -> canonicalizer.encryptionJson(new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                "%%%",
+                64 * 1024,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                ChunkManifestEncryption.TAG_SIZE_BYTES)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("fileNonce"));
+    }
+
+    /**
+     * 验证 v2 分片必须携带正数 plainSize/frameCount，并满足精确密文字节公式。
+     */
+    @Test
+    void normalize_shouldRejectInvalidFramedChunkEvidenceVariants() {
+        assertThatThrownBy(() -> canonicalizer.normalize(framedDraft(
+                new ChunkManifestChunk(0, canonicalHash('a'), canonicalHash('b'), 72L,
+                        "storage/tenant/7/chunk/0", "S3", null, "SHA-256", 0L, 1),
+                1L)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("plainSize must be positive"));
+
+        assertThatThrownBy(() -> canonicalizer.normalize(framedDraft(
+                new ChunkManifestChunk(0, canonicalHash('a'), canonicalHash('b'), 73L,
+                        "storage/tenant/7/chunk/0", "S3", null, "SHA-256", 1L, 0),
+                1L)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("frameCount must be positive"));
+
+        assertThatThrownBy(() -> canonicalizer.normalize(framedDraft(
+                new ChunkManifestChunk(0, canonicalHash('a'), canonicalHash('b'), 73L,
+                        "storage/tenant/7/chunk/0", "S3", null, "SHA-256", null, null),
+                1L)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("plainSize and frameCount are required"));
+
+        assertThatThrownBy(() -> canonicalizer.normalize(framedDraft(
+                new ChunkManifestChunk(0, canonicalHash('a'), canonicalHash('b'), 74L,
+                        "storage/tenant/7/chunk/0", "S3", null, "SHA-256", 1L, 1),
+                1L)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("inconsistent"));
+    }
+
+    /**
+     * 验证 v2 manifest 的 totalSize 明确按明文总量校验。
+     */
+    @Test
+    void normalize_shouldRejectFramedPlainTotalMismatch() {
+        ChunkManifestChunk chunk = new ChunkManifestChunk(
+                0, canonicalHash('a'), canonicalHash('b'), 73L,
+                "storage/tenant/7/chunk/0", "S3", null, "SHA-256", 1L, 1);
+
+        assertThatThrownBy(() -> canonicalizer.normalize(framedDraft(chunk, 2L)))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getData())
+                        .asString()
+                        .contains("sum of chunk plain sizes"));
+    }
+
     private ChunkManifestDraft draft(List<ChunkManifestChunk> chunks) {
         return new ChunkManifestDraft(
                 null,
@@ -166,5 +320,44 @@ class ChunkManifestCanonicalizerTest {
 
     private ChunkManifestChunk chunk(int index, String plainHash, String cipherHash, long size, String storagePath) {
         return new ChunkManifestChunk(index, plainHash, cipherHash, size, storagePath, null, null, null);
+    }
+
+    /**
+     * 构造 allowlist 内的 framed v2 descriptor。
+     */
+    private ChunkManifestEncryption framedEncryption() {
+        return new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                "AAAAAAAAAAAAAAAAAAAAAA",
+                64 * 1024,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                ChunkManifestEncryption.TAG_SIZE_BYTES);
+    }
+
+    /**
+     * 构造单分片 framed v2 draft，便于逐项验证分片证据。
+     */
+    private ChunkManifestDraft framedDraft(ChunkManifestChunk chunk, long totalSize) {
+        return new ChunkManifestDraft(
+                null,
+                "file-hash",
+                null,
+                64 * 1024L,
+                totalSize,
+                null,
+                "FRAMED_AEAD_V2",
+                "S3",
+                framedEncryption(),
+                List.of(chunk));
+    }
+
+    /**
+     * 构造规范 sha256 摘要。
+     */
+    private String canonicalHash(char value) {
+        return "sha256:" + String.valueOf(value).repeat(64);
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/ChunkManifestCanonicalizerTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/ChunkManifestCanonicalizerTest.java
@@ -12,7 +12,35 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("ChunkManifestCanonicalizer")
 class ChunkManifestCanonicalizerTest {
 
+    private static final String LEGACY_CANONICAL_JSON =
+            "{\"chunkSize\":10,\"chunks\":["
+                    + "{\"checksumAlgorithm\":\"SHA-256\",\"cipherHash\":\"cipher-0\","
+                    + "\"index\":0,\"plainHash\":\"plain-0\",\"size\":6,"
+                    + "\"storageBackend\":\"S3\",\"storagePath\":\"storage/tenant/7/chunk/0\"},"
+                    + "{\"checksumAlgorithm\":\"SHA-256\",\"cipherHash\":\"cipher-1\","
+                    + "\"index\":1,\"plainHash\":\"plain-1\",\"size\":4,"
+                    + "\"storageBackend\":\"S3\",\"storagePath\":\"storage/tenant/7/chunk/1\"}],"
+                    + "\"encryptionAlgorithm\":\"CHACHA20_POLY1305\",\"fileHash\":\"file-hash\","
+                    + "\"hashAlgorithm\":\"SHA-256\",\"schema\":\"cn.flying.chunk-manifest.v1\","
+                    + "\"storageBackend\":\"S3\",\"totalSize\":10}";
+    private static final String LEGACY_MANIFEST_HASH =
+            "sha256:5ca61f7ea9db649d569246fef159cd785d79e20d820b1fe19deed4e1b7450791";
+
     private final ChunkManifestCanonicalizer canonicalizer = new ChunkManifestCanonicalizer();
+
+    /**
+     * 验证旧 manifest 的 null encryption/plainSize/frameCount 字段仍产生与 main 基线完全相同的字节和 hash。
+     */
+    @Test
+    void legacyNullFields_shouldRemainByteIdenticalToMainCanonicalContract() {
+        ChunkManifestDraft legacyDraft = draft(List.of(
+                chunk(1, " plain-1 ", " cipher-1 ", 4L, " storage/tenant/7/chunk/1 "),
+                chunk(0, "plain-0", "cipher-0", 6L, "storage/tenant/7/chunk/0")
+        ));
+
+        assertThat(canonicalizer.canonicalJson(legacyDraft)).isEqualTo(LEGACY_CANONICAL_JSON);
+        assertThat(canonicalizer.manifestHash(legacyDraft)).isEqualTo(LEGACY_MANIFEST_HASH);
+    }
 
     /**
      * Verifies canonical hashing is stable across input chunk order and whitespace.
@@ -81,6 +109,45 @@ class ChunkManifestCanonicalizerTest {
                 .satisfies(ex -> assertThat(((GeneralException) ex).getData())
                         .asString()
                         .contains("sum of chunk sizes"));
+    }
+
+    /**
+     * 验证 framed v2 的 totalSize 使用明文分片总量，而不是密文对象字节总量。
+     */
+    @Test
+    void normalize_shouldUsePlainSizeForFramedV2Total() {
+        ChunkManifestEncryption encryption = new ChunkManifestEncryption(
+                ChunkManifestEncryption.FORMAT_FRAMED_V2,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                "AAAAAAAAAAAAAAAAAAAAAA",
+                64 * 1024,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                ChunkManifestEncryption.TAG_SIZE_BYTES);
+        ChunkManifestDraft draft = new ChunkManifestDraft(
+                null,
+                "file-hash",
+                null,
+                64 * 1024L,
+                64 * 1024L + 3,
+                null,
+                "FRAMED_AEAD_V2",
+                "S3",
+                encryption,
+                List.of(
+                        new ChunkManifestChunk(0, "sha256:" + "a".repeat(64),
+                                "sha256:" + "b".repeat(64), 65_608L,
+                                "storage/tenant/7/chunk/sha256:" + "b".repeat(64),
+                                "S3", null, "SHA-256", 64 * 1024L, 1),
+                        new ChunkManifestChunk(1, "sha256:" + "c".repeat(64),
+                                "sha256:" + "d".repeat(64), 75L,
+                                "storage/tenant/7/chunk/sha256:" + "d".repeat(64),
+                                "S3", null, "SHA-256", 3L, 1)
+                ));
+
+        assertThat(canonicalizer.normalize(draft).totalSize()).isEqualTo(64 * 1024L + 3);
+        assertThat(canonicalizer.manifestHash(draft)).startsWith("sha256:");
     }
 
     private ChunkManifestDraft draft(List<ChunkManifestChunk> chunks) {

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/FramedManifestFinalizationServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/FramedManifestFinalizationServiceTest.java
@@ -10,6 +10,7 @@ import cn.flying.platformapi.response.FileDetailVO;
 import cn.flying.service.encryption.FramedAeadCrypto;
 import cn.flying.service.encryption.FramedAeadWriter;
 import cn.flying.service.remote.FileRemoteClient;
+import cn.flying.service.support.StoredObjectReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,8 +29,11 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -540,6 +545,375 @@ class FramedManifestFinalizationServiceTest {
                 .contains("明文大小不一致");
 
         verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 逐项验证 framed v2 Redis 不可变检查点，确保长短路条件的每个失败分支都关闭。
+     */
+    @Test
+    void validateFramedState_shouldRejectEveryImmutableCheckpointVariant() {
+        List<Consumer<FileUploadState>> invalidMutations = List.of(
+                state -> state.setEncryptionRecoveryVersion(null),
+                state -> state.setEncryptionRecoveryVersion(1),
+                state -> state.setEncryptionFormatVersion(1),
+                state -> state.setEncryptionAlgorithmSuite("legacy"),
+                state -> state.setFileDataKey(null),
+                state -> state.setFileDataKey(new byte[FramedAeadCrypto.FILE_DEK_SIZE - 1]),
+                state -> state.setFileNonce(null),
+                state -> state.setFileNonce(new byte[FramedAeadCrypto.FILE_NONCE_SIZE - 1]),
+                state -> state.setFramePlainSize(null),
+                state -> state.setFramePlainSize(ChunkManifestEncryption.MIN_FRAME_PLAIN_SIZE - 1),
+                state -> state.setFramePlainSize(ChunkManifestEncryption.MAX_FRAME_PLAIN_SIZE + 1),
+                state -> state.setKeyDerivation("PBKDF2"),
+                state -> state.setNonceDerivation("PBKDF2"),
+                state -> state.setAadSchema("other-aad"),
+                state -> state.setTagSize(12),
+                state -> state.setFileSize(0),
+                state -> state.setChunkSize(0),
+                state -> state.setTotalChunks(0)
+        );
+
+        ReflectionTestUtils.invokeMethod(finalizationService, "validateFramedState", framedState());
+        assertThrows(GeneralException.class,
+                () -> ReflectionTestUtils.invokeMethod(finalizationService, "validateFramedState", (Object) null));
+        for (Consumer<FileUploadState> mutation : invalidMutations) {
+            FileUploadState state = framedState();
+            mutation.accept(state);
+            assertThrows(GeneralException.class,
+                    () -> ReflectionTestUtils.invokeMethod(finalizationService, "validateFramedState", state));
+        }
+
+        FileUploadState inconsistentPlan = framedState();
+        inconsistentPlan.setFileSize(34L);
+        assertThrows(GeneralException.class,
+                () -> ReflectionTestUtils.invokeMethod(
+                        finalizationService, "validateFramedState", inconsistentPlan));
+
+        FileUploadState withoutManifestCheckpoint = framedState();
+        withoutManifestCheckpoint.setManifestHash(null);
+        ReflectionTestUtils.invokeMethod(finalizationService, "validateFramedState", withoutManifestCheckpoint);
+    }
+
+    /**
+     * 穷举文件身份与 fileParam 的稳定字段漂移，覆盖每个短路条件而不依赖远程服务。
+     */
+    @Test
+    void validationHelpers_shouldRejectEveryIdentityAndFileParamDrift() {
+        assertIdentityFailure(null, framedFile(), framedState());
+        assertIdentityFailure(USER_ID, null, framedState());
+        assertIdentityFailure(USER_ID, framedFile().setId(null), framedState());
+        assertIdentityFailure(USER_ID, framedFile().setFileHash(" "), framedState());
+        assertIdentityFailure(USER_ID, framedFile().setTenantId(null), framedState());
+
+        FileUploadState missingTenant = framedState();
+        missingTenant.setTenantId(null);
+        assertIdentityFailure(USER_ID, framedFile(), missingTenant);
+        FileUploadState missingUser = framedState();
+        missingUser.setUserId(null);
+        assertIdentityFailure(USER_ID, framedFile(), missingUser);
+        FileUploadState missingPreparedFile = framedState();
+        missingPreparedFile.setPreparedFileId(null);
+        assertIdentityFailure(USER_ID, framedFile(), missingPreparedFile);
+        FileUploadState wrongSize = framedState();
+        wrongSize.setFileSize(34L);
+        assertIdentityFailure(USER_ID, framedFile(), wrongSize);
+        FileUploadState wrongTenant = framedState();
+        wrongTenant.setTenantId(TENANT_ID + 1);
+        assertIdentityFailure(USER_ID, framedFile(), wrongTenant);
+        FileUploadState wrongUser = framedState();
+        wrongUser.setUserId(USER_ID + 1);
+        assertIdentityFailure(USER_ID, framedFile(), wrongUser);
+        FileUploadState wrongPreparedFile = framedState();
+        wrongPreparedFile.setPreparedFileId(FILE_ID + 1);
+        assertIdentityFailure(USER_ID, framedFile(), wrongPreparedFile);
+
+        ReflectionTestUtils.invokeMethod(
+                finalizationService, "validateFileIdentity", USER_ID, framedFile(), framedState());
+
+        Map<String, String> fileParamDrifts = new LinkedHashMap<>();
+        fileParamDrifts.put("null", "null");
+        fileParamDrifts.put("algorithm", framedFile().getFileParam()
+                .replace("\"encryptionAlgorithm\":\"FRAMED_AEAD_V2\"", "\"encryptionAlgorithm\":\"NONE\""));
+        fileParamDrifts.put("suite", framedFile().getFileParam()
+                .replace("RP-AES256-GCM-FRAMED-V2", "OTHER-SUITE"));
+        fileParamDrifts.put("nonce", framedFile().getFileParam()
+                .replace("AQIDBAUGBwgJCgsMDQ4PEA", "ERITFBUWFxgZGhscHR4fIA"));
+        fileParamDrifts.put("keyDerivation", framedFile().getFileParam()
+                .replace("\"keyDerivation\":\"HKDF-SHA256\"", "\"keyDerivation\":\"OTHER\""));
+        fileParamDrifts.put("nonceDerivation", framedFile().getFileParam()
+                .replace("\"nonceDerivation\":\"HKDF-SHA256\"", "\"nonceDerivation\":\"OTHER\""));
+        fileParamDrifts.put("aad", framedFile().getFileParam()
+                .replace("cn.flying.framed-aead.aad.v2", "other-aad"));
+        fileParamDrifts.put("format", framedFile().getFileParam()
+                .replace("\"formatVersion\":2", "\"formatVersion\":1"));
+        fileParamDrifts.put("frameSize", framedFile().getFileParam()
+                .replace("\"framePlainSize\":65536", "\"framePlainSize\":131072"));
+        fileParamDrifts.put("tag", framedFile().getFileParam()
+                .replace("\"tagSize\":16", "\"tagSize\":12"));
+        fileParamDrifts.put("fileSize", framedFile().getFileParam()
+                .replace("\"fileSize\":33", "\"fileSize\":34"));
+        fileParamDrifts.put("chunkSize", framedFile().getFileParam()
+                .replace("\"chunkSize\":33", "\"chunkSize\":32"));
+        fileParamDrifts.put("chunkCount", framedFile().getFileParam()
+                .replace("\"chunkCount\":1", "\"chunkCount\":2"));
+        fileParamDrifts.put("malformed", "{not-json");
+
+        for (String fileParam : fileParamDrifts.values()) {
+            assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                    finalizationService, "validateFileParam", framedFile().setFileParam(fileParam), framedState()));
+        }
+        ReflectionTestUtils.invokeMethod(
+                finalizationService, "validateFileParam", framedFile(), framedState());
+    }
+
+    /**
+     * 验证 active manifest 顶层、分片和 canonical hash 的每项不可变证据。
+     */
+    @Test
+    void validateActiveManifest_shouldRejectEveryTopLevelAndChunkDrift() {
+        when(chunkManifestService.calculateManifestHash(any())).thenReturn(MANIFEST_HASH);
+
+        Map<String, Object> topLevelDrifts = new LinkedHashMap<>();
+        topLevelDrifts.put("fileId", FILE_ID + 1);
+        topLevelDrifts.put("fileVersion", 2);
+        topLevelDrifts.put("fileHash", "other-hash");
+        topLevelDrifts.put("schemaId", "other-schema");
+        topLevelDrifts.put("hashAlgorithm", "SHA-512");
+        topLevelDrifts.put("chunkSize", 32L);
+        topLevelDrifts.put("chunkCount", null);
+        topLevelDrifts.put("totalSize", 34L);
+        topLevelDrifts.put("encryptionAlgorithm", "AES-GCM");
+        topLevelDrifts.put("storageBackend", "MINIO");
+        topLevelDrifts.put("encryption", null);
+        topLevelDrifts.put("chunks", List.of());
+
+        assertActiveManifestFailure(null, framedState());
+        for (Map.Entry<String, Object> drift : topLevelDrifts.entrySet()) {
+            assertActiveManifestFailure(copyManifest(activeManifest(), drift.getKey(), drift.getValue()), framedState());
+        }
+
+        Map<String, Object> chunkDrifts = new LinkedHashMap<>();
+        chunkDrifts.put("index", 1);
+        chunkDrifts.put("plainSize", 32L);
+        chunkDrifts.put("frameCount", 2);
+        chunkDrifts.put("size", 104L);
+        chunkDrifts.put("plainHash", "not-a-hash");
+        chunkDrifts.put("cipherHash", "not-a-hash");
+        chunkDrifts.put("checksumAlgorithm", "SHA-512");
+        chunkDrifts.put("storageBackend", "MINIO");
+        chunkDrifts.put("storagePath", " ");
+        for (Map.Entry<String, Object> drift : chunkDrifts.entrySet()) {
+            ChunkManifestChunk chunk = copyChunk(
+                    activeManifest().chunks().getFirst(), drift.getKey(), drift.getValue());
+            assertActiveManifestFailure(
+                    copyManifest(activeManifest(), "chunks", List.of(chunk)), framedState());
+        }
+
+        ChunkManifestChunk wrongTenantPath = copyChunk(
+                activeManifest().chunks().getFirst(), "storagePath",
+                "storage/tenant/999/chunk/" + CIPHER_HASH);
+        assertActiveManifestFailure(
+                copyManifest(activeManifest(), "chunks", List.of(wrongTenantPath)), framedState());
+
+        when(chunkManifestService.calculateManifestHash(any())).thenReturn("sha256:" + "d".repeat(64));
+        assertActiveManifestFailure(activeManifest(), framedState());
+        when(chunkManifestService.calculateManifestHash(any())).thenReturn(MANIFEST_HASH);
+        FileUploadState mismatchedCheckpoint = framedState();
+        mismatchedCheckpoint.setManifestHash("sha256:" + "d".repeat(64));
+        assertActiveManifestFailure(activeManifest(), mismatchedCheckpoint);
+
+        FileUploadState overflowState = framedState();
+        overflowState.setFileSize(Long.MAX_VALUE);
+        overflowState.setChunkSize(1);
+        overflowState.setTotalChunks(1);
+        ChunkManifestView overflowManifest = copyManifest(activeManifest(), "chunkSize", 1L);
+        overflowManifest = copyManifest(overflowManifest, "totalSize", Long.MAX_VALUE);
+        assertActiveManifestFailure(overflowManifest, overflowState);
+    }
+
+    /**
+     * 验证引用、摘要、路径和分片尺寸辅助函数覆盖安全与兼容格式边界。
+     */
+    @Test
+    void referenceAndDigestHelpers_shouldCoverAllSafetyBranches() throws IOException {
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "isFramedV2", (Object) null)).isFalse();
+        FileUploadState formatOnly = framedState();
+        formatOnly.setEncryptionAlgorithmSuite(null);
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", formatOnly)).isTrue();
+        FileUploadState suiteOnly = framedState();
+        suiteOnly.setEncryptionFormatVersion(null);
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", suiteOnly)).isTrue();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", new FileUploadState())).isFalse();
+
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", (File) null)).isFalse();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", new File().setFileParam(" "))).isFalse();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", new File().setFileParam("{\"formatVersion\":2}"))).isTrue();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", new File().setFileParam(
+                        "{\"algorithmSuite\":\"RP-AES256-GCM-FRAMED-V2\"}"))).isTrue();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", new File().setFileParam("{\"formatVersion\":1}"))).isFalse();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "declaresFramedV2", new File().setFileParam("{not-json"))).isFalse();
+
+        assertThat((Long) ReflectionTestUtils.invokeMethod(
+                finalizationService, "expectedPlainChunkSize", twoChunkState(), 0)).isEqualTo(33L);
+        assertThat((Long) ReflectionTestUtils.invokeMethod(
+                finalizationService, "expectedPlainChunkSize", twoChunkState(), 1)).isEqualTo(1L);
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "expectedPlainChunkSize", twoChunkState(), -1));
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "expectedPlainChunkSize", twoChunkState(), 2));
+
+        String base64Digest = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[32]);
+        assertThat((String) ReflectionTestUtils.invokeMethod(
+                finalizationService, "normalizeDigest", "A".repeat(64)))
+                .isEqualTo("sha256:" + "a".repeat(64));
+        assertThat((String) ReflectionTestUtils.invokeMethod(
+                finalizationService, "normalizeDigest", base64Digest))
+                .isEqualTo("sha256:" + "0".repeat(64));
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "normalizeDigest", " "));
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "normalizeDigest", "x".repeat(2049)));
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "normalizeDigest", "AQID"));
+
+        String safePath = storagePath(CIPHER_HASH);
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "containsUnsafePathText", safePath)).isFalse();
+        for (String unsafe : List.of("/absolute", "../relative", "control\npath", "windows\\path")) {
+            assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                    finalizationService, "containsUnsafePathText", unsafe)).isTrue();
+        }
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "isTenantStoragePath", TENANT_ID, safePath, CIPHER_HASH)).isTrue();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "isTenantStoragePath", null, safePath, CIPHER_HASH)).isFalse();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "isTenantStoragePath", TENANT_ID, " ", CIPHER_HASH)).isFalse();
+        assertThat((Boolean) ReflectionTestUtils.invokeMethod(
+                finalizationService, "isTenantStoragePath", TENANT_ID,
+                "storage/tenant/999/chunk/" + CIPHER_HASH, CIPHER_HASH)).isFalse();
+
+        FileUploadState state = framedState();
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "validateReferences", framedFile(), state, null, List.of(CIPHER_HASH)));
+        assertReferenceFailure(new StoredObjectReference(1, CIPHER_HASH, safePath));
+        assertReferenceFailure(new StoredObjectReference(0, " ", safePath));
+        assertReferenceFailure(new StoredObjectReference(0, CIPHER_HASH, " "));
+        assertReferenceFailure(new StoredObjectReference(0, "x".repeat(2049), safePath));
+        assertReferenceFailure(new StoredObjectReference(0, CIPHER_HASH, "x".repeat(2049)));
+        assertReferenceFailure(new StoredObjectReference(0, CIPHER_HASH, "/absolute"));
+
+        Path processed = tempDir.resolve("aggregate-framed.bin");
+        Files.write(processed, new byte[]{1});
+        FileUploadState aggregateState = twoChunkState();
+        when(framedAeadWriter.verify(any(), any(), any(), eq(0), eq(2), eq(FRAME_SIZE)))
+                .thenReturn(new FramedAeadWriter.WriteResult(33L, 105L, 1, PLAIN_HASH, CIPHER_HASH));
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService,
+                "buildChunks",
+                aggregateState,
+                List.of(processed.toFile()),
+                List.of(CIPHER_HASH),
+                List.of(new StoredObjectReference(0, CIPHER_HASH, safePath)),
+                encryptionDescriptor()));
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService,
+                "buildChunks",
+                framedState(),
+                Collections.singletonList(null),
+                List.of(CIPHER_HASH),
+                List.of(new StoredObjectReference(0, CIPHER_HASH, safePath)),
+                encryptionDescriptor()));
+    }
+
+    /**
+     * 断言文件身份私有校验失败。
+     */
+    private void assertIdentityFailure(Long userId, File file, FileUploadState state) {
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "validateFileIdentity", userId, file, state));
+    }
+
+    /**
+     * 断言 active manifest 私有校验失败。
+     */
+    private void assertActiveManifestFailure(ChunkManifestView manifest, FileUploadState state) {
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService, "validateActiveManifest", manifest, framedFile(), state));
+    }
+
+    /**
+     * 断言单条链引用在私有引用校验中失败。
+     */
+    private void assertReferenceFailure(StoredObjectReference reference) {
+        assertThrows(GeneralException.class, () -> ReflectionTestUtils.invokeMethod(
+                finalizationService,
+                "validateReferences",
+                framedFile(),
+                framedState(),
+                List.of(reference),
+                List.of(CIPHER_HASH)));
+    }
+
+    /**
+     * 复制 manifest 并替换一个指定字段，便于逐字段生成失败样本。
+     */
+    @SuppressWarnings("unchecked")
+    private ChunkManifestView copyManifest(ChunkManifestView source, String field, Object value) {
+        return new ChunkManifestView(
+                source.manifestId(),
+                "fileId".equals(field) ? (Long) value : source.fileId(),
+                "fileVersion".equals(field) ? (Integer) value : source.fileVersion(),
+                "schemaId".equals(field) ? (String) value : source.schemaId(),
+                "fileHash".equals(field) ? (String) value : source.fileHash(),
+                source.manifestHash(),
+                "hashAlgorithm".equals(field) ? (String) value : source.hashAlgorithm(),
+                "chunkSize".equals(field) ? ((Number) value).longValue() : source.chunkSize(),
+                "chunkCount".equals(field) ? (Integer) value : source.chunkCount(),
+                "totalSize".equals(field) ? ((Number) value).longValue() : source.totalSize(),
+                source.merkleRoot(),
+                "encryptionAlgorithm".equals(field) ? (String) value : source.encryptionAlgorithm(),
+                "storageBackend".equals(field) ? (String) value : source.storageBackend(),
+                "encryption".equals(field) ? (ChunkManifestEncryption) value : source.encryption(),
+                "chunks".equals(field) ? (List<ChunkManifestChunk>) value : source.chunks());
+    }
+
+    /**
+     * 复制 manifest 分片并替换一个指定字段，便于逐字段生成失败样本。
+     */
+    private ChunkManifestChunk copyChunk(ChunkManifestChunk source, String field, Object value) {
+        return new ChunkManifestChunk(
+                "index".equals(field) ? ((Number) value).intValue() : source.index(),
+                "plainHash".equals(field) ? (String) value : source.plainHash(),
+                "cipherHash".equals(field) ? (String) value : source.cipherHash(),
+                "size".equals(field) ? ((Number) value).longValue() : source.size(),
+                "storagePath".equals(field) ? (String) value : source.storagePath(),
+                "storageBackend".equals(field) ? (String) value : source.storageBackend(),
+                source.etag(),
+                "checksumAlgorithm".equals(field) ? (String) value : source.checksumAlgorithm(),
+                "plainSize".equals(field) ? (Long) value : source.plainSize(),
+                "frameCount".equals(field) ? (Integer) value : source.frameCount());
+    }
+
+    /**
+     * 构造两分片状态，用于覆盖首分片、尾分片和明文聚合边界。
+     */
+    private FileUploadState twoChunkState() {
+        FileUploadState state = framedState();
+        state.setFileSize(34L);
+        state.setChunkSize(33);
+        state.setTotalChunks(2);
+        return state;
     }
 
     /**

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/FramedManifestFinalizationServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/FramedManifestFinalizationServiceTest.java
@@ -1,0 +1,363 @@
+package cn.flying.service.manifest;
+
+import cn.flying.common.constant.FileUploadStatus;
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.dao.dto.File;
+import cn.flying.dao.vo.file.FileUploadState;
+import cn.flying.platformapi.constant.Result;
+import cn.flying.platformapi.response.FileDetailVO;
+import cn.flying.service.encryption.FramedAeadCrypto;
+import cn.flying.service.encryption.FramedAeadWriter;
+import cn.flying.service.remote.FileRemoteClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证普通 v2 manifest 的生成、DB SUCCESS 恢复和失败证据保留边界。
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("FramedManifestFinalizationService")
+class FramedManifestFinalizationServiceTest {
+
+    private static final Long USER_ID = 100L;
+    private static final Long TENANT_ID = 77L;
+    private static final Long FILE_ID = 9001L;
+    private static final String FILE_HASH = "chain-file-hash";
+    private static final int FRAME_SIZE = 64 * 1024;
+    private static final HexFormat HEX = HexFormat.of();
+    private static final byte[] FILE_DEK = HEX.parseHex(
+            "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf");
+    private static final byte[] FILE_NONCE = HEX.parseHex("0102030405060708090a0b0c0d0e0f10");
+    private static final String PLAIN_HASH =
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private static final String CIPHER_HASH =
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private static final String MANIFEST_HASH =
+            "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+    @Mock
+    private FileRemoteClient fileRemoteClient;
+
+    @Mock
+    private ChunkManifestService chunkManifestService;
+
+    @Mock
+    private FramedAeadWriter framedAeadWriter;
+
+    @InjectMocks
+    private FramedManifestFinalizationService finalizationService;
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * 验证 DB SUCCESS 重试在临时目录已经清理时复用并严格校验 active manifest。
+     */
+    @Test
+    void ensureManifest_shouldReuseValidatedActiveManifestDuringDbSuccessRecovery() {
+        File file = framedFile();
+        FileUploadState state = framedState();
+        ChunkManifestView active = activeManifest();
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.of(active));
+        when(chunkManifestService.calculateManifestHash(any())).thenReturn(MANIFEST_HASH);
+
+        Optional<ChunkManifestView> result = finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(), List.of());
+
+        assertThat(result).containsSame(active);
+        verify(chunkManifestService).calculateManifestHash(any());
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+        verifyNoInteractions(fileRemoteClient, framedAeadWriter);
+    }
+
+    /**
+     * 验证 active manifest 的 storagePath 被替换时，在任何远程读取或保存前 fail closed。
+     */
+    @Test
+    void ensureManifest_shouldRejectStoragePathSubstitutionBeforeReuseOrSave() {
+        File file = framedFile();
+        FileUploadState state = framedState();
+        ChunkManifestChunk substitutedChunk = new ChunkManifestChunk(
+                0,
+                PLAIN_HASH,
+                CIPHER_HASH,
+                105L,
+                "storage/tenant/" + TENANT_ID + "/chunk/sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                "S3",
+                null,
+                "SHA-256",
+                33L,
+                1);
+        ChunkManifestView substituted = new ChunkManifestView(
+                11L,
+                FILE_ID,
+                1,
+                ChunkManifestCanonicalizer.SCHEMA_ID,
+                FILE_HASH,
+                MANIFEST_HASH,
+                ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                33L,
+                1,
+                33L,
+                null,
+                "FRAMED_AEAD_V2",
+                "S3",
+                encryptionDescriptor(),
+                List.of(substitutedChunk));
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.of(substituted));
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(), List.of()));
+
+        assertThat(failure.getData()).asString().contains("active");
+        verifyNoInteractions(fileRemoteClient, framedAeadWriter);
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证 active manifest 含 null 分片时 fail closed，而不是在校验字段时抛出 NPE。
+     */
+    @Test
+    void ensureManifest_shouldRejectNullActiveManifestChunk() {
+        File file = framedFile();
+        FileUploadState state = framedState();
+        ChunkManifestView active = new ChunkManifestView(
+                12L,
+                FILE_ID,
+                1,
+                ChunkManifestCanonicalizer.SCHEMA_ID,
+                FILE_HASH,
+                MANIFEST_HASH,
+                ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                33L,
+                1,
+                33L,
+                null,
+                "FRAMED_AEAD_V2",
+                "S3",
+                encryptionDescriptor(),
+                Collections.singletonList(null));
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.of(active));
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(), List.of()));
+
+        assertThat(failure.getResultEnum()).isEqualTo(ResultEnum.FILE_RECORD_ERROR);
+        assertThat(String.valueOf(failure.getData())).contains("active v2 manifest");
+        verifyNoInteractions(fileRemoteClient, framedAeadWriter);
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证 manifest 保存失败时保留已生成对象文件，并且错误上下文不包含 DEK/nonce。
+     */
+    @Test
+    void ensureManifest_shouldRetainProcessedEvidenceWhenManifestSaveFails() throws IOException {
+        File file = framedFile();
+        FileUploadState state = framedState();
+        Path processed = tempDir.resolve("encrypted_chunk_0");
+        Files.write(processed, new byte[]{1, 2, 3});
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH, storagePath(CIPHER_HASH))));
+        when(framedAeadWriter.verify(
+                eq(processed), eq(FILE_DEK), eq(FILE_NONCE), eq(0), eq(1), eq(FRAME_SIZE)))
+                .thenReturn(new FramedAeadWriter.WriteResult(33L, 105L, 1, PLAIN_HASH, CIPHER_HASH));
+        when(chunkManifestService.calculateManifestHash(any())).thenReturn(MANIFEST_HASH);
+        doThrow(new GeneralException(ResultEnum.FILE_RECORD_ERROR, "manifest store unavailable"))
+                .when(chunkManifestService).saveManifest(eq(USER_ID), eq(FILE_ID), any());
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(processed.toFile()), List.of(CIPHER_HASH)));
+
+        assertThat(Files.isRegularFile(processed)).isTrue();
+        assertThat(String.valueOf(failure.getData()))
+                .doesNotContain(Base64.getEncoder().encodeToString(FILE_DEK))
+                .doesNotContain(Base64.getEncoder().encodeToString(FILE_NONCE));
+        ArgumentCaptor<ChunkManifestDraft> draftCaptor = ArgumentCaptor.forClass(ChunkManifestDraft.class);
+        verify(chunkManifestService).saveManifest(eq(USER_ID), eq(FILE_ID), draftCaptor.capture());
+        assertThat(draftCaptor.getValue().chunks().getFirst().storagePath())
+                .isEqualTo(storagePath(CIPHER_HASH));
+        assertThat(draftCaptor.getValue().encryption()).isEqualTo(encryptionDescriptor());
+    }
+
+    /**
+     * 验证 direct NONE 会话不被 framed finalizer 接管，也不会触发链查询、writer 或 manifest 保存。
+     */
+    @Test
+    void ensureManifest_shouldLeaveDirectNoneUploadUntouched() {
+        File file = new File()
+                .setId(FILE_ID)
+                .setUid(USER_ID)
+                .setTenantId(TENANT_ID)
+                .setFileHash(FILE_HASH)
+                .setFileSize(33L)
+                .setVersion(1)
+                .setStatus(FileUploadStatus.SUCCESS.getCode())
+                .setFileParam("{\"uploadMode\":\"DIRECT_MULTIPART\",\"encryptionAlgorithm\":\"NONE\"}");
+        FileUploadState state = new FileUploadState(USER_ID, "direct.bin", 33L,
+                "application/octet-stream", "direct-client", 33, 1);
+        state.setTenantId(TENANT_ID);
+        state.setDirectUpload(true);
+
+        assertThat(finalizationService.ensureManifest(USER_ID, file, state, List.of(), List.of()))
+                .isEmpty();
+        verifyNoInteractions(fileRemoteClient, chunkManifestService, framedAeadWriter);
+    }
+
+    /**
+     * 验证 fileParam 明确声明 v2 但 Redis 检查点残缺时不会静默降级为 legacy。
+     */
+    @Test
+    void ensureManifest_shouldRejectIncompleteExplicitV2Checkpoint() {
+        File file = framedFile();
+        FileUploadState state = new FileUploadState(USER_ID, "broken.bin", 33L,
+                "application/octet-stream", "broken-client", 33, 1);
+        state.setTenantId(TENANT_ID);
+        state.setEncryptionFormatVersion(FramedAeadCrypto.FORMAT_VERSION);
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(), List.of()));
+
+        assertThat(failure.getResultEnum()).isEqualTo(ResultEnum.FILE_RECORD_ERROR);
+        verifyNoInteractions(fileRemoteClient, chunkManifestService, framedAeadWriter);
+    }
+
+    /**
+     * 构造完整 framed v2 文件记录。
+     */
+    private File framedFile() {
+        return new File()
+                .setId(FILE_ID)
+                .setUid(USER_ID)
+                .setTenantId(TENANT_ID)
+                .setFileHash(FILE_HASH)
+                .setFileSize(33L)
+                .setVersion(1)
+                .setStatus(FileUploadStatus.SUCCESS.getCode())
+                .setFileParam("{"
+                        + "\"fileSize\":33,"
+                        + "\"chunkSize\":33,"
+                        + "\"chunkCount\":1,"
+                        + "\"encryptionAlgorithm\":\"FRAMED_AEAD_V2\","
+                        + "\"algorithmSuite\":\"RP-AES256-GCM-FRAMED-V2\","
+                        + "\"fileNonce\":\"AQIDBAUGBwgJCgsMDQ4PEA\","
+                        + "\"keyDerivation\":\"HKDF-SHA256\","
+                        + "\"nonceDerivation\":\"HKDF-SHA256\","
+                        + "\"aadSchema\":\"cn.flying.framed-aead.aad.v2\","
+                        + "\"formatVersion\":2,\"framePlainSize\":65536,\"tagSize\":16"
+                        + "}");
+    }
+
+    /**
+     * 构造完整 framed v2 Redis 检查点，模拟重试时稳定的 DEK/nonce 和上传计划。
+     */
+    private FileUploadState framedState() {
+        FileUploadState state = new FileUploadState(USER_ID, "framed.bin", 33L,
+                "application/octet-stream", "framed-client", 33, 1);
+        state.setTenantId(TENANT_ID);
+        state.setSuid("encoded-user");
+        state.setPreparedFileId(FILE_ID);
+        state.setEncryptionRecoveryVersion(2);
+        state.setEncryptionFormatVersion(FramedAeadCrypto.FORMAT_VERSION);
+        state.setEncryptionAlgorithmSuite(ChunkManifestEncryption.SUITE_FRAMED_V2);
+        state.setFileDataKey(FILE_DEK.clone());
+        state.setFileNonce(FILE_NONCE.clone());
+        state.setFramePlainSize(FRAME_SIZE);
+        state.setKeyDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+        state.setNonceDerivation(ChunkManifestEncryption.DERIVATION_HKDF_SHA256);
+        state.setAadSchema(ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2);
+        state.setTagSize(FramedAeadCrypto.TAG_SIZE);
+        state.setManifestHash(MANIFEST_HASH);
+        return state;
+    }
+
+    /**
+     * 构造与固定 v2 检查点一致的加密描述。
+     */
+    private ChunkManifestEncryption encryptionDescriptor() {
+        return new ChunkManifestEncryption(
+                FramedAeadCrypto.FORMAT_VERSION,
+                ChunkManifestEncryption.SUITE_FRAMED_V2,
+                "AQIDBAUGBwgJCgsMDQ4PEA",
+                FRAME_SIZE,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.DERIVATION_HKDF_SHA256,
+                ChunkManifestEncryption.AAD_SCHEMA_FRAMED_V2,
+                FramedAeadCrypto.TAG_SIZE);
+    }
+
+    /**
+     * 构造通过租户和摘要绑定的最终对象路径。
+     */
+    private String storagePath(String cipherHash) {
+        return "storage/tenant/" + TENANT_ID + "/chunk/" + cipherHash;
+    }
+
+    /**
+     * 构造链上对象引用详情，模拟普通上传存证结果。
+     */
+    private FileDetailVO chainDetail(String cipherHash, String storagePath) {
+        String content = "[{\"index\":0,\"cipherHash\":\"" + cipherHash
+                + "\",\"storagePath\":\"" + storagePath + "\"}]";
+        return new FileDetailVO(
+                String.valueOf(USER_ID), "framed.bin", "{}", content,
+                FILE_HASH, "2026-07-26T00:00:00Z", 1L, 33L,
+                "application/octet-stream");
+    }
+
+    /**
+     * 构造具有精确尺寸和 frame 证据的 active manifest。
+     */
+    private ChunkManifestView activeManifest() {
+        return new ChunkManifestView(
+                10L,
+                FILE_ID,
+                1,
+                ChunkManifestCanonicalizer.SCHEMA_ID,
+                FILE_HASH,
+                MANIFEST_HASH,
+                ChunkManifestCanonicalizer.HASH_ALGORITHM,
+                33L,
+                1,
+                33L,
+                null,
+                "FRAMED_AEAD_V2",
+                "S3",
+                encryptionDescriptor(),
+                List.of(new ChunkManifestChunk(
+                        0, PLAIN_HASH, CIPHER_HASH, 105L,
+                        storagePath(CIPHER_HASH), "S3", null, "SHA-256", 33L, 1)));
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/FramedManifestFinalizationServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/manifest/FramedManifestFinalizationServiceTest.java
@@ -255,6 +255,294 @@ class FramedManifestFinalizationServiceTest {
     }
 
     /**
+     * 验证首次最终化会保存并返回由链上路径与 writer 认证共同构造的 active manifest。
+     */
+    @Test
+    void ensureManifest_shouldSaveVerifiedManifestForFirstFinalization() throws IOException {
+        File file = framedFile();
+        FileUploadState state = framedState();
+        Path processed = tempDir.resolve("encrypted_chunk_0");
+        Files.write(processed, new byte[]{1, 2, 3});
+        ChunkManifestView saved = activeManifest();
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH, storagePath(CIPHER_HASH))));
+        when(framedAeadWriter.verify(
+                eq(processed), eq(FILE_DEK), eq(FILE_NONCE), eq(0), eq(1), eq(FRAME_SIZE)))
+                .thenReturn(new FramedAeadWriter.WriteResult(33L, 105L, 1, PLAIN_HASH, CIPHER_HASH));
+        when(chunkManifestService.calculateManifestHash(any())).thenReturn(MANIFEST_HASH);
+        when(chunkManifestService.saveManifest(eq(USER_ID), eq(FILE_ID), any())).thenReturn(saved);
+
+        Optional<ChunkManifestView> result = finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(processed.toFile()), List.of(CIPHER_HASH));
+
+        assertThat(result).containsSame(saved);
+        verify(chunkManifestService).saveManifest(eq(USER_ID), eq(FILE_ID), any());
+    }
+
+    /**
+     * 验证 Redis 中的 manifest hash 检查点与当前对象证据不一致时禁止保存。
+     */
+    @Test
+    void ensureManifest_shouldRejectManifestCheckpointMismatch() throws IOException {
+        File file = framedFile();
+        FileUploadState state = framedState();
+        Path processed = tempDir.resolve("encrypted_chunk_0");
+        Files.write(processed, new byte[]{1, 2, 3});
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH, storagePath(CIPHER_HASH))));
+        when(framedAeadWriter.verify(
+                eq(processed), eq(FILE_DEK), eq(FILE_NONCE), eq(0), eq(1), eq(FRAME_SIZE)))
+                .thenReturn(new FramedAeadWriter.WriteResult(33L, 105L, 1, PLAIN_HASH, CIPHER_HASH));
+        when(chunkManifestService.calculateManifestHash(any()))
+                .thenReturn("sha256:" + "d".repeat(64));
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, file, state, List.of(processed.toFile()), List.of(CIPHER_HASH)));
+
+        assertThat(failure.getData()).asString().contains("manifest 检查点");
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证恢复版本、分片计划和 manifest hash 格式均属于不可变检查点。
+     */
+    @Test
+    void ensureManifest_shouldRejectInvalidFramedStateVariants() {
+        FileUploadState missingRecoveryVersion = framedState();
+        missingRecoveryVersion.setEncryptionRecoveryVersion(null);
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), missingRecoveryVersion, List.of(), List.of())).getData())
+                .asString()
+                .contains("检查点不完整");
+
+        FileUploadState inconsistentPlan = framedState();
+        inconsistentPlan.setTotalChunks(2);
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), inconsistentPlan, List.of(), List.of())).getData())
+                .asString()
+                .contains("分片计划");
+
+        FileUploadState malformedManifestHash = framedState();
+        malformedManifestHash.setManifestHash("sha256:BAD");
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), malformedManifestHash, List.of(), List.of())).getData())
+                .asString()
+                .contains("hash 检查点格式");
+
+        verifyNoInteractions(fileRemoteClient, chunkManifestService, framedAeadWriter);
+    }
+
+    /**
+     * 验证持久化 fileParam 的字段漂移与损坏 JSON 均失败关闭。
+     */
+    @Test
+    void ensureManifest_shouldRejectMismatchedOrMalformedFileParam() {
+        File mismatched = framedFile().setFileParam(
+                framedFile().getFileParam().replace("RP-AES256-GCM-FRAMED-V2", "OTHER-SUITE"));
+        GeneralException mismatchFailure = assertThrows(GeneralException.class,
+                () -> finalizationService.ensureManifest(
+                        USER_ID, mismatched, framedState(), List.of(), List.of()));
+        assertThat(mismatchFailure.getData()).asString().contains("fileParam");
+
+        File malformed = framedFile().setFileParam("{\"encryptionAlgorithm\":\"FRAMED_AEAD_V2\"");
+        GeneralException malformedFailure = assertThrows(GeneralException.class,
+                () -> finalizationService.ensureManifest(
+                        USER_ID, malformed, framedState(), List.of(), List.of()));
+        assertThat(malformedFailure.getData()).asString().contains("JSON 解析失败");
+
+        verifyNoInteractions(fileRemoteClient, chunkManifestService, framedAeadWriter);
+    }
+
+    /**
+     * 验证链记录缺失、格式损坏和摘要替换均在 writer 认证前失败关闭。
+     */
+    @Test
+    void ensureManifest_shouldRejectInvalidChainReferenceEvidence() {
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetailWithContent(" ")));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(new java.io.File("unused")),
+                List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("引用缺失");
+
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetailWithContent("{not-json")));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(new java.io.File("unused")),
+                List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("格式无效");
+
+        String substitutedHash = "sha256:" + "d".repeat(64);
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(substitutedHash, storagePath(substitutedHash))));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(new java.io.File("unused")),
+                List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("摘要");
+
+        verifyNoInteractions(framedAeadWriter);
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证 writer 重新认证失败时保留对象证据并阻止 manifest 保存。
+     */
+    @Test
+    void ensureManifest_shouldRejectWriterVerificationFailure() throws IOException {
+        Path processed = tempDir.resolve("encrypted_chunk_0");
+        Files.write(processed, new byte[]{1, 2, 3});
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH, storagePath(CIPHER_HASH))));
+        when(framedAeadWriter.verify(
+                eq(processed), eq(FILE_DEK), eq(FILE_NONCE), eq(0), eq(1), eq(FRAME_SIZE)))
+                .thenThrow(new IOException("tag mismatch"));
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(processed.toFile()), List.of(CIPHER_HASH)));
+
+        assertThat(failure.getData()).asString().contains("认证或长度校验失败");
+        assertThat(Files.isRegularFile(processed)).isTrue();
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证残缺 fileParam 的显式 v2 标识不会被当作 legacy 静默跳过。
+     */
+    @Test
+    void ensureManifest_shouldRejectMalformedExplicitV2FileParam() {
+        File malformed = framedFile().setFileParam("{FRAMED_AEAD_V2");
+        FileUploadState legacyState = new FileUploadState(
+                USER_ID, "legacy.bin", 33L, "application/octet-stream", "legacy-client", 33, 1);
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, malformed, legacyState, List.of(), List.of()));
+
+        assertThat(failure.getData()).asString().contains("fileParam 格式无效");
+        verifyNoInteractions(fileRemoteClient, chunkManifestService, framedAeadWriter);
+    }
+
+    /**
+     * 验证文件 owner 与稳定上传用户不一致时拒绝恢复。
+     */
+    @Test
+    void ensureManifest_shouldRejectFileOwnerMismatch() {
+        File file = framedFile().setUid(200L);
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, file, framedState(), List.of(), List.of()));
+
+        assertThat(failure.getResultEnum()).isEqualTo(ResultEnum.PERMISSION_UNAUTHORIZED);
+        verifyNoInteractions(fileRemoteClient, chunkManifestService, framedAeadWriter);
+    }
+
+    /**
+     * 验证没有完整 processed/cipher 证据时不读取链上引用或创建 manifest。
+     */
+    @Test
+    void ensureManifest_shouldRejectIncompleteObjectEvidence() {
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+
+        GeneralException failure = assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(), List.of()));
+
+        assertThat(failure.getData()).asString().contains("输入证据不完整");
+        verifyNoInteractions(fileRemoteClient, framedAeadWriter);
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证链上引用的数量、路径租户、摘要后缀和摘要编码均严格绑定。
+     */
+    @Test
+    void ensureManifest_shouldRejectReferenceBindingViolations() {
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        java.io.File placeholder = new java.io.File("unused");
+
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetailWithContent(
+                        "[{\"index\":0,\"cipherHash\":\"" + CIPHER_HASH
+                                + "\",\"storagePath\":\"" + storagePath(CIPHER_HASH)
+                                + "\"},{\"index\":1,\"cipherHash\":\"" + CIPHER_HASH
+                                + "\",\"storagePath\":\"" + storagePath(CIPHER_HASH) + "-1\"}]")));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(placeholder), List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("数量不一致");
+
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH, "../" + CIPHER_HASH)));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(placeholder), List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("索引或路径无效");
+
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH,
+                        "storage/tenant/999/chunk/" + CIPHER_HASH)));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(placeholder), List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("租户不匹配");
+
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH,
+                        storagePath("sha256:" + "d".repeat(64)))));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(placeholder), List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("storagePath 与密文摘要");
+
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail("not-a-digest", "storage/tenant/" + TENANT_ID
+                        + "/chunk/not-a-digest")));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(placeholder), List.of("not-a-digest"))).getData())
+                .asString()
+                .contains("摘要格式无效");
+
+        verifyNoInteractions(framedAeadWriter);
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
+     * 验证 writer 返回的密文摘要或明文大小与上传证据不一致时拒绝保存。
+     */
+    @Test
+    void ensureManifest_shouldRejectWriterEvidenceMismatch() throws IOException {
+        Path processed = tempDir.resolve("encrypted_chunk_0");
+        Files.write(processed, new byte[]{1, 2, 3});
+        when(chunkManifestService.findActiveManifest(USER_ID, FILE_ID)).thenReturn(Optional.empty());
+        when(fileRemoteClient.getFile(String.valueOf(USER_ID), FILE_HASH))
+                .thenReturn(Result.success(chainDetail(CIPHER_HASH, storagePath(CIPHER_HASH))));
+        when(framedAeadWriter.verify(
+                eq(processed), eq(FILE_DEK), eq(FILE_NONCE), eq(0), eq(1), eq(FRAME_SIZE)))
+                .thenReturn(new FramedAeadWriter.WriteResult(33L, 105L, 1, PLAIN_HASH,
+                        "sha256:" + "d".repeat(64)));
+
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(processed.toFile()), List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("密文摘要不一致");
+
+        when(framedAeadWriter.verify(
+                eq(processed), eq(FILE_DEK), eq(FILE_NONCE), eq(0), eq(1), eq(FRAME_SIZE)))
+                .thenReturn(new FramedAeadWriter.WriteResult(32L, 104L, 1, PLAIN_HASH, CIPHER_HASH));
+        assertThat(assertThrows(GeneralException.class, () -> finalizationService.ensureManifest(
+                USER_ID, framedFile(), framedState(), List.of(processed.toFile()), List.of(CIPHER_HASH))).getData())
+                .asString()
+                .contains("明文大小不一致");
+
+        verify(chunkManifestService, never()).saveManifest(anyLong(), anyLong(), any());
+    }
+
+    /**
      * 构造完整 framed v2 文件记录。
      */
     private File framedFile() {
@@ -331,6 +619,13 @@ class FramedManifestFinalizationServiceTest {
     private FileDetailVO chainDetail(String cipherHash, String storagePath) {
         String content = "[{\"index\":0,\"cipherHash\":\"" + cipherHash
                 + "\",\"storagePath\":\"" + storagePath + "\"}]";
+        return chainDetailWithContent(content);
+    }
+
+    /**
+     * 构造指定 content 的链上文件详情，用于损坏引用边界测试。
+     */
+    private FileDetailVO chainDetailWithContent(String content) {
         return new FileDetailVO(
                 String.valueOf(USER_ID), "framed.bin", "{}", content,
                 FILE_HASH, "2026-07-26T00:00:00Z", 1L, 33L,

--- a/platform-backend/backend-web/src/main/java/cn/flying/listener/FileStorageEventListener.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/listener/FileStorageEventListener.java
@@ -8,6 +8,7 @@ import cn.flying.dao.dto.File;
 import cn.flying.dao.vo.file.FileUploadState;
 import cn.flying.service.FileService;
 import cn.flying.service.assistant.FileUploadRedisStateManager;
+import cn.flying.service.manifest.FramedManifestFinalizationService;
 import cn.flying.service.sse.SseEmitterManager;
 import cn.flying.service.sse.SseEvent;
 import cn.flying.service.sse.SseEventType;
@@ -41,6 +42,9 @@ public class FileStorageEventListener {
     @Resource
     private SseEmitterManager sseEmitterManager;
 
+    @Resource
+    private FramedManifestFinalizationService framedManifestFinalizationService;
+
     /**
      * 同步处理文件存证事件，使发布者仅在文件最终化成功后推进上传完成态。
      *
@@ -73,6 +77,22 @@ public class FileStorageEventListener {
             );
             if (storedFile == null) {
                 throw new GeneralException(ResultEnum.FILE_RECORD_ERROR, "存储结果为空");
+            }
+
+            // 普通 v2 上传必须先完成 manifest 认证和持久化，发布者才会清理临时目录并标记完成。
+            if (framedManifestFinalizationService != null) {
+                FileUploadState state = redisStateManager.getState(event.getClientId());
+                framedManifestFinalizationService.ensureManifest(
+                        event.getUid(),
+                        storedFile,
+                        state,
+                        event.getProcessedFiles(),
+                        event.getFileHashes()).ifPresent(manifest -> {
+                    if (state != null) {
+                        state.setManifestHash(manifest.manifestHash());
+                        redisStateManager.updateState(state);
+                    }
+                });
             }
 
             log.info("文件存储和上链成功: 用户={}, 文件名={}, 文件哈希={}",

--- a/platform-backend/backend-web/src/main/resources/application.yml
+++ b/platform-backend/backend-web/src/main/resources/application.yml
@@ -192,6 +192,9 @@ file:
     benchmark-data-size: 1048576
     # Benchmark iterations
     benchmark-iterations: 3
+    # 普通后端代理上传的对象格式；切回 v1 仅影响新上传，reader 始终保留兼容能力。
+    writer-format: v2
+    frame-plain-size: 1048576
   key-envelope:
     provider: local
     kms-key-id: local-file-key-v1
@@ -211,6 +214,7 @@ file:
     # deprecated-after: 2030-01-01T00:00:00Z
     supported-algorithm-suites:
       - RP-AES256-GCM-CHUNK-CHAIN-V1
+      - RP-AES256-GCM-FRAMED-V2
     supported-signature-suites:
       - UNSIGNED-V1
     supported-kem-suites:

--- a/platform-backend/backend-web/src/main/resources/db/migration/V1.16.0__framed_download_contract.sql
+++ b/platform-backend/backend-web/src/main/resources/db/migration/V1.16.0__framed_download_contract.sql
@@ -1,0 +1,14 @@
+-- V1.16.0: Add nullable framed-encryption metadata for bounded authenticated downloads.
+
+ALTER TABLE `file_chunk_manifest`
+    ADD COLUMN `encryption_metadata` JSON DEFAULT NULL
+        COMMENT 'Versioned framed-encryption descriptor; null for historical manifests'
+        AFTER `storage_backend`;
+
+ALTER TABLE `file_chunk_manifest_item`
+    ADD COLUMN `plain_size` BIGINT DEFAULT NULL
+        COMMENT 'Plaintext bytes represented by this stored object'
+        AFTER `size`,
+    ADD COLUMN `frame_count` INT DEFAULT NULL
+        COMMENT 'Authenticated frame count for framed encryption v2'
+        AFTER `plain_size`;

--- a/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
@@ -315,6 +315,33 @@ class OpenApiContractExportTest {
         JsonNode integrityAlertSchema = rootNode.path("components").path("schemas").path("IntegrityAlertVO");
         assertThat(integrityAlertSchema.path("properties").has("severity")).isTrue();
         assertThat(integrityAlertSchema.path("properties").has("evidence")).isTrue();
+        JsonNode downloadMetadataSchema = rootNode.path("components").path("schemas")
+                .path("FileDownloadMetadataVO");
+        assertThat(downloadMetadataSchema.isMissingNode()).isFalse();
+        assertThat(downloadMetadataSchema.path("properties").has("encryption")).isTrue();
+        assertThat(downloadMetadataSchema.path("properties").has("canonicalManifestJson")).isTrue();
+        assertThat(downloadMetadataSchema.path("properties").path("canonicalManifestJson")
+                .path("type").asText()).isEqualTo("string");
+        JsonNode downloadEncryptionSchema = rootNode.path("components").path("schemas")
+                .path("FileDownloadEncryptionVO");
+        assertThat(downloadEncryptionSchema.path("properties").has("formatVersion")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("algorithmSuite")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("fileNonce")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("framePlainSize")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("keyDerivation")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("nonceDerivation")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("aadSchema")).isTrue();
+        assertThat(downloadEncryptionSchema.path("properties").has("tagSize")).isTrue();
+        JsonNode downloadPartSchema = rootNode.path("components").path("schemas")
+                .path("FileDownloadPartVO");
+        assertThat(downloadPartSchema.path("properties").has("plainSize")).isTrue();
+        assertThat(downloadPartSchema.path("properties").has("frameCount")).isTrue();
+        JsonNode downloadMetadataOperation = rootNode.path("paths")
+                .path("/api/v1/files/hash/{fileHash}/download-metadata").path("get");
+        assertThat(downloadMetadataOperation.isMissingNode()).isFalse();
+        assertThat(downloadMetadataOperation.path("responses").path("200")
+                .path("content").path("*/*").path("schema").path("$ref").asText())
+                .isEqualTo("#/components/schemas/ResultFileDownloadMetadataVO");
         JsonNode directCompletePartSchema = rootNode.path("components").path("schemas")
                 .path("DirectUploadCompletePartRequest");
         assertThat(directCompletePartSchema.path("properties").has("eTag")).isTrue();

--- a/platform-backend/backend-web/src/test/java/cn/flying/listener/FileStorageEventListenerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/listener/FileStorageEventListenerTest.java
@@ -8,6 +8,8 @@ import cn.flying.dao.dto.File;
 import cn.flying.dao.vo.file.FileUploadState;
 import cn.flying.service.FileService;
 import cn.flying.service.assistant.FileUploadRedisStateManager;
+import cn.flying.service.manifest.ChunkManifestView;
+import cn.flying.service.manifest.FramedManifestFinalizationService;
 import cn.flying.service.sse.SseEmitterManager;
 import cn.flying.service.sse.SseEvent;
 import org.junit.jupiter.api.DisplayName;
@@ -17,10 +19,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,6 +87,29 @@ class FileStorageEventListenerTest {
         );
     }
 
+    /**
+     * 为单个测试注入 framed manifest 最终化服务，保留其他历史用例的空依赖兼容分支。
+     *
+     * @return framed manifest 最终化服务 mock
+     */
+    private FramedManifestFinalizationService injectFramedManifestFinalizationService() {
+        FramedManifestFinalizationService service = mock(FramedManifestFinalizationService.class);
+        ReflectionTestUtils.setField(listener, "framedManifestFinalizationService", service);
+        return service;
+    }
+
+    /**
+     * 构造仅携带监听器所需 manifest 摘要的持久化视图。
+     *
+     * @param manifestHash manifest 摘要
+     * @return manifest 持久化视图
+     */
+    private ChunkManifestView buildManifest(String manifestHash) {
+        return new ChunkManifestView(
+                1L, 1L, 1, "v1", "hash-1", manifestHash, "SHA-256",
+                1024L, 1, 1024L, null, "FRAMED_AEAD_V2", "S3", List.of());
+    }
+
     @Test
     @DisplayName("success path should send file-record-success event")
     void successPathShouldSendFileRecordSuccessEvent() {
@@ -107,6 +134,89 @@ class FileStorageEventListenerTest {
         verify(fileService, never()).changeFileStatusById(anyLong(), anyLong(), anyInt());
         verify(fileService, never()).markFileUploadFailed(anyLong(), anyLong());
         verify(redisStateManager, never()).removeSession(anyString(), anyString());
+    }
+
+    /**
+     * 验证普通 framed v2 存储成功后把 active manifest 摘要回写到稳定 Redis 检查点。
+     */
+    @Test
+    void framedManifestShouldPersistHashIntoUploadState() {
+        FileStorageEvent event = buildEvent();
+        File storedFile = new File();
+        storedFile.setFileHash("hash-1");
+        FileUploadState state = new FileUploadState(
+                100L, "contract.pdf", 1024L, "application/pdf", "client-1", 1024, 1);
+        ChunkManifestView manifest = buildManifest("sha256:manifest");
+        FramedManifestFinalizationService finalizationService = injectFramedManifestFinalizationService();
+        when(fileService.storeFile(
+                anyLong(), any(Long.class), anyString(), anyList(), anyList(), anyString(), anyString()))
+                .thenReturn(storedFile);
+        when(redisStateManager.getState("client-1")).thenReturn(state);
+        when(finalizationService.ensureManifest(
+                eq(100L), same(storedFile), same(state),
+                same(event.getProcessedFiles()), same(event.getFileHashes())))
+                .thenReturn(Optional.of(manifest));
+
+        listener.handleFileStorageEvent(event);
+
+        assertThat(state.getManifestHash()).isEqualTo("sha256:manifest");
+        verify(finalizationService).ensureManifest(
+                eq(100L), same(storedFile), same(state),
+                same(event.getProcessedFiles()), same(event.getFileHashes()));
+        verify(redisStateManager).updateState(same(state));
+    }
+
+    /**
+     * 验证 legacy 或无需 manifest 的成功存储不会改写上传检查点。
+     */
+    @Test
+    void emptyFramedManifestShouldNotUpdateUploadState() {
+        FileStorageEvent event = buildEvent();
+        File storedFile = new File();
+        storedFile.setFileHash("hash-1");
+        FileUploadState state = new FileUploadState(
+                100L, "contract.pdf", 1024L, "application/pdf", "client-1", 1024, 1);
+        FramedManifestFinalizationService finalizationService = injectFramedManifestFinalizationService();
+        when(fileService.storeFile(
+                anyLong(), any(Long.class), anyString(), anyList(), anyList(), anyString(), anyString()))
+                .thenReturn(storedFile);
+        when(redisStateManager.getState("client-1")).thenReturn(state);
+        when(finalizationService.ensureManifest(
+                eq(100L), same(storedFile), same(state),
+                same(event.getProcessedFiles()), same(event.getFileHashes())))
+                .thenReturn(Optional.empty());
+
+        listener.handleFileStorageEvent(event);
+
+        assertThat(state.getManifestHash()).isNull();
+        verify(redisStateManager, never()).updateState(any());
+    }
+
+    /**
+     * 验证 Redis 会话已过期时仍允许复用 active manifest，但不得凭空创建状态。
+     */
+    @Test
+    void activeManifestWithoutUploadStateShouldSkipRedisUpdate() {
+        FileStorageEvent event = buildEvent();
+        File storedFile = new File();
+        storedFile.setFileHash("hash-1");
+        ChunkManifestView manifest = buildManifest("sha256:manifest");
+        FramedManifestFinalizationService finalizationService = injectFramedManifestFinalizationService();
+        when(fileService.storeFile(
+                anyLong(), any(Long.class), anyString(), anyList(), anyList(), anyString(), anyString()))
+                .thenReturn(storedFile);
+        when(redisStateManager.getState("client-1")).thenReturn(null);
+        when(finalizationService.ensureManifest(
+                eq(100L), same(storedFile), isNull(),
+                same(event.getProcessedFiles()), same(event.getFileHashes())))
+                .thenReturn(Optional.of(manifest));
+
+        listener.handleFileStorageEvent(event);
+
+        verify(finalizationService).ensureManifest(
+                eq(100L), same(storedFile), isNull(),
+                same(event.getProcessedFiles()), same(event.getFileHashes()));
+        verify(redisStateManager, never()).updateState(any());
     }
 
     @Test

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
@@ -47,6 +47,7 @@ class FlywayMigrationVersionTest {
         assertTrue(migrationFiles.contains("V1.13.0__attestation_contract_registry_snapshot.sql"));
         assertTrue(migrationFiles.contains("V1.14.0__signed_proof_bundle.sql"));
         assertTrue(migrationFiles.contains("V1.15.0__proof_status_timestamp_precision.sql"));
+        assertTrue(migrationFiles.contains("V1.16.0__framed_download_contract.sql"));
         assertFalse(migrationFiles.contains("V1.0.1__add_account_nickname.sql"));
         assertFalse(migrationFiles.contains("V1.5.0__integrity_alert.sql"));
 
@@ -335,6 +336,30 @@ class FlywayMigrationVersionTest {
         assertFalse(sql.matches("(?is).*ALTER\\s+TABLE\\s+`proof_signing_key`.*"));
         assertFalse(sql.matches("(?is).*UPDATE\\s+`proof_signing_key`.*"));
         assertFalse(sql.matches("(?is).*DROP\\s+(TABLE|COLUMN).*"));
+    }
+
+    /**
+     * 验证 framed 下载迁移只追加 nullable 描述列和分片证据列，不改写历史数据或删除结构。
+     */
+    @Test
+    @DisplayName("should add framed download columns through an additive forward migration")
+    void shouldAddFramedDownloadContractThroughForwardMigration() throws IOException {
+        Path migration = resolveMigrationDir().resolve("V1.16.0__framed_download_contract.sql");
+        assertTrue(Files.isRegularFile(migration), "Missing framed download contract migration");
+        String sql = Files.readString(migration);
+        String normalizedSql = sql.replaceAll("\\s+", " ").trim();
+
+        assertTrue(normalizedSql.contains("ALTER TABLE `file_chunk_manifest`"));
+        assertTrue(normalizedSql.contains(
+                "ADD COLUMN `encryption_metadata` JSON DEFAULT NULL"));
+        assertTrue(normalizedSql.contains("ALTER TABLE `file_chunk_manifest_item`"));
+        assertTrue(normalizedSql.contains("ADD COLUMN `plain_size` BIGINT DEFAULT NULL"));
+        assertTrue(normalizedSql.contains("ADD COLUMN `frame_count` INT DEFAULT NULL"));
+        assertTrue(normalizedSql.contains("Versioned framed-encryption descriptor"));
+        assertTrue(normalizedSql.contains("Plaintext bytes represented by this stored object"));
+        assertTrue(normalizedSql.contains("Authenticated frame count for framed encryption v2"));
+        assertFalse(normalizedSql.matches("(?is).*UPDATE\\s+`(?:file_chunk_manifest|file_chunk_manifest_item)`.*"));
+        assertFalse(normalizedSql.matches("(?is).*DROP\\s+(TABLE|COLUMN).*"));
     }
 
     /**

--- a/platform-frontend/.prettierignore
+++ b/platform-frontend/.prettierignore
@@ -4,3 +4,4 @@ dist
 coverage
 pnpm-lock.yaml
 src/lib/api/types/generated.ts
+output/

--- a/platform-frontend/e2e/download-memory/download-memory.spec.ts
+++ b/platform-frontend/e2e/download-memory/download-memory.spec.ts
@@ -1,0 +1,237 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+import type {
+  DownloadMemoryGateApi,
+  DownloadMemoryResult,
+  DownloadMemoryRunOptions,
+} from "./types";
+
+const SIZES = [64, 256, 512] as const;
+const BUFFER_LIMIT = 4 * 1024 * 1024;
+
+type GateWindow = Window & { downloadMemoryGate?: DownloadMemoryGateApi };
+
+interface SampledRun {
+  options: DownloadMemoryRunOptions;
+  result: DownloadMemoryResult;
+  heapStartUsedBytes: number;
+  heapPeakUsedBytes: number;
+  heapEndUsedBytes: number;
+}
+
+/** 打开隔离测试页并确认门禁 API 已由 Vite 模块安装。 */
+async function openGate(page: Page): Promise<void> {
+  await page.goto("/e2e/download-memory/");
+  await expect(page.locator("h1")).toHaveText("Download memory gate");
+  await page.waitForFunction(() =>
+    Boolean((window as GateWindow).downloadMemoryGate),
+  );
+}
+
+/** 启动浏览器内下载，同时用 Chromium CDP 采集辅助 heap 指标。 */
+async function runWithHeapSampling(
+  page: Page,
+  options: DownloadMemoryRunOptions,
+  testInfo: TestInfo,
+): Promise<SampledRun> {
+  const session = await page.context().newCDPSession(page);
+  await session.send("HeapProfiler.enable");
+  await session.send("HeapProfiler.collectGarbage");
+  const runId = await page.evaluate((runOptions) => {
+    const gate = (window as GateWindow).downloadMemoryGate;
+    if (!gate) throw new Error("download memory gate is not installed");
+    return gate.start(runOptions);
+  }, options);
+  const heapSamples: number[] = [];
+  let done = false;
+  while (!done) {
+    const usage = await session.send("Runtime.getHeapUsage");
+    heapSamples.push(usage.usedSize);
+    const status = await page.evaluate((id) => {
+      const gate = (window as GateWindow).downloadMemoryGate;
+      if (!gate) throw new Error("download memory gate disappeared");
+      return gate.status(id);
+    }, runId);
+    done = status.done;
+    if (!done) {
+      if (heapSamples.length % 5 === 0) {
+        await session.send("HeapProfiler.collectGarbage");
+      }
+      await page.waitForTimeout(100);
+    }
+  }
+  const result = await page.evaluate((id) => {
+    const gate = (window as GateWindow).downloadMemoryGate;
+    if (!gate) throw new Error("download memory gate disappeared");
+    return gate.wait(id);
+  }, runId);
+  const heapStartUsedBytes = heapSamples[0] ?? 0;
+  const heapPeakUsedBytes = Math.max(...heapSamples, heapStartUsedBytes);
+  const heapEndUsedBytes = heapSamples.at(-1) ?? heapStartUsedBytes;
+  await testInfo.attach(
+    `download-memory-${options.format.toLowerCase()}-${options.sizeMiB}mib-${options.failure ?? "success"}`,
+    {
+      body: JSON.stringify(
+        {
+          options,
+          result,
+          heapStartUsedBytes,
+          heapPeakUsedBytes,
+          heapEndUsedBytes,
+          chromiumVersion: page.context().browser()?.version(),
+        },
+        null,
+        2,
+      ),
+      contentType: "application/json",
+    },
+  );
+  await session.detach();
+  return {
+    options,
+    result,
+    heapStartUsedBytes,
+    heapPeakUsedBytes,
+    heapEndUsedBytes,
+  };
+}
+
+/** 断言 NONE 大文件使用真实 OPFS sink 且应用层 buffer 不随文件放大。 */
+test("NONE 64/256/512MiB stays within a non-growing buffer budget", async ({
+  page,
+}, testInfo) => {
+  await openGate(page);
+  const runs: SampledRun[] = [];
+  for (const sizeMiB of SIZES) {
+    const run = await runWithHeapSampling(
+      page,
+      { format: "NONE", sizeMiB },
+      testInfo,
+    );
+    runs.push(run);
+    expect(run.result.ok, run.result.error).toBe(true);
+    expect(run.result.metrics.currentBufferedBytes).toBe(0);
+    expect(run.result.metrics.framesAuthenticated).toBe(0);
+    expect(run.result.metrics.partsCompleted).toBe(1);
+    expect(run.result.metrics.bytesWritten).toBe(sizeMiB * 1024 * 1024);
+    expect(run.result.metrics.peakBufferedBytes).toBeLessThanOrEqual(
+      BUFFER_LIMIT,
+    );
+    expect(run.result.sinkCloseCalls).toBe(1);
+    expect(run.result.sinkAbortCalls).toBe(0);
+    expect(run.result.outputValid).toBe(true);
+    expect(run.result.outputSize).toBe(sizeMiB * 1024 * 1024);
+  }
+  const peaks = runs.map((run) => run.result.metrics.peakBufferedBytes);
+  expect(peaks[2]).toBeLessThanOrEqual(peaks[0] + 1024 * 1024);
+  const heapDeltas = runs.map(
+    (run) => run.heapPeakUsedBytes - run.heapStartUsedBytes,
+  );
+  expect(heapDeltas[2]).toBeLessThan(heapDeltas[0] + 64 * 1024 * 1024);
+  expect(heapDeltas[2]).toBeLessThan(192 * 1024 * 1024);
+});
+
+/** 断言 framed v2 三档文件逐 frame 认证后才写入 OPFS，且 buffer 不增长。 */
+test("framed v2 64/256/512MiB authenticates bounded frames", async ({
+  page,
+}, testInfo) => {
+  await openGate(page);
+  const runs: SampledRun[] = [];
+  for (const sizeMiB of SIZES) {
+    const run = await runWithHeapSampling(
+      page,
+      { format: "FRAMED_V2", sizeMiB },
+      testInfo,
+    );
+    runs.push(run);
+    expect(run.result.ok, run.result.error).toBe(true);
+    expect(run.result.metrics.currentBufferedBytes).toBe(0);
+    expect(run.result.metrics.framesAuthenticated).toBe(sizeMiB);
+    expect(run.result.metrics.partsCompleted).toBe(1);
+    expect(run.result.metrics.bytesWritten).toBe(sizeMiB * 1024 * 1024);
+    expect(run.result.metrics.peakBufferedBytes).toBeLessThanOrEqual(
+      BUFFER_LIMIT,
+    );
+    expect(run.result.sinkCloseCalls).toBe(1);
+    expect(run.result.sinkAbortCalls).toBe(0);
+    expect(run.result.outputValid).toBe(true);
+    expect(run.result.outputSize).toBe(sizeMiB * 1024 * 1024);
+  }
+  const peaks = runs.map((run) => run.result.metrics.peakBufferedBytes);
+  expect(peaks[2]).toBeLessThanOrEqual(peaks[0] + 1024 * 1024);
+  const heapDeltas = runs.map(
+    (run) => run.heapPeakUsedBytes - run.heapStartUsedBytes,
+  );
+  expect(heapDeltas[2]).toBeLessThan(heapDeltas[0] + 64 * 1024 * 1024);
+  expect(heapDeltas[2]).toBeLessThan(192 * 1024 * 1024);
+});
+
+/** 断言篡改、截断、取消和 sink abort 都在 close 前失败并保留原 OPFS 文件。 */
+test("tamper, truncate, cancel and sink abort fail closed", async ({
+  page,
+}, testInfo) => {
+  await openGate(page);
+  const failures: Array<DownloadMemoryRunOptions> = [
+    { format: "FRAMED_V2", sizeMiB: 64, failure: "tamper" },
+    { format: "FRAMED_V2", sizeMiB: 64, failure: "truncate" },
+    { format: "NONE", sizeMiB: 64, failure: "cancel" },
+    { format: "FRAMED_V2", sizeMiB: 64, failure: "abort" },
+  ];
+  for (const options of failures) {
+    const run = await runWithHeapSampling(page, options, testInfo);
+    expect(run.result.ok).toBe(false);
+    expect(run.result.error).toBeTruthy();
+    expect(run.result.sinkCloseCalls).toBe(0);
+    expect(run.result.sinkAbortCalls).toBeGreaterThan(0);
+    expect(run.result.sentinelPreserved).toBe(true);
+    if (options.failure === "cancel") {
+      expect(run.result.streamCancelled).toBe(true);
+    }
+  }
+});
+
+/** 断言 frame 坐标、密钥/AAD 绑定和过期 URL 都在 close 前失败。 */
+test("reorder, duplicate, key substitution and expired URLs fail closed", async ({
+  page,
+}, testInfo) => {
+  await openGate(page);
+  const failures: Array<{
+    options: DownloadMemoryRunOptions;
+    expectedError: string;
+  }> = [
+    {
+      options: { format: "FRAMED_V2", sizeMiB: 64, failure: "reorder" },
+      expectedError: "framed AEAD frame header 与 manifest 不一致",
+    },
+    {
+      options: { format: "FRAMED_V2", sizeMiB: 64, failure: "duplicate" },
+      expectedError: "framed AEAD frame header 与 manifest 不一致",
+    },
+    {
+      options: { format: "FRAMED_V2", sizeMiB: 64, failure: "wrong-key" },
+      expectedError: "framed AEAD 分片 0 frame 0 认证失败",
+    },
+    {
+      options: { format: "FRAMED_V2", sizeMiB: 64, failure: "cross-file" },
+      expectedError: "framed AEAD 分片 0 frame 0 认证失败",
+    },
+    {
+      options: { format: "FRAMED_V2", sizeMiB: 64, failure: "expired-401" },
+      expectedError: "下载地址已过期，请重新发起下载",
+    },
+    {
+      options: { format: "FRAMED_V2", sizeMiB: 64, failure: "expired-403" },
+      expectedError: "下载地址已过期，请重新发起下载",
+    },
+  ];
+
+  for (const { options, expectedError } of failures) {
+    const run = await runWithHeapSampling(page, options, testInfo);
+    expect(run.result.ok).toBe(false);
+    expect(run.result.error).toBe(expectedError);
+    expect(run.result.sinkCloseCalls).toBe(0);
+    expect(run.result.sinkAbortCalls).toBeGreaterThan(0);
+    expect(run.result.sentinelPreserved).toBe(true);
+    expect(run.result.fetchAttempts).toBe(1);
+  }
+});

--- a/platform-frontend/e2e/download-memory/fixtures.ts
+++ b/platform-frontend/e2e/download-memory/fixtures.ts
@@ -1,0 +1,455 @@
+import type {
+  FileDownloadMetadataVO,
+  FileDownloadPartVO,
+} from "../../src/lib/api/types/files";
+import {
+  buildFramedAad,
+  deriveFramedKeyMaterial,
+  FRAMED_AEAD_AAD_SCHEMA,
+  FRAMED_AEAD_FORMAT_VERSION,
+  FRAMED_AEAD_FRAME_HEADER_BYTES,
+  FRAMED_AEAD_HEADER_BYTES,
+  FRAMED_AEAD_SUITE,
+  FRAMED_AEAD_TAG_BYTES,
+} from "../../src/lib/utils/framedAead";
+import {
+  bytesToHex,
+  createSha256,
+  decodeBase64,
+} from "../../src/lib/utils/downloadIntegrity";
+import type { DownloadMemoryFailure, DownloadMemoryRunOptions } from "./types";
+
+export const FRAME_PLAIN_SIZE = 1024 * 1024;
+export const DOWNLOAD_SIZES_MIB = [64, 256, 512] as const;
+export const FILE_NONCE_BASE64 = "AQIDBAUGBwgJCgsMDQ4PEA==";
+export const FILE_DEK_BASE64 = "oKGio6SlpqeoqaqrrK2ur7CxsrO0tba3uLm6u7y9vr8=";
+const CROSS_FILE_NONCE_BASE64 = "EBESExQVFhcYGRobHB0eHw==";
+const WRONG_FILE_DEK_BASE64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+
+const NETWORK_CHUNK_SIZES = [131_071, 524_287, 1_048_573, 262_147] as const;
+
+interface FixtureProfile {
+  sizeBytes: number;
+  frameCount: number;
+  encodedSize: number;
+  plainHash: string;
+  cipherHash: string;
+}
+
+/** 递归排序 manifest 键并按 Jackson NON_NULL 规则移除空值。 */
+function canonicalizeManifestValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeManifestValue);
+  }
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => entry !== null && entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalizeManifestValue(entry)]),
+  );
+}
+
+/** 生成与后端 canonicalizer 一致的 UTF-8 manifest JSON 和 SHA-256。 */
+function createCanonicalManifest(
+  options: DownloadMemoryRunOptions,
+  profile: FixtureProfile,
+  part: FileDownloadPartVO,
+  encryption: FileDownloadMetadataVO["encryption"],
+): { json: string; hash: string } {
+  const payload = canonicalizeManifestValue({
+    schema: "chunk-manifest.v1",
+    fileHash: profile.plainHash,
+    hashAlgorithm: "SHA-256",
+    chunkSize: profile.sizeBytes,
+    totalSize: profile.sizeBytes,
+    encryptionAlgorithm:
+      options.format === "FRAMED_V2" ? "FRAMED_AEAD_V2" : "NONE",
+    storageBackend: "OPFS",
+    encryption,
+    chunks: [
+      {
+        index: part.index,
+        plainHash: part.plainHash,
+        cipherHash: part.cipherHash,
+        size: part.size,
+        storagePath: part.storagePath,
+        storageBackend: part.storageBackend ?? "OPFS",
+        checksumAlgorithm: part.checksumAlgorithm ?? "SHA-256",
+        plainSize: part.plainSize,
+        frameCount: part.frameCount,
+      },
+    ],
+  });
+  const json = JSON.stringify(payload);
+  const digest = createSha256();
+  digest.update(new TextEncoder().encode(json));
+  return { json, hash: `sha256:${bytesToHex(digest.digest())}` };
+}
+
+const FIXTURE_PROFILES: Record<
+  (typeof DOWNLOAD_SIZES_MIB)[number],
+  FixtureProfile
+> = {
+  64: {
+    sizeBytes: 67_108_864,
+    frameCount: 64,
+    encodedSize: 67_110_700,
+    plainHash:
+      "sha256:281e519df3077b557c6b03f5da83c4e8d397219259615dd7c3308f89cae8f2a6",
+    cipherHash:
+      "sha256:636b3dafe61a9c414c4a2529680ef634d5a9483e791476aa97a9e88cd1f6a1dd",
+  },
+  256: {
+    sizeBytes: 268_435_456,
+    frameCount: 256,
+    encodedSize: 268_442_668,
+    plainHash:
+      "sha256:486cc817b95d853d3c357ff283b204c0144bd255e73fe2deb1389493b257e3c0",
+    cipherHash:
+      "sha256:9925607532083f8393c870d241f5860abac747fed3cab37e6b374dbe68b8dad9",
+  },
+  512: {
+    sizeBytes: 536_870_912,
+    frameCount: 512,
+    encodedSize: 536_885_292,
+    plainHash:
+      "sha256:c047731a3c134f3d34286d608e9c173027d50f43ab9d2064f3c360939977e908",
+    cipherHash:
+      "sha256:c49e684216df495873c758d8099b548a734a73a1cb8e5f10673f9e6430672516",
+  },
+};
+
+export interface SyntheticStreamState {
+  emittedBytes: number;
+  cancelled: boolean;
+  cancelReason: string | null;
+}
+
+export interface SyntheticResponse {
+  response: Response;
+  state: SyntheticStreamState;
+}
+
+/** 返回固定大小档位的合成下载合同，避免测试依赖后端或真实对象存储。 */
+export function getFixtureProfile(
+  sizeMiB: DownloadMemoryRunOptions["sizeMiB"],
+): FixtureProfile {
+  return FIXTURE_PROFILES[sizeMiB];
+}
+
+/** 构造 deterministic 明文，使大文件测试不需要预分配完整文件。 */
+export function createPlainBytes(offset: number, length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  for (let index = 0; index < length; index++) {
+    bytes[index] = (offset + index) & 0xff;
+  }
+  return bytes;
+}
+
+/** 构造 NONE 或 framed v2 的 metadata，并绑定固定 hash/尺寸证据。 */
+export function createDownloadMetadata(
+  options: DownloadMemoryRunOptions,
+): FileDownloadMetadataVO {
+  const profile = getFixtureProfile(options.sizeMiB);
+  const isFramed = options.format === "FRAMED_V2";
+  const part: FileDownloadPartVO = {
+    index: 0,
+    size: isFramed ? profile.encodedSize : profile.sizeBytes,
+    downloadUrl: `https://download-memory.test/${options.format.toLowerCase()}/${options.sizeMiB}`,
+    expiresAtEpochSeconds: 4_000_000_000,
+    storagePath: `fixtures/${options.format.toLowerCase()}/${options.sizeMiB}`,
+    storageBackend: "OPFS",
+    plainHash: profile.plainHash,
+    cipherHash: isFramed ? profile.cipherHash : profile.plainHash,
+    checksumAlgorithm: "SHA-256",
+    plainSize: profile.sizeBytes,
+    frameCount: isFramed ? profile.frameCount : undefined,
+  };
+  const encryption = isFramed
+    ? {
+        formatVersion: FRAMED_AEAD_FORMAT_VERSION,
+        algorithmSuite: FRAMED_AEAD_SUITE,
+        fileNonce:
+          options.failure === "cross-file"
+            ? CROSS_FILE_NONCE_BASE64
+            : FILE_NONCE_BASE64,
+        framePlainSize: FRAME_PLAIN_SIZE,
+        keyDerivation: "HKDF-SHA256",
+        nonceDerivation: "HKDF-SHA256",
+        aadSchema: FRAMED_AEAD_AAD_SCHEMA,
+        tagSize: FRAMED_AEAD_TAG_BYTES,
+      }
+    : undefined;
+  const manifest = createCanonicalManifest(options, profile, part, encryption);
+  return {
+    fileId: `playwright-${options.format}-${options.sizeMiB}`,
+    fileHash: profile.plainHash,
+    fileName: `download-memory-${options.format}-${options.sizeMiB}.bin`,
+    fileSize: profile.sizeBytes,
+    contentType: "application/octet-stream",
+    initialKey: isFramed
+      ? options.failure === "wrong-key"
+        ? WRONG_FILE_DEK_BASE64
+        : FILE_DEK_BASE64
+      : undefined,
+    manifestSchemaId: "chunk-manifest.v1",
+    manifestHash: manifest.hash,
+    canonicalManifestJson: manifest.json,
+    hashAlgorithm: "SHA-256",
+    encryptionAlgorithm: isFramed ? "FRAMED_AEAD_V2" : "NONE",
+    storageBackend: "OPFS",
+    chunkSize: profile.sizeBytes,
+    totalChunks: 1,
+    parts: [part],
+    encryption,
+  };
+}
+
+/** 写入 framed wire format 使用的无符号大端整数。 */
+function writeUint32(bytes: Uint8Array, offset: number, value: number): void {
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).setUint32(
+    offset,
+    value,
+    false,
+  );
+}
+
+/** 创建单个 framed chunk header。 */
+function createChunkHeader(
+  profile: FixtureProfile,
+  failure?: DownloadMemoryFailure,
+): Uint8Array {
+  const header = new Uint8Array(FRAMED_AEAD_HEADER_BYTES);
+  header.set(new TextEncoder().encode("RPF2"), 0);
+  header[4] = FRAMED_AEAD_FORMAT_VERSION;
+  header[5] = 1;
+  writeUint32(header, 8, 0);
+  writeUint32(header, 12, 1);
+  writeUint32(header, 16, FRAME_PLAIN_SIZE);
+  writeUint32(header, 20, profile.frameCount);
+  writeUint32(header, 24, profile.sizeBytes);
+  header.set(
+    decodeBase64(
+      failure === "cross-file" ? CROSS_FILE_NONCE_BASE64 : FILE_NONCE_BASE64,
+    ),
+    28,
+  );
+  return header;
+}
+
+/** 将输出位置映射为实际 frame 坐标，用于构造重排和重复 wire 序列。 */
+function resolveWireFrameIndex(
+  framePosition: number,
+  failure?: DownloadMemoryFailure,
+): number {
+  if (failure === "reorder") {
+    if (framePosition === 0) return 1;
+    if (framePosition === 1) return 0;
+  }
+  if (failure === "duplicate" && framePosition === 1) return 0;
+  return framePosition;
+}
+
+/** 对一个明文 frame 生成与 Java writer 合同一致的 AES-GCM 密文。 */
+async function encryptFrame(
+  frameIndex: number,
+  profile: FixtureProfile,
+  failure?: DownloadMemoryFailure,
+): Promise<Uint8Array> {
+  const plaintext = createPlainBytes(
+    frameIndex * FRAME_PLAIN_SIZE,
+    FRAME_PLAIN_SIZE,
+  );
+  const fileNonce = decodeBase64(FILE_NONCE_BASE64);
+  const material = deriveFramedKeyMaterial({
+    fileDek: decodeBase64(FILE_DEK_BASE64),
+    fileNonce,
+    chunkIndex: 0,
+    frameIndex,
+  });
+  const aad = buildFramedAad({
+    fileNonce,
+    chunkIndex: 0,
+    chunkCount: 1,
+    frameIndex,
+    frameCount: profile.frameCount,
+    plainLength: plaintext.byteLength,
+    chunkPlainSize: profile.sizeBytes,
+  });
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw",
+    material.key as unknown as BufferSource,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+  const ciphertext = new Uint8Array(
+    await globalThis.crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: material.nonce as unknown as BufferSource,
+        additionalData: aad as unknown as BufferSource,
+        tagLength: FRAMED_AEAD_TAG_BYTES * 8,
+      },
+      key,
+      plaintext as unknown as BufferSource,
+    ),
+  );
+  if (failure === "tamper" && frameIndex === 1) {
+    ciphertext[32] ^= 0xff;
+  }
+  return ciphertext;
+}
+
+/** 创建 framed frame header。 */
+function createFrameHeader(
+  frameIndex: number,
+  cipherLength: number,
+): Uint8Array {
+  const header = new Uint8Array(FRAMED_AEAD_FRAME_HEADER_BYTES);
+  writeUint32(header, 0, frameIndex);
+  writeUint32(header, 4, FRAME_PLAIN_SIZE);
+  writeUint32(header, 8, cipherLength);
+  return header;
+}
+
+/** 创建按任意网络边界切分的真实 ReadableStream Response。 */
+export function createSyntheticResponse(
+  options: DownloadMemoryRunOptions,
+): SyntheticResponse {
+  const profile = getFixtureProfile(options.sizeMiB);
+  const state: SyntheticStreamState = {
+    emittedBytes: 0,
+    cancelled: false,
+    cancelReason: null,
+  };
+  const truncateAt =
+    options.failure === "truncate" ? profile.encodedSize - 37 : null;
+  let networkChunkIndex = 0;
+  let pending: Uint8Array | null = null;
+  let pendingOffset = 0;
+  let nextFrameIndex = -1;
+  let framePhase: "header" | "ciphertext" = "header";
+  let finished = false;
+
+  /** 取出下一个 framed wire segment，保持只保留当前 frame。 */
+  async function ensureFramedSegment(): Promise<void> {
+    if (pending && pendingOffset < pending.byteLength) return;
+    pending = null;
+    pendingOffset = 0;
+    if (nextFrameIndex === -1) {
+      pending = createChunkHeader(profile, options.failure);
+      nextFrameIndex = 0;
+      return;
+    }
+    if (nextFrameIndex >= profile.frameCount) {
+      finished = true;
+      return;
+    }
+    if (framePhase === "header") {
+      const wireFrameIndex = resolveWireFrameIndex(
+        nextFrameIndex,
+        options.failure,
+      );
+      pending = createFrameHeader(
+        wireFrameIndex,
+        FRAME_PLAIN_SIZE + FRAMED_AEAD_TAG_BYTES,
+      );
+      framePhase = "ciphertext";
+      return;
+    }
+    pending = await encryptFrame(
+      resolveWireFrameIndex(nextFrameIndex, options.failure),
+      profile,
+      options.failure,
+    );
+    nextFrameIndex += 1;
+    framePhase = "header";
+  }
+
+  /** 生成一个有界网络 chunk，并在截断场景中提前结束流。 */
+  async function nextNetworkChunk(): Promise<Uint8Array | null> {
+    if (finished) return null;
+    const target =
+      NETWORK_CHUNK_SIZES[networkChunkIndex++ % NETWORK_CHUNK_SIZES.length];
+    if (options.format === "NONE") {
+      const remaining = profile.sizeBytes - state.emittedBytes;
+      if (remaining <= 0) {
+        finished = true;
+        return null;
+      }
+      const length = Math.min(
+        target,
+        remaining,
+        truncateAt == null ? remaining : truncateAt - state.emittedBytes,
+      );
+      if (length <= 0) {
+        finished = true;
+        return null;
+      }
+      const output = createPlainBytes(state.emittedBytes, length);
+      state.emittedBytes += output.byteLength;
+      if (truncateAt != null && state.emittedBytes >= truncateAt)
+        finished = true;
+      return output;
+    }
+
+    const output = new Uint8Array(target);
+    let written = 0;
+    while (written < output.byteLength && !finished) {
+      await ensureFramedSegment();
+      if (!pending) break;
+      const available = pending.byteLength - pendingOffset;
+      const take = Math.min(available, output.byteLength - written);
+      output.set(
+        pending.subarray(pendingOffset, pendingOffset + take),
+        written,
+      );
+      pendingOffset += take;
+      written += take;
+    }
+    if (written === 0) return null;
+    let chunk = output.subarray(0, written);
+    if (truncateAt != null) {
+      const allowed = truncateAt - state.emittedBytes;
+      if (allowed <= 0) return null;
+      if (chunk.byteLength > allowed) chunk = chunk.subarray(0, allowed);
+    }
+    state.emittedBytes += chunk.byteLength;
+    if (truncateAt != null && state.emittedBytes >= truncateAt) finished = true;
+    return chunk;
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await nextNetworkChunk();
+        if (!chunk) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      state.cancelled = true;
+      state.cancelReason =
+        reason instanceof Error ? reason.message : String(reason);
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: {
+        "content-length": String(
+          options.format === "NONE" ? profile.sizeBytes : profile.encodedSize,
+        ),
+        "content-type": "application/octet-stream",
+      },
+    }),
+    state,
+  };
+}

--- a/platform-frontend/e2e/download-memory/harness.ts
+++ b/platform-frontend/e2e/download-memory/harness.ts
@@ -1,0 +1,269 @@
+import type { FileSystemDownloadSink } from "../../src/lib/utils/downloadSink";
+import {
+  createFileSystemDownloadSink,
+  type DownloadSink,
+} from "../../src/lib/utils/downloadSink";
+import { executeBoundedDownload } from "../../src/lib/utils/boundedDownloader";
+import { DownloadMetricsTracker } from "../../src/lib/utils/downloadMetrics";
+import {
+  createDownloadMetadata,
+  createPlainBytes,
+  createSyntheticResponse,
+} from "./fixtures";
+import type {
+  DownloadMemoryGateApi,
+  DownloadMemoryResult,
+  DownloadMemoryRunOptions,
+  DownloadMemoryRunStatus,
+} from "./types";
+
+const SENTINEL = new TextEncoder().encode("pre-existing-opfs-content");
+const CANCEL_AFTER_BYTES = 8 * 1024 * 1024;
+const SAMPLE_BYTES = 64 * 1024;
+
+interface RunEntry {
+  done: boolean;
+  result?: DownloadMemoryResult;
+  promise?: Promise<DownloadMemoryResult>;
+}
+
+/** 包装真实 OPFS sink，记录 close/abort 并注入取消或写入失败。 */
+class ObservedSink implements DownloadSink {
+  readonly supportsRandomAccess: boolean;
+  closeCalls = 0;
+  abortCalls = 0;
+  private writtenBytes = 0;
+  private aborted = false;
+
+  constructor(
+    private readonly delegate: FileSystemDownloadSink,
+    private readonly options: DownloadMemoryRunOptions,
+    private readonly controller: AbortController,
+  ) {
+    this.supportsRandomAccess = delegate.supportsRandomAccess;
+  }
+
+  /** 顺序写入并在指定失败场景触发可控状态变化。 */
+  async write(data: Uint8Array): Promise<void> {
+    if (
+      this.options.failure === "abort" &&
+      this.writtenBytes >= CANCEL_AFTER_BYTES
+    ) {
+      throw new Error("synthetic OPFS sink failure");
+    }
+    await this.delegate.write(data);
+    this.writtenBytes += data.byteLength;
+    if (
+      this.options.failure === "cancel" &&
+      this.writtenBytes >= CANCEL_AFTER_BYTES
+    ) {
+      this.controller.abort("synthetic cancellation");
+    }
+  }
+
+  /** 支持历史路径需要的随机写入，并复用同一故障策略。 */
+  async writeAt(position: number, data: Uint8Array): Promise<void> {
+    if (
+      this.options.failure === "abort" &&
+      this.writtenBytes >= CANCEL_AFTER_BYTES
+    ) {
+      throw new Error("synthetic OPFS sink failure");
+    }
+    await this.delegate.writeAt(position, data);
+    this.writtenBytes += data.byteLength;
+  }
+
+  /** 记录事务提交次数。 */
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    await this.delegate.close();
+  }
+
+  /** 只向底层 OPFS 发起一次 abort，保持失败路径幂等。 */
+  async abort(reason?: unknown): Promise<void> {
+    this.abortCalls += 1;
+    if (this.aborted) return;
+    this.aborted = true;
+    await this.delegate.abort(reason);
+  }
+}
+
+/** 将短哨兵内容写入 OPFS，随后用 abort 证明原文件不会被半成品替换。 */
+async function seedOpfsFile(handle: FileSystemFileHandle): Promise<void> {
+  const writable = await handle.createWritable();
+  await writable.write(SENTINEL.buffer);
+  await writable.close();
+}
+
+/** 比较 OPFS 文件中的短样本，避免为校验再次把大文件装入内存。 */
+async function validateOutputSamples(
+  file: File,
+  expectedSize: number,
+): Promise<boolean> {
+  if (file.size !== expectedSize) return false;
+  const offsets = [
+    0,
+    Math.max(0, Math.floor(expectedSize / 2) - Math.floor(SAMPLE_BYTES / 2)),
+    Math.max(0, expectedSize - SAMPLE_BYTES),
+  ];
+  for (const offset of offsets) {
+    const length = Math.min(SAMPLE_BYTES, expectedSize - offset);
+    const actual = new Uint8Array(
+      await file.slice(offset, offset + length).arrayBuffer(),
+    );
+    const expected = createPlainBytes(offset, length);
+    if (actual.length !== expected.length) return false;
+    for (let index = 0; index < expected.length; index++) {
+      if (actual[index] !== expected[index]) return false;
+    }
+  }
+  return true;
+}
+
+/** 判断 abort 后 OPFS 是否仍保留原有哨兵内容。 */
+async function isSentinelPreserved(file: File): Promise<boolean> {
+  if (file.size !== SENTINEL.byteLength) return false;
+  const actual = new Uint8Array(await file.arrayBuffer());
+  return actual.every((value, index) => value === SENTINEL[index]);
+}
+
+/** 在独立 OPFS 文件上执行一次下载场景并返回可序列化证据。 */
+async function runScenario(
+  options: DownloadMemoryRunOptions,
+): Promise<DownloadMemoryResult> {
+  const metadata = createDownloadMetadata(options);
+  const root = await navigator.storage.getDirectory();
+  const fileName = `pw-${crypto.randomUUID()}.bin`;
+  const handle = await root.getFileHandle(fileName, { create: true });
+  await seedOpfsFile(handle);
+
+  const controller = new AbortController();
+  const synthetic = createSyntheticResponse(options);
+  const delegate = await createFileSystemDownloadSink(handle);
+  const sink = new ObservedSink(delegate, options, controller);
+  let responseUsed = false;
+  let fetchAttempts = 0;
+  const fetchImpl: typeof fetch = async (_input) => {
+    fetchAttempts += 1;
+    if (options.failure === "expired-401") {
+      return new Response(null, { status: 401 });
+    }
+    if (options.failure === "expired-403") {
+      return new Response(null, { status: 403 });
+    }
+    if (responseUsed) throw new Error("synthetic response reused");
+    responseUsed = true;
+    return synthetic.response;
+  };
+  const metrics = new DownloadMetricsTracker();
+  let ok = false;
+  let errorMessage: string | undefined;
+  try {
+    await executeBoundedDownload({
+      metadata,
+      expectedFileHash: metadata.fileHash,
+      sink,
+      signal: controller.signal,
+      fetchImpl,
+      metrics,
+    });
+    ok = true;
+  } catch (error) {
+    errorMessage = error instanceof Error ? error.message : String(error);
+  }
+
+  const file = await handle.getFile();
+  const outputValid = ok
+    ? await validateOutputSamples(file, metadata.fileSize)
+    : false;
+  const sentinelPreserved = ok ? false : await isSentinelPreserved(file);
+  const result: DownloadMemoryResult = {
+    ok,
+    format: options.format,
+    sizeMiB: options.sizeMiB,
+    error: errorMessage,
+    metrics: metrics.snapshot(),
+    fetchAttempts,
+    sinkCloseCalls: sink.closeCalls,
+    sinkAbortCalls: sink.abortCalls,
+    streamCancelled: synthetic.state.cancelled,
+    sentinelPreserved,
+    outputValid,
+    outputSize: file.size,
+    fileName,
+  };
+  await root.removeEntry(fileName);
+  return result;
+}
+
+const runs = new Map<string, RunEntry>();
+
+/** 启动异步下载场景，供 Playwright 在 Chromium 外部采样 heap。 */
+function start(options: DownloadMemoryRunOptions): string {
+  const runId = crypto.randomUUID();
+  const entry: RunEntry = {
+    done: false,
+  };
+  entry.promise = runScenario(options).then(
+    (result) => {
+      entry.done = true;
+      entry.result = result;
+      return result;
+    },
+    (error: unknown) => {
+      const result: DownloadMemoryResult = {
+        ok: false,
+        format: options.format,
+        sizeMiB: options.sizeMiB,
+        error: error instanceof Error ? error.message : String(error),
+        metrics: {
+          currentBufferedBytes: 0,
+          peakBufferedBytes: 0,
+          framesAuthenticated: 0,
+          partsCompleted: 0,
+          bytesWritten: 0,
+        },
+        fetchAttempts: 0,
+        sinkCloseCalls: 0,
+        sinkAbortCalls: 0,
+        streamCancelled: false,
+        sentinelPreserved: false,
+        outputValid: false,
+        outputSize: 0,
+        fileName: "",
+      };
+      entry.done = true;
+      entry.result = result;
+      return result;
+    },
+  );
+  runs.set(runId, entry);
+  return runId;
+}
+
+/** 返回当前场景是否完成以及已完成结果。 */
+function status(runId: string): DownloadMemoryRunStatus {
+  const entry = runs.get(runId);
+  if (!entry) throw new Error(`unknown download run: ${runId}`);
+  return { done: entry.done, result: entry.result };
+}
+
+/** 等待场景结束并返回完整指标。 */
+async function wait(runId: string): Promise<DownloadMemoryResult> {
+  const entry = runs.get(runId);
+  if (!entry?.promise) throw new Error(`unknown download run: ${runId}`);
+  return entry.promise;
+}
+
+declare global {
+  interface Window {
+    downloadMemoryGate: DownloadMemoryGateApi;
+  }
+}
+
+/** 将门禁 API 暴露到测试页，保持生产路由与后端完全隔离。 */
+function installDownloadMemoryGate(): void {
+  window.downloadMemoryGate = { start, status, wait };
+}
+
+installDownloadMemoryGate();

--- a/platform-frontend/e2e/download-memory/index.html
+++ b/platform-frontend/e2e/download-memory/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Download memory gate</title>
+  </head>
+  <body>
+    <main>
+      <h1>Download memory gate</h1>
+      <p id="status">Ready</p>
+    </main>
+    <script type="module" src="./harness.ts"></script>
+  </body>
+</html>

--- a/platform-frontend/e2e/download-memory/types.ts
+++ b/platform-frontend/e2e/download-memory/types.ts
@@ -1,0 +1,54 @@
+export type DownloadMemoryFormat = "NONE" | "FRAMED_V2";
+
+export type DownloadMemoryFailure =
+  | "tamper"
+  | "truncate"
+  | "cancel"
+  | "abort"
+  | "reorder"
+  | "duplicate"
+  | "wrong-key"
+  | "cross-file"
+  | "expired-401"
+  | "expired-403";
+
+export interface DownloadMemoryRunOptions {
+  format: DownloadMemoryFormat;
+  sizeMiB: 64 | 256 | 512;
+  failure?: DownloadMemoryFailure;
+}
+
+export interface DownloadMemoryMetrics {
+  currentBufferedBytes: number;
+  peakBufferedBytes: number;
+  framesAuthenticated: number;
+  partsCompleted: number;
+  bytesWritten: number;
+}
+
+export interface DownloadMemoryResult {
+  ok: boolean;
+  format: DownloadMemoryFormat;
+  sizeMiB: DownloadMemoryRunOptions["sizeMiB"];
+  error?: string;
+  metrics: DownloadMemoryMetrics;
+  fetchAttempts: number;
+  sinkCloseCalls: number;
+  sinkAbortCalls: number;
+  streamCancelled: boolean;
+  sentinelPreserved: boolean;
+  outputValid: boolean;
+  outputSize: number;
+  fileName: string;
+}
+
+export interface DownloadMemoryRunStatus {
+  done: boolean;
+  result?: DownloadMemoryResult;
+}
+
+export interface DownloadMemoryGateApi {
+  start(options: DownloadMemoryRunOptions): string;
+  status(runId: string): DownloadMemoryRunStatus;
+  wait(runId: string): Promise<DownloadMemoryResult>;
+}

--- a/platform-frontend/e2e/download-memory/vite.config.ts
+++ b/platform-frontend/e2e/download-memory/vite.config.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+const frontendRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+export default defineConfig({
+  root: frontendRoot,
+  resolve: {
+    alias: {
+      $api: path.resolve(frontendRoot, "src/lib/api"),
+      $components: path.resolve(frontendRoot, "src/lib/components"),
+      $services: path.resolve(frontendRoot, "src/lib/services"),
+      $stores: path.resolve(frontendRoot, "src/lib/stores"),
+      $utils: path.resolve(frontendRoot, "src/lib/utils"),
+    },
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 4174,
+    strictPort: true,
+  },
+});

--- a/platform-frontend/package.json
+++ b/platform-frontend/package.json
@@ -15,9 +15,11 @@
     "types:gen:check": "pnpm types:gen && git diff --exit-code -- src/lib/api/types/generated.ts",
     "test": "svelte-kit sync && vitest run",
     "test:watch": "svelte-kit sync && vitest",
-    "test:coverage": "svelte-kit sync && vitest run --coverage"
+    "test:coverage": "svelte-kit sync && vitest run --coverage",
+    "test:e2e:download-memory": "playwright test --config=playwright.download-memory.config.ts"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@eslint/js": "^10.0.1",
     "@internationalized/date": "^3.12.1",
     "@lucide/svelte": "^1.14.0",
@@ -52,6 +54,7 @@
   },
   "dependencies": {
     "@noble/ciphers": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "clsx": "^2.1.1",
     "echarts": "^6.1.0",
     "mode-watcher": "^1.1.0",

--- a/platform-frontend/playwright.download-memory.config.ts
+++ b/platform-frontend/playwright.download-memory.config.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "@playwright/test";
+
+const frontendRoot = path.dirname(fileURLToPath(import.meta.url));
+const testResults = path.resolve(
+  frontendRoot,
+  "output/playwright/download-memory",
+);
+
+export default defineConfig({
+  testDir: path.resolve(frontendRoot, "e2e/download-memory"),
+  testMatch: "**/*.spec.ts",
+  outputDir: testResults,
+  fullyParallel: false,
+  workers: 1,
+  timeout: 15 * 60 * 1000,
+  expect: {
+    timeout: 30 * 1000,
+  },
+  reporter: process.env.CI
+    ? [["dot"], ["json", { outputFile: path.join(testResults, "report.json") }]]
+    : [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:4174",
+    serviceWorkers: "block",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        browserName: "chromium",
+        launchOptions: {
+          args: ["--js-flags=--expose-gc"],
+        },
+      },
+    },
+  ],
+  webServer: {
+    command: "pnpm exec vite --config e2e/download-memory/vite.config.ts",
+    url: "http://127.0.0.1:4174/e2e/download-memory/",
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/platform-frontend/pnpm-lock.yaml
+++ b/platform-frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@noble/ciphers':
         specifier: ^2.2.0
         version: 2.2.0
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -57,6 +60,9 @@ importers:
       '@lucide/svelte':
         specifier: ^1.14.0
         version: 1.16.0(svelte@5.55.7(@typescript-eslint/types@8.59.3))
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
         version: 3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))
@@ -74,13 +80,13 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.7
-        version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))
+        version: 5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))
       '@types/node':
         specifier: ^25.6.2
         version: 25.8.0
       '@vitest/coverage-v8':
         specifier: 3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))
+        version: 3.2.6(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))
       bits-ui:
         specifier: ^2.18.1
         version: 2.18.1(@internationalized/date@3.12.1)(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@5.9.3)(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))
@@ -98,7 +104,7 @@ importers:
         version: 17.6.0
       jsdom:
         specifier: ^29.1.1
-        version: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -140,7 +146,7 @@ importers:
         version: 7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3)
+        version: 3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3)
 
 packages:
 
@@ -547,6 +553,10 @@ packages:
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
@@ -562,6 +572,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1407,6 +1422,11 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1837,6 +1857,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -2642,7 +2672,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -2742,6 +2774,8 @@ snapshots:
 
   '@noble/ciphers@2.2.0': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/deferred-promise@3.0.0': {}
@@ -2755,6 +2789,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -3003,14 +3041,14 @@ snapshots:
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.59.3)
 
-  '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))':
+  '@testing-library/svelte@5.3.1(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.0.0(svelte@5.55.7(@typescript-eslint/types@8.59.3))
       svelte: 5.55.7(@typescript-eslint/types@8.59.3)
     optionalDependencies:
       vite: 7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
-      vitest: 3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3)
+      vitest: 3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3)
 
   '@types/aria-query@5.0.4': {}
 
@@ -3134,7 +3172,7 @@ snapshots:
       '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3149,7 +3187,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3)
+      vitest: 3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3346,10 +3384,10 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -3594,6 +3632,9 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3629,9 +3670,9 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.0.1
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -3719,17 +3760,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.1.1:
+  jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.6
       parse5: 8.0.1
@@ -3740,7 +3781,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -3999,6 +4040,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 
@@ -4425,7 +4474,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3):
+  vitest@3.2.6(@types/node@25.8.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -4452,7 +4501,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.8.0
-      jsdom: 29.1.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -4475,9 +4524,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:

--- a/platform-frontend/src/lib/api/types/files.ts
+++ b/platform-frontend/src/lib/api/types/files.ts
@@ -230,6 +230,25 @@ export type DirectUploadCompleteVO = OpenApiSchema<"DirectUploadCompleteVO">;
  * 文件分片预签名下载元数据。
  * @see FileDownloadPartVO.java
  */
+export interface ChunkManifestEncryption {
+  /** 合同格式版本：0/1 为历史语义，2 为 framed AEAD。 */
+  formatVersion: number;
+  /** 允许的加密套件名称。 */
+  algorithmSuite: string;
+  /** 文件级 nonce，Base64 或 Base64URL。 */
+  fileNonce: string;
+  /** 每个 frame 的明文目标大小。 */
+  framePlainSize: number;
+  /** frame key 派生算法。 */
+  keyDerivation: string;
+  /** frame nonce 派生算法。 */
+  nonceDerivation: string;
+  /** AAD 规范标识。 */
+  aadSchema: string;
+  /** GCM tag 字节数。 */
+  tagSize: number;
+}
+
 export interface FileDownloadPartVO {
   /** 分片索引，从 0 开始 */
   index: number;
@@ -241,12 +260,20 @@ export interface FileDownloadPartVO {
   expiresAtEpochSeconds: number;
   /** 分片 storagePath */
   storagePath: string;
+  /** manifest 归属的存储后端；用于绑定 canonical manifest。 */
+  storageBackend?: string | null;
+  /** manifest 中的对象 ETag；历史 metadata 可能为空。 */
+  etag?: string | null;
   /** 明文分片哈希 */
   plainHash: string;
   /** 密文分片哈希 */
   cipherHash: string;
   /** 校验算法 */
   checksumAlgorithm?: string | null;
+  /** 明文分片字节数；历史 manifest 可能为空。 */
+  plainSize?: number | null;
+  /** framed v2 的 frame 数量；历史格式为空。 */
+  frameCount?: number | null;
 }
 
 /**
@@ -262,12 +289,16 @@ export interface FileDownloadMetadataVO {
   initialKey?: string;
   manifestSchemaId: string;
   manifestHash: string;
+  /** canonical manifest JSON，不包含 initialKey/file DEK。 */
+  canonicalManifestJson: string;
   hashAlgorithm: string;
   encryptionAlgorithm?: string;
   storageBackend: string;
   chunkSize: number;
   totalChunks: number;
   parts: FileDownloadPartVO[];
+  /** 可选加密描述；为空时按历史 v1/NONE 兼容语义读取。 */
+  encryption?: ChunkManifestEncryption | null;
 }
 
 /**
@@ -455,6 +486,8 @@ export interface FileDecryptInfoVO extends OpenApiSchema<"FileDecryptInfoVO"> {
   chunkCount: number;
   /** 文件哈希 */
   fileHash: string;
+  /** 原始上传分片大小；历史文件可能为空。 */
+  chunkSize?: number;
 }
 
 /**

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -3494,6 +3494,11 @@ export interface components {
              * @description 分片数量
              */
             chunkCount?: number;
+            /**
+             * Format: int64
+             * @description 原始上传分片大小；历史文件可能为空
+             */
+            chunkSize?: number;
             /** @description 文件MIME类型 */
             contentType?: string;
             /** @description 文件哈希 */
@@ -3508,8 +3513,38 @@ export interface components {
             /** @description 初始密钥（最后一个分片的解密密钥，Base64编码） */
             initialKey?: string;
         };
+        /** @description 文件下载加密格式描述 */
+        FileDownloadEncryptionVO: {
+            /** @description AAD 字节合同标识 */
+            aadSchema?: string;
+            /** @description 算法套件 */
+            algorithmSuite?: string;
+            /** @description 文件级 nonce，Base64URL 无填充 */
+            fileNonce?: string;
+            /**
+             * Format: int32
+             * @description 加密格式版本：0=NONE，1=legacy，2=framed AEAD
+             */
+            formatVersion?: number;
+            /**
+             * Format: int32
+             * @description 单帧明文大小
+             */
+            framePlainSize?: number;
+            /** @description 帧密钥派生算法 */
+            keyDerivation?: string;
+            /** @description 帧 nonce 派生算法 */
+            nonceDerivation?: string;
+            /**
+             * Format: int32
+             * @description AEAD 标签字节数
+             */
+            tagSize?: number;
+        };
         /** @description 文件预签名分片下载元数据 */
         FileDownloadMetadataVO: {
+            /** @description 不含密钥材料的 canonical manifest JSON */
+            canonicalManifestJson?: string;
             /**
              * Format: int64
              * @description 分片大小
@@ -3517,6 +3552,7 @@ export interface components {
             chunkSize?: number;
             /** @description 文件 MIME 类型 */
             contentType?: string;
+            encryption?: components["schemas"]["FileDownloadEncryptionVO"];
             /** @description 加密算法 */
             encryptionAlgorithm?: string;
             /** @description 文件哈希 */
@@ -3556,11 +3592,18 @@ export interface components {
             cipherHash?: string;
             /** @description 预签名下载 URL */
             downloadUrl?: string;
+            /** @description manifest 中的对象 ETag；历史 metadata 可为空 */
+            etag?: string;
             /**
              * Format: int64
              * @description URL 过期时间（Unix 秒）
              */
             expiresAtEpochSeconds?: number;
+            /**
+             * Format: int32
+             * @description 分片认证 frame 数量；非 v2 可为空
+             */
+            frameCount?: number;
             /**
              * Format: int32
              * @description 分片索引，从 0 开始
@@ -3570,9 +3613,16 @@ export interface components {
             plainHash?: string;
             /**
              * Format: int64
+             * @description 分片明文字节数；历史 manifest 可为空
+             */
+            plainSize?: number;
+            /**
+             * Format: int64
              * @description 分片字节数
              */
             size?: number;
+            /** @description manifest 归属的存储后端 */
+            storageBackend?: string;
             /** @description 分片 storagePath */
             storagePath?: string;
         };

--- a/platform-frontend/src/lib/stores/download.svelte.test.ts
+++ b/platform-frontend/src/lib/stores/download.svelte.test.ts
@@ -35,9 +35,14 @@ const mocks = vi.hoisted(() => {
       performPreDownloadCheck: vi.fn(),
       formatFileSize: vi.fn(),
       isStreamingSupported: vi.fn(),
+      MAX_SAFE_INMEMORY_SIZE: 64 * 1024 * 1024,
     },
     streaming: {
       executeBufferedStreamingDownload: vi.fn(),
+    },
+    boundedDownloader: {
+      executeBoundedDownload: vi.fn(),
+      executeLegacyFallbackDownload: vi.fn(),
     },
   };
 });
@@ -54,6 +59,16 @@ vi.mock("$utils/downloadStorage", () => mocks.downloadStorage);
 vi.mock("$utils/crypto", () => mocks.crypto);
 vi.mock("$utils/fileSize", () => mocks.fileSize);
 vi.mock("$utils/streamingDownloader", () => mocks.streaming);
+vi.mock("$utils/boundedDownloader", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("$utils/boundedDownloader")>();
+  return {
+    ...actual,
+    executeBoundedDownload: mocks.boundedDownloader.executeBoundedDownload,
+    executeLegacyFallbackDownload:
+      mocks.boundedDownloader.executeLegacyFallbackDownload,
+  };
+});
 
 const AUTH_CONTEXT_HASH =
   "ef7b394c6766be8db576d762d728771fb2bc198bb24831d7a2b5cc628c4210e1";
@@ -114,6 +129,42 @@ async function waitForBatchStatus(
  */
 function createBlob(): Blob {
   return new Blob(["content"], { type: "application/octet-stream" });
+}
+
+/**
+ * 完成一次 store 级有界下载 mock，并保持 sink 的 close/读取语义。
+ */
+async function completeBoundedDownload(options: {
+  sink: { write(data: Uint8Array): Promise<void>; close(): Promise<void> };
+  metadata?: { fileSize: number; totalChunks: number };
+  fileSize?: number;
+  totalChunks?: number;
+  onPartComplete?: (completed: number, total: number) => void;
+}) {
+  const fileSize = options.metadata?.fileSize ?? options.fileSize ?? 0;
+  const totalChunks = options.metadata?.totalChunks ?? options.totalChunks ?? 0;
+  await options.sink.write(new Uint8Array(fileSize));
+  options.onPartComplete?.(totalChunks, totalChunks);
+  await options.sink.close();
+  return {
+    currentBufferedBytes: 0,
+    peakBufferedBytes: fileSize > 0 ? 1 : 0,
+    framesAuthenticated: 0,
+    partsCompleted: totalChunks,
+    bytesWritten: fileSize,
+  };
+}
+
+/** 创建可供 FileSystemDownloadSink 包装的事务性测试句柄。 */
+function createWritableHandle() {
+  return {
+    createWritable: vi.fn(async () => ({
+      write: vi.fn(async () => {}),
+      seek: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      abort: vi.fn(async () => {}),
+    })),
+  };
 }
 
 /**
@@ -230,9 +281,15 @@ describe("download store", () => {
       success: true,
       bytesWritten: 100,
     });
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementation(
+      completeBoundedDownload,
+    );
+    mocks.boundedDownloader.executeLegacyFallbackDownload.mockImplementation(
+      completeBoundedDownload,
+    );
 
     Object.defineProperty(window, "showSaveFilePicker", {
-      value: vi.fn().mockResolvedValue({ handle: "h" }),
+      value: vi.fn().mockResolvedValue(createWritableHandle()),
       configurable: true,
     });
   });
@@ -266,8 +323,8 @@ describe("download store", () => {
     expect(mocks.fileApi.getDownloadMetadata).toHaveBeenCalledWith("hash-1");
     expect(mocks.fileApi.getDownloadAddress).not.toHaveBeenCalled();
     expect(mocks.fileApi.getDecryptInfo).not.toHaveBeenCalled();
-    expect(mocks.chunkDownloader.downloadAllChunks).toHaveBeenCalled();
-    expect(mocks.crypto.decryptFile).toHaveBeenCalled();
+    expect(mocks.boundedDownloader.executeBoundedDownload).toHaveBeenCalled();
+    expect(mocks.crypto.decryptFile).not.toHaveBeenCalled();
     expect(mocks.crypto.downloadBlob).toHaveBeenCalled();
     expect(mocks.downloadStorage.saveTask).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -304,9 +361,15 @@ describe("download store", () => {
       "hash-legacy",
     );
     expect(mocks.fileApi.getDecryptInfo).toHaveBeenCalledWith("hash-legacy");
-    expect(mocks.chunkDownloader.downloadAllChunks).toHaveBeenCalledWith(
-      ["legacy-u1"],
-      expect.any(Object),
+    expect(
+      mocks.boundedDownloader.executeLegacyFallbackDownload,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urls: ["legacy-u1"],
+        encrypted: true,
+        fileSize: 1024,
+        totalChunks: 1,
+      }),
     );
   });
 
@@ -372,6 +435,7 @@ describe("download store", () => {
       initialKey: null,
       encryptionAlgorithm: "NONE",
       contentType: "application/octet-stream",
+      fileSize: 3,
       totalChunks: 2,
       parts: [
         {
@@ -396,10 +460,24 @@ describe("download store", () => {
         },
       ],
     });
-    mocks.chunkDownloader.downloadAllChunks.mockResolvedValueOnce([
-      new Uint8Array([1, 2]),
-      new Uint8Array([3]),
-    ]);
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementationOnce(
+      async (options: {
+        sink: {
+          write(data: Uint8Array): Promise<void>;
+          close(): Promise<void>;
+        };
+      }) => {
+        await options.sink.write(new Uint8Array([1, 2, 3]));
+        await options.sink.close();
+        return {
+          currentBufferedBytes: 0,
+          peakBufferedBytes: 3,
+          framesAuthenticated: 0,
+          partsCompleted: 2,
+          bytesWritten: 3,
+        };
+      },
+    );
 
     const download = await loadDownloadStore();
     const id = await download.startDownload(
@@ -495,17 +573,16 @@ describe("download store", () => {
       "completed",
     );
 
-    expect(mocks.streaming.executeBufferedStreamingDownload).toHaveBeenCalled();
+    expect(mocks.boundedDownloader.executeBoundedDownload).toHaveBeenCalled();
     expect(mocks.fileApi.getDownloadMetadata).toHaveBeenCalledWith(
       "hash-stream",
     );
   });
 
   it("streaming 失败为用户取消时应标记 cancelled", async () => {
-    mocks.streaming.executeBufferedStreamingDownload.mockResolvedValue({
-      success: false,
-      error: "File save cancelled by user",
-    });
+    mocks.boundedDownloader.executeBoundedDownload.mockRejectedValue(
+      new Error("Download cancelled"),
+    );
 
     const download = await loadDownloadStore();
     const id = await download.startDownload(
@@ -522,30 +599,58 @@ describe("download store", () => {
     );
   });
 
+  it("streaming 下载器在取消后返回也不得覆盖 cancelled 状态", async () => {
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementationOnce(
+      async () => deferred.promise,
+    );
+
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-finalize-cancel",
+      "cancel-finalize.bin",
+      { type: "owned" },
+      undefined,
+      "streaming",
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "streaming",
+    );
+    await download.cancelDownload(id);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(download.tasks.find((task) => task.id === id)?.status).toBe(
+      "cancelled",
+    );
+  });
+
   it("pause/resume/cancel/retry/remove/clearCompleted 应按预期工作", async () => {
-    const deferred = createDeferred<Uint8Array[]>();
-    mocks.chunkDownloader.downloadAllChunks
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeBoundedDownload
       .mockImplementationOnce(async () => deferred.promise)
-      .mockImplementation(
-        async (
-          _urls: string[],
-          options: {
-            onChunkComplete?: (result: {
-              index: number;
-              data: Uint8Array;
-            }) => Promise<void>;
-            onProgress?: (progress: {
-              completed: number;
-              total: number;
-            }) => void;
-          },
-        ) => {
-          const data = new Uint8Array([1]);
-          await options.onChunkComplete?.({ index: 0, data });
-          options.onProgress?.({ completed: 1, total: 1 });
-          return [data];
-        },
-      );
+      .mockImplementation(completeBoundedDownload);
 
     const download = await loadDownloadStore();
 
@@ -566,7 +671,13 @@ describe("download store", () => {
       "paused",
     );
 
-    deferred.resolve([new Uint8Array([1])]);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
 
     await download.resumeDownload(id);
     await waitForStatus(
@@ -762,8 +873,14 @@ describe("download store", () => {
   });
 
   it("批量下载中出现 paused 任务时应结束批次并标记失败", async () => {
-    const deferred = createDeferred<Uint8Array[]>();
-    mocks.chunkDownloader.downloadAllChunks.mockImplementationOnce(
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementationOnce(
       async () => deferred.promise,
     );
 
@@ -776,7 +893,13 @@ describe("download store", () => {
     await waitForStatus(() => download.tasks[0]?.status, "downloading");
 
     download.pauseDownload(download.tasks[0].id);
-    deferred.resolve([new Uint8Array([1])]);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
 
     const batch = await batchPromise;
     expect(batch.status).toBe("completed");
@@ -878,9 +1001,15 @@ describe("download store extra branches", () => {
       success: true,
       bytesWritten: 10,
     });
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementation(
+      completeBoundedDownload,
+    );
+    mocks.boundedDownloader.executeLegacyFallbackDownload.mockImplementation(
+      completeBoundedDownload,
+    );
 
     Object.defineProperty(window, "showSaveFilePicker", {
-      value: vi.fn().mockResolvedValue({ handle: "h" }),
+      value: vi.fn().mockResolvedValue(createWritableHandle()),
       configurable: true,
     });
   });
@@ -897,6 +1026,28 @@ describe("download store extra branches", () => {
     );
 
     expect(mocks.fileApi.downloadFile).toHaveBeenCalledWith("hash-fallback");
+  });
+
+  it("backend proxy 响应超过 64 MiB 时应失败且不提交 Blob", async () => {
+    mocks.fileApi.publicDownloadFile.mockResolvedValueOnce({
+      size: 64 * 1024 * 1024 + 1,
+    } as Blob);
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-oversized-share",
+      "oversized.bin",
+      { type: "public_share", shareCode: "share-oversized" },
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "failed",
+    );
+
+    expect(mocks.crypto.downloadBlob).not.toHaveBeenCalled();
+    expect(download.tasks.find((task) => task.id === id)?.error).toContain(
+      "64 MiB",
+    );
   });
 
   it("streaming 选择文件阶段 AbortError 应标记 cancelled", async () => {
@@ -925,10 +1076,9 @@ describe("download store extra branches", () => {
   });
 
   it("streaming 执行返回普通失败时应进入 failed", async () => {
-    mocks.streaming.executeBufferedStreamingDownload.mockResolvedValue({
-      success: false,
-      error: "decrypt failed",
-    });
+    mocks.boundedDownloader.executeBoundedDownload.mockRejectedValue(
+      new Error("decrypt failed"),
+    );
 
     const download = await loadDownloadStore();
     const id = await download.startDownload(
@@ -952,6 +1102,10 @@ describe("download store extra branches", () => {
       encryptionAlgorithm: "NONE",
       contentType: "application/octet-stream",
     });
+    Object.defineProperty(window, "showSaveFilePicker", {
+      value: vi.fn().mockResolvedValue({ handle: "h" }),
+      configurable: true,
+    });
 
     const download = await loadDownloadStore();
     const id = await download.startDownload(
@@ -967,13 +1121,19 @@ describe("download store extra branches", () => {
       "failed",
     );
     expect(download.tasks.find((task) => task.id === id)?.error).toBe(
-      "Streaming download file handle is invalid",
+      "下载文件句柄无效",
     );
   });
 
   it("下载中 cancel 后应命中取消分支，resume/retry 非法状态应提前返回", async () => {
-    const deferred = createDeferred<Uint8Array[]>();
-    mocks.chunkDownloader.downloadAllChunks.mockImplementationOnce(
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementationOnce(
       async () => deferred.promise,
     );
 
@@ -996,7 +1156,13 @@ describe("download store extra branches", () => {
       "cancelled",
     );
 
-    deferred.resolve([new Uint8Array([1])]);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
 
     await download.resumeDownload("not-exist");
     await download.retryDownload("not-exist");
@@ -1005,8 +1171,14 @@ describe("download store extra branches", () => {
   });
 
   it("removeTask 在活动任务上应触发 abort 与清理", async () => {
-    const deferred = createDeferred<Uint8Array[]>();
-    mocks.chunkDownloader.downloadAllChunks.mockImplementationOnce(
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeBoundedDownload.mockImplementationOnce(
       async () => deferred.promise,
     );
 
@@ -1027,7 +1199,13 @@ describe("download store extra branches", () => {
     await download.removeTask(id);
     expect(download.tasks.some((task) => task.id === id)).toBe(false);
 
-    deferred.resolve([new Uint8Array([1])]);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
   });
 
   it("restoreTasks 出错时应记录日志并完成初始化", async () => {

--- a/platform-frontend/src/lib/stores/download.svelte.test.ts
+++ b/platform-frontend/src/lib/stores/download.svelte.test.ts
@@ -1050,6 +1050,281 @@ describe("download store extra branches", () => {
     );
   });
 
+  it("backend proxy 响应大小与声明不一致时应失败", async () => {
+    mocks.fileApi.publicDownloadFile.mockResolvedValueOnce(
+      new Blob(["tiny"], { type: "application/octet-stream" }),
+    );
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-size-mismatch",
+      "mismatch.bin",
+      { type: "public_share", shareCode: "share-mismatch" },
+      8,
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "failed",
+    );
+
+    expect(mocks.crypto.downloadBlob).not.toHaveBeenCalled();
+    expect(download.tasks.find((task) => task.id === id)?.error).toBe(
+      "共享文件响应超过 64 MiB 或与声明大小不一致",
+    );
+  });
+
+  it("dispatch 应拒绝无界策略并允许无 picker 的小文件 fallback", async () => {
+    mocks.fileSize.isStreamingSupported.mockReturnValue(false);
+    const download = await loadDownloadStore();
+
+    const oversizedShareId = await download.startDownload(
+      "hash-share-too-large",
+      "share-too-large.bin",
+      { type: "public_share", shareCode: "share-too-large" },
+      64 * 1024 * 1024 + 1,
+      "inmemory",
+    );
+    const backendProxyId = await download.startDownload(
+      "hash-owned-proxy",
+      "owned-proxy.bin",
+      { type: "owned" },
+      1024,
+      "backend_proxy",
+    );
+    const streamingFallbackId = await download.startDownload(
+      "hash-streaming-fallback",
+      "streaming-fallback.bin",
+      { type: "owned" },
+      1024,
+      "streaming",
+    );
+    const oversizedStreamingId = await download.startDownload(
+      "hash-streaming-too-large",
+      "streaming-too-large.bin",
+      { type: "owned" },
+      64 * 1024 * 1024 + 1,
+      "streaming",
+    );
+    const oversizedMemoryId = await download.startDownload(
+      "hash-memory-too-large",
+      "memory-too-large.bin",
+      { type: "owned" },
+      64 * 1024 * 1024 + 1,
+      "inmemory",
+    );
+
+    await waitForStatus(
+      () =>
+        download.tasks.find((task) => task.id === streamingFallbackId)?.status,
+      "completed",
+    );
+
+    expect(
+      download.tasks.find((task) => task.id === oversizedShareId)?.error,
+    ).toContain("共享文件大小无效或超过 64 MiB");
+    expect(
+      download.tasks.find((task) => task.id === backendProxyId)?.error,
+    ).toContain("Chrome 或 Edge");
+    expect(
+      download.tasks.find((task) => task.id === oversizedStreamingId)?.status,
+    ).toBe("failed");
+    expect(
+      download.tasks.find((task) => task.id === oversizedMemoryId)?.status,
+    ).toBe("failed");
+    expect(
+      mocks.boundedDownloader.executeBoundedDownload,
+    ).toHaveBeenCalledOnce();
+    expect(mocks.fileApi.publicDownloadFile).not.toHaveBeenCalled();
+  });
+
+  it("streaming 缺少文件保存 API 时应明确失败", async () => {
+    Object.defineProperty(window, "showSaveFilePicker", {
+      value: undefined,
+      configurable: true,
+    });
+
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-no-picker",
+      "no-picker.bin",
+      { type: "owned" },
+      1024,
+      "streaming",
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "failed",
+    );
+
+    expect(download.tasks.find((task) => task.id === id)?.error).toBe(
+      "Streaming download not supported in this browser",
+    );
+    expect(mocks.fileApi.getDownloadMetadata).not.toHaveBeenCalled();
+  });
+
+  it("streaming 在文件选择器打开期间取消后不得继续请求 metadata", async () => {
+    const picker = createDeferred<ReturnType<typeof createWritableHandle>>();
+    Object.defineProperty(window, "showSaveFilePicker", {
+      value: vi.fn(() => picker.promise),
+      configurable: true,
+    });
+
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-picker-cancel",
+      "picker-cancel.bin",
+      { type: "owned" },
+      1024,
+      "streaming",
+    );
+
+    await download.cancelDownload(id);
+    picker.resolve(createWritableHandle());
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "cancelled",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.fileApi.getDownloadMetadata).not.toHaveBeenCalled();
+    expect(
+      mocks.boundedDownloader.executeBoundedDownload,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("legacy streaming 应通过文件系统 sink 完成并记录进度", async () => {
+    mocks.fileApi.getDownloadMetadata.mockRejectedValueOnce(
+      new Error("文件缺少分片 manifest"),
+    );
+
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-legacy-stream",
+      "legacy-stream.bin",
+      { type: "owned" },
+      1024,
+      "streaming",
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "completed",
+    );
+
+    expect(
+      mocks.boundedDownloader.executeLegacyFallbackDownload,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urls: ["legacy-u1"],
+        fileSize: 1024,
+        totalChunks: 1,
+        encrypted: true,
+      }),
+    );
+    expect(download.tasks.find((task) => task.id === id)).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        progress: 100,
+        downloadedChunks: 1,
+        downloadMetrics: expect.objectContaining({
+          partsCompleted: 1,
+          bytesWritten: 1024,
+        }),
+      }),
+    );
+    expect(mocks.crypto.downloadBlob).not.toHaveBeenCalled();
+  });
+
+  it("legacy streaming 在下载器返回前取消后不得覆盖 cancelled", async () => {
+    mocks.fileApi.getDownloadMetadata.mockRejectedValueOnce(
+      new Error("文件缺少分片 manifest"),
+    );
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeLegacyFallbackDownload.mockImplementationOnce(
+      async () => deferred.promise,
+    );
+
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-legacy-stream-cancel",
+      "legacy-stream-cancel.bin",
+      { type: "owned" },
+      1024,
+      "streaming",
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "streaming",
+    );
+    await download.cancelDownload(id);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(download.tasks.find((task) => task.id === id)?.status).toBe(
+      "cancelled",
+    );
+  });
+
+  it("legacy 内存下载在下载器返回前取消后不得提交 Blob", async () => {
+    mocks.fileApi.getDownloadMetadata.mockRejectedValueOnce(
+      new Error("文件缺少分片 manifest"),
+    );
+    const deferred = createDeferred<{
+      currentBufferedBytes: number;
+      peakBufferedBytes: number;
+      framesAuthenticated: number;
+      partsCompleted: number;
+      bytesWritten: number;
+    }>();
+    mocks.boundedDownloader.executeLegacyFallbackDownload.mockImplementationOnce(
+      async () => deferred.promise,
+    );
+
+    const download = await loadDownloadStore();
+    const id = await download.startDownload(
+      "hash-legacy-memory-cancel",
+      "legacy-memory-cancel.bin",
+      { type: "owned" },
+      1024,
+      "inmemory",
+    );
+
+    await waitForStatus(
+      () => download.tasks.find((task) => task.id === id)?.status,
+      "downloading",
+    );
+    await download.cancelDownload(id);
+    deferred.resolve({
+      currentBufferedBytes: 0,
+      peakBufferedBytes: 1,
+      framesAuthenticated: 0,
+      partsCompleted: 1,
+      bytesWritten: 1024,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(download.tasks.find((task) => task.id === id)?.status).toBe(
+      "cancelled",
+    );
+    expect(mocks.crypto.downloadBlob).not.toHaveBeenCalled();
+  });
+
   it("streaming 选择文件阶段 AbortError 应标记 cancelled", async () => {
     Object.defineProperty(window, "showSaveFilePicker", {
       value: vi

--- a/platform-frontend/src/lib/stores/download.svelte.ts
+++ b/platform-frontend/src/lib/stores/download.svelte.ts
@@ -9,13 +9,7 @@ import { env } from "$env/dynamic/public";
 import { getToken } from "$api/client";
 import * as fileApi from "$api/endpoints/files";
 import {
-  downloadAllChunks,
-  type ChunkDownloadResult,
-  type DownloadProgress,
-} from "$utils/chunkDownloader";
-import {
   saveTask,
-  saveChunk,
   getChunks,
   getPendingTasks,
   clearTaskData,
@@ -24,7 +18,20 @@ import {
   type PersistedDownloadTask,
   type DownloadSource,
 } from "$utils/downloadStorage";
-import { decryptFile, arrayToBlob, downloadBlob } from "$utils/crypto";
+import { arrayToBlob, downloadBlob } from "$utils/crypto";
+import {
+  executeBoundedDownload,
+  executeLegacyFallbackDownload,
+} from "$utils/boundedDownloader";
+import {
+  createFileSystemDownloadSink,
+  MemoryDownloadSink,
+} from "$utils/downloadSink";
+import {
+  DownloadMetricsTracker,
+  type DownloadStreamMetrics,
+} from "$utils/downloadMetrics";
+import type { FileDownloadMetadataVO } from "$api/types";
 import {
   buildBatchMetricsPayload,
   calculateRetryCount,
@@ -36,11 +43,8 @@ import {
   type BrowserCapabilities,
   formatFileSize,
   isStreamingSupported,
+  MAX_SAFE_INMEMORY_SIZE,
 } from "$utils/fileSize";
-import {
-  executeBufferedStreamingDownload,
-  type StreamingPhase,
-} from "$utils/streamingDownloader";
 
 // Re-export types
 export type { DownloadSource } from "$utils/downloadStorage";
@@ -94,6 +98,10 @@ export interface DownloadTask {
   abortController: AbortController | null;
   /** Download strategy used for this task */
   strategy: DownloadStrategy;
+  /** 已验证的 manifest 元数据，供重试复用同一合同。 */
+  downloadMetadata: FileDownloadMetadataVO | null;
+  /** 最近一次有界下载的内存、认证与写入指标。 */
+  downloadMetrics: DownloadStreamMetrics | null;
 }
 
 export interface BatchDownloadItem {
@@ -123,20 +131,11 @@ export interface BatchDownloadState {
   completedAt: number | null;
 }
 
-type WritableFileStreamLike = {
-  write(data: Blob | BufferSource | string): Promise<void>;
-  close(): Promise<void>;
-  abort?: () => Promise<void>;
-};
-
-type WritableFileHandleLike = {
-  createWritable(): Promise<WritableFileStreamLike>;
-};
-
 type PresignedUrlMetadata = {
   urls: string[];
   decryptInfo: fileApi.FileDecryptInfoVO;
   encryptionAlgorithm: string | null;
+  metadata: FileDownloadMetadataVO | null;
 };
 
 // ===== Pre-download Check Result =====
@@ -213,30 +212,6 @@ function isPlainDownload(
   encryptionAlgorithm: string | null | undefined,
 ): boolean {
   return encryptionAlgorithm?.trim().toUpperCase() === "NONE";
-}
-
-/**
- * 读取加密下载必需的 initialKey；缺失时立即失败，避免把 null 传给解密器。
- */
-function requireInitialKey(initialKey: string | null | undefined): string {
-  if (!initialKey) {
-    throw new Error("缺少加密文件初始密钥");
-  }
-  return initialKey;
-}
-
-/**
- * 将未加密分片按顺序拼接成单个字节数组。
- */
-function concatenatePlainChunks(chunks: Uint8Array[]): Uint8Array {
-  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return result;
 }
 
 /**
@@ -383,7 +358,6 @@ async function executeBatchItem(
           item.fileName,
           item.source ?? { type: "owned" },
           item.fileSize,
-          "inmemory",
         );
       } else {
         await retryDownload(taskId);
@@ -441,6 +415,7 @@ async function fetchPresignedUrls(
         urls,
         decryptInfo,
         encryptionAlgorithm: metadata.encryptionAlgorithm ?? null,
+        metadata,
       };
     } catch (metadataError) {
       if (!isMissingManifestError(metadataError)) {
@@ -475,6 +450,7 @@ async function fetchLegacyPresignedUrls(
     urls,
     decryptInfo,
     encryptionAlgorithm: decryptInfo.initialKey ? null : "NONE",
+    metadata: null,
   };
 }
 
@@ -490,6 +466,7 @@ function isMissingManifestError(error: unknown): boolean {
 async function executeDownload(task: DownloadTask): Promise<void> {
   const taskId = task.id;
   const abortController = new AbortController();
+  let metricsTracker: DownloadMetricsTracker | null = null;
   updateTask(taskId, { abortController });
 
   try {
@@ -501,16 +478,18 @@ async function executeDownload(task: DownloadTask): Promise<void> {
     let fileName = task.fileName;
     let fileSize = task.fileSize;
     let encryptionAlgorithm = task.encryptionAlgorithm;
+    let downloadMetadata = task.downloadMetadata;
     const authContextHash = await getAuthContextHash();
 
     if (urls.length === 0 || areUrlsExpired(task.urlsFetchedAt)) {
       updateTask(taskId, { status: "fetching_urls" });
 
+      const fetchedMetadata = await fetchPresignedUrls(task);
       const {
         urls: newUrls,
         decryptInfo,
         encryptionAlgorithm: metadataEncryptionAlgorithm,
-      } = await fetchPresignedUrls(task);
+      } = fetchedMetadata;
       urls = newUrls;
       initialKey = decryptInfo.initialKey ?? null;
       totalChunks = decryptInfo.chunkCount;
@@ -518,6 +497,7 @@ async function executeDownload(task: DownloadTask): Promise<void> {
       fileName = decryptInfo.fileName;
       fileSize = decryptInfo.fileSize;
       encryptionAlgorithm = metadataEncryptionAlgorithm;
+      downloadMetadata = fetchedMetadata.metadata;
 
       updateTask(taskId, {
         presignedUrls: urls,
@@ -528,6 +508,7 @@ async function executeDownload(task: DownloadTask): Promise<void> {
         contentType,
         fileName,
         fileSize,
+        downloadMetadata,
         chunks: Array.from({ length: totalChunks }, (_, i) => ({
           index: i,
           status: "pending" as const,
@@ -552,85 +533,76 @@ async function executeDownload(task: DownloadTask): Promise<void> {
       }
     }
 
-    // Step 2: Load existing chunks from IndexedDB (for resume)
-    let existingChunks = downloadedChunksMap.get(taskId);
-    if (!existingChunks) {
-      existingChunks = authContextHash ? await getChunks(taskId) : new Map();
-      downloadedChunksMap.set(taskId, existingChunks);
-    }
-
-    // Update status
-    updateTask(taskId, {
-      status: "downloading",
-      startedAt: task.startedAt ?? Date.now(),
-      downloadedChunks: existingChunks.size,
-      progress: Math.round((existingChunks.size / totalChunks) * 100),
-    });
-
-    // Step 3: Download chunks
-    const allChunks = await downloadAllChunks(urls, {
-      concurrency,
-      signal: abortController.signal,
-      existingChunks,
-      onChunkComplete: async (result: ChunkDownloadResult) => {
-        // Update memory cache
-        existingChunks!.set(result.index, result.data);
-
-        // Persist to IndexedDB
-        if (authContextHash) {
-          await saveChunk(taskId, result.index, result.data);
-        }
-
-        // Update chunk state
-        const currentTask = getTask(taskId);
-        if (currentTask) {
-          const chunks = [...currentTask.chunks];
-          chunks[result.index] = {
-            ...chunks[result.index],
-            status: "completed",
-          };
-          updateTask(taskId, { chunks });
-        }
-      },
-      onProgress: (progress: DownloadProgress) => {
-        updateTask(taskId, {
-          downloadedChunks: progress.completed,
-          progress: Math.round((progress.completed / progress.total) * 100),
-        });
-      },
-    });
-
-    // Check if cancelled during download
-    const currentTask = getTask(taskId);
-    if (
-      !currentTask ||
-      currentTask.status === "cancelled" ||
-      currentTask.status === "paused"
-    ) {
+    // Manifest-backed downloads use the bounded reader for all three formats.
+    if (downloadMetadata) {
+      const sink = new MemoryDownloadSink(fileSize, MAX_SAFE_INMEMORY_SIZE);
+      metricsTracker = new DownloadMetricsTracker();
+      updateTask(taskId, { status: "downloading" });
+      const metrics = await executeBoundedDownload({
+        metadata: downloadMetadata,
+        expectedFileHash: task.fileHash,
+        sink,
+        metrics: metricsTracker,
+        signal: abortController.signal,
+        onPartComplete: (completed, total) => {
+          updateTask(taskId, {
+            status: "downloading",
+            downloadedChunks: completed,
+            progress: Math.round((completed / total) * 100),
+          });
+        },
+      });
+      if (abortController.signal.aborted) {
+        throw new Error("Download cancelled");
+      }
+      downloadBlob(arrayToBlob(sink.getData(), contentType), fileName);
+      await clearTaskData(taskId);
+      downloadedChunksMap.delete(taskId);
+      updateTask(taskId, {
+        status: "completed",
+        progress: 100,
+        downloadedChunks: totalChunks,
+        completedAt: Date.now(),
+        abortController: null,
+        downloadMetrics: metrics,
+      });
       return;
     }
 
-    // Step 4: Build the output bytes
-    const plainDownload = isPlainDownload(encryptionAlgorithm);
-    updateTask(taskId, { status: plainDownload ? "writing" : "decrypting" });
-
-    const outputData = plainDownload
-      ? concatenatePlainChunks(allChunks)
-      : await decryptFile(allChunks, requireInitialKey(initialKey));
-    const blob = arrayToBlob(outputData, contentType);
-
-    // Step 5: Trigger browser download
-    downloadBlob(blob, fileName);
-
-    // Step 6: Cleanup and mark complete
+    // 历史无 manifest 文件也必须逐分片读取，并对 v1 密文执行硬性 part 上限。
+    const sink = new MemoryDownloadSink(fileSize, MAX_SAFE_INMEMORY_SIZE);
+    metricsTracker = new DownloadMetricsTracker();
+    updateTask(taskId, { status: "downloading" });
+    const metrics = await executeLegacyFallbackDownload({
+      urls,
+      fileSize,
+      totalChunks,
+      initialKey,
+      encrypted: !isPlainDownload(encryptionAlgorithm),
+      sink,
+      signal: abortController.signal,
+      metrics: metricsTracker,
+      onPartComplete: (completed, total) => {
+        updateTask(taskId, {
+          status: "downloading",
+          downloadedChunks: completed,
+          progress: Math.round((completed / total) * 100),
+        });
+      },
+    });
+    if (abortController.signal.aborted) {
+      throw new Error("Download cancelled");
+    }
+    downloadBlob(arrayToBlob(sink.getData(), contentType), fileName);
     await clearTaskData(taskId);
     downloadedChunksMap.delete(taskId);
-
     updateTask(taskId, {
       status: "completed",
       progress: 100,
+      downloadedChunks: totalChunks,
       completedAt: Date.now(),
       abortController: null,
+      downloadMetrics: metrics,
     });
   } catch (error) {
     const err = error as Error;
@@ -645,6 +617,7 @@ async function executeDownload(task: DownloadTask): Promise<void> {
         updateTask(taskId, {
           status: "cancelled",
           abortController: null,
+          downloadMetrics: metricsTracker?.snapshot() ?? null,
         });
       }
       return;
@@ -654,66 +627,12 @@ async function executeDownload(task: DownloadTask): Promise<void> {
       status: "failed",
       error: err.message,
       abortController: null,
+      downloadMetrics: metricsTracker?.snapshot() ?? null,
     });
   }
 }
 
 // ===== Streaming Download (File System Access API) =====
-
-/**
- * 流式下载未加密分片并直接写入用户选择的文件。
- */
-async function executePlainStreamingDownload(params: {
-  contentType: string;
-  totalChunks: number;
-  presignedUrls: string[];
-  fileHandle: unknown;
-  signal: AbortSignal;
-  onProgress: (phase: StreamingPhase, current: number, total: number) => void;
-}): Promise<{ success: boolean; bytesWritten?: number; error?: string }> {
-  const fileHandle = params.fileHandle as Partial<WritableFileHandleLike>;
-  if (typeof fileHandle?.createWritable !== "function") {
-    return {
-      success: false,
-      error: "Streaming download file handle is invalid",
-    };
-  }
-
-  let writable: WritableFileStreamLike | null = null;
-  try {
-    writable = await fileHandle.createWritable();
-    let bytesWritten = 0;
-    for (let index = 0; index < params.presignedUrls.length; index++) {
-      if (params.signal.aborted) {
-        throw new Error("Download cancelled");
-      }
-      const response = await fetch(params.presignedUrls[index], {
-        signal: params.signal,
-      });
-      if (!response.ok) {
-        throw new Error(`分片 ${index + 1} 下载失败: ${response.status}`);
-      }
-      const chunk = new Uint8Array(await response.arrayBuffer());
-      if (params.signal.aborted) {
-        throw new Error("Download cancelled");
-      }
-      await writable.write(new Blob([chunk], { type: params.contentType }));
-      bytesWritten += chunk.byteLength;
-      params.onProgress("downloading", index + 1, params.totalChunks);
-    }
-    await writable.close();
-    params.onProgress("completed", params.totalChunks, params.totalChunks);
-    return { success: true, bytesWritten };
-  } catch (error) {
-    if (writable?.abort) {
-      await writable.abort();
-    }
-    if (params.signal.aborted) {
-      return { success: false, error: "Download cancelled" };
-    }
-    return { success: false, error: (error as Error).message };
-  }
-}
 
 /**
  * Execute streaming download for large files
@@ -722,6 +641,7 @@ async function executePlainStreamingDownload(params: {
 async function executeStreamingDownload(task: DownloadTask): Promise<void> {
   const taskId = task.id;
   const abortController = new AbortController();
+  let metricsTracker: DownloadMetricsTracker | null = null;
   updateTask(taskId, { abortController });
 
   let fileHandle: unknown;
@@ -764,15 +684,17 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
     let fileName = task.fileName;
     let fileSize = task.fileSize;
     let encryptionAlgorithm = task.encryptionAlgorithm;
+    let downloadMetadata = task.downloadMetadata;
 
     if (urls.length === 0 || areUrlsExpired(task.urlsFetchedAt)) {
       updateTask(taskId, { status: "fetching_urls" });
 
+      const fetchedMetadata = await fetchPresignedUrls(task);
       const {
         urls: newUrls,
         decryptInfo,
         encryptionAlgorithm: metadataEncryptionAlgorithm,
-      } = await fetchPresignedUrls(task);
+      } = fetchedMetadata;
       urls = newUrls;
       initialKey = decryptInfo.initialKey ?? null;
       totalChunks = decryptInfo.chunkCount;
@@ -780,6 +702,7 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
       fileName = decryptInfo.fileName;
       fileSize = decryptInfo.fileSize;
       encryptionAlgorithm = metadataEncryptionAlgorithm;
+      downloadMetadata = fetchedMetadata.metadata;
 
       updateTask(taskId, {
         presignedUrls: urls,
@@ -790,6 +713,7 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
         contentType,
         fileName,
         fileSize,
+        downloadMetadata,
         chunks: Array.from({ length: totalChunks }, (_, i) => ({
           index: i,
           status: "pending" as const,
@@ -804,66 +728,56 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
       startedAt: task.startedAt ?? Date.now(),
     });
 
-    const onStreamingProgress = (
-      phase: StreamingPhase,
-      current: number,
-      total: number,
-    ) => {
-      const currentTask = getTask(taskId);
-      if (
-        !currentTask ||
-        currentTask.status === "cancelled" ||
-        currentTask.status === "paused"
-      ) {
-        return;
-      }
-
-      const progress = Math.round((current / total) * 100);
-
-      switch (phase) {
-        case "downloading":
+    let result: { success: boolean; error?: string };
+    let completedMetrics: DownloadStreamMetrics | null = null;
+    if (downloadMetadata) {
+      const sink = await createFileSystemDownloadSink(fileHandle);
+      metricsTracker = new DownloadMetricsTracker();
+      const metrics = await executeBoundedDownload({
+        metadata: downloadMetadata,
+        expectedFileHash: task.fileHash,
+        sink,
+        signal: abortController.signal,
+        metrics: metricsTracker,
+        onPartComplete: (completed, total) => {
           updateTask(taskId, {
             status: "streaming",
-            downloadedChunks: current,
-            progress,
+            downloadedChunks: completed,
+            progress: Math.round((completed / total) * 100),
           });
-          break;
-        case "decrypting":
-          updateTask(taskId, {
-            status: "decrypting",
-            progress,
-          });
-          break;
-        case "writing":
-          updateTask(taskId, {
-            status: "writing",
-            progress,
-          });
-          break;
-        case "completed":
-          break;
+        },
+      });
+      completedMetrics = metrics;
+      if (abortController.signal.aborted) {
+        throw new Error("Download cancelled");
       }
-    };
-
-    const result = isPlainDownload(encryptionAlgorithm)
-      ? await executePlainStreamingDownload({
-          contentType,
-          totalChunks,
-          presignedUrls: urls,
-          fileHandle,
-          signal: abortController.signal,
-          onProgress: onStreamingProgress,
-        })
-      : await executeBufferedStreamingDownload({
-          fileName,
-          contentType,
-          totalChunks,
-          initialKey: requireInitialKey(initialKey),
-          presignedUrls: urls,
-          fileHandle,
-          signal: abortController.signal,
-          onProgress: onStreamingProgress,
-        });
+      result = { success: true };
+    } else {
+      const sink = await createFileSystemDownloadSink(fileHandle);
+      metricsTracker = new DownloadMetricsTracker();
+      const metrics = await executeLegacyFallbackDownload({
+        urls,
+        fileSize,
+        totalChunks,
+        initialKey,
+        encrypted: !isPlainDownload(encryptionAlgorithm),
+        sink,
+        signal: abortController.signal,
+        metrics: metricsTracker,
+        onPartComplete: (completed, total) => {
+          updateTask(taskId, {
+            status: "streaming",
+            downloadedChunks: completed,
+            progress: Math.round((completed / total) * 100),
+          });
+        },
+      });
+      completedMetrics = metrics;
+      if (abortController.signal.aborted) {
+        throw new Error("Download cancelled");
+      }
+      result = { success: true };
+    }
 
     // Check result
     if (!result.success) {
@@ -895,6 +809,7 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
       progress: 100,
       completedAt: Date.now(),
       abortController: null,
+      downloadMetrics: completedMetrics,
     });
   } catch (error) {
     const err = error as Error;
@@ -908,6 +823,7 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
         updateTask(taskId, {
           status: "cancelled",
           abortController: null,
+          downloadMetrics: metricsTracker?.snapshot() ?? null,
         });
       }
       return;
@@ -926,14 +842,86 @@ async function executeStreamingDownload(task: DownloadTask): Promise<void> {
       status: "failed",
       error: err.message,
       abortController: null,
+      downloadMetrics: metricsTracker?.snapshot() ?? null,
     });
   }
 }
 
 // ===== Fallback for shared files (backend proxy) =====
 
+const UNSUPPORTED_LARGE_DOWNLOAD_MESSAGE =
+  "当前浏览器不支持超过 64 MiB 的有界保存，请使用 Chrome 或 Edge。";
+
+/** 将不允许进入 Blob/backend proxy 的任务置为失败。 */
+function rejectUnboundedDownload(
+  taskId: string,
+  reason = UNSUPPORTED_LARGE_DOWNLOAD_MESSAGE,
+): void {
+  updateTask(taskId, {
+    status: "failed",
+    error: reason,
+    abortController: null,
+  });
+}
+
+/** 按来源、策略和文件大小统一调度下载，避免绕过内存硬上限。 */
+function dispatchDownloadTask(task: DownloadTask): void {
+  if (task.source.type !== "owned") {
+    if (
+      !Number.isSafeInteger(task.fileSize) ||
+      task.fileSize < 0 ||
+      task.fileSize > MAX_SAFE_INMEMORY_SIZE
+    ) {
+      rejectUnboundedDownload(
+        task.id,
+        "共享文件大小无效或超过 64 MiB，当前浏览器不支持有界保存。",
+      );
+      return;
+    }
+    void executeBackendProxyDownload(task);
+    return;
+  }
+
+  if (task.strategy === "backend_proxy") {
+    rejectUnboundedDownload(task.id);
+    return;
+  }
+
+  if (task.strategy === "streaming") {
+    if (canUseStreaming()) {
+      void executeStreamingDownload(task);
+      return;
+    }
+    if (
+      Number.isSafeInteger(task.fileSize) &&
+      task.fileSize > 0 &&
+      task.fileSize <= MAX_SAFE_INMEMORY_SIZE
+    ) {
+      void executeDownload(task);
+      return;
+    }
+    rejectUnboundedDownload(task.id);
+    return;
+  }
+
+  if (task.fileSize > MAX_SAFE_INMEMORY_SIZE) {
+    rejectUnboundedDownload(task.id);
+    return;
+  }
+  void executeDownload(task);
+}
+
 async function executeBackendProxyDownload(task: DownloadTask): Promise<void> {
   const taskId = task.id;
+
+  if (
+    !Number.isSafeInteger(task.fileSize) ||
+    task.fileSize < 0 ||
+    task.fileSize > MAX_SAFE_INMEMORY_SIZE
+  ) {
+    rejectUnboundedDownload(taskId);
+    return;
+  }
 
   try {
     updateTask(taskId, { status: "downloading", startedAt: Date.now() });
@@ -948,6 +936,16 @@ async function executeBackendProxyDownload(task: DownloadTask): Promise<void> {
     } else {
       // Fallback for owned files without presigned URLs
       blob = await fileApi.downloadFile(task.fileHash);
+    }
+
+    // 共享文件可能未携带预先知道的大小，必须以响应 Blob 的实际大小再次封顶。
+    if (
+      !blob ||
+      !Number.isSafeInteger(blob.size) ||
+      blob.size > MAX_SAFE_INMEMORY_SIZE ||
+      (task.fileSize > 0 && blob.size !== task.fileSize)
+    ) {
+      throw new Error("共享文件响应超过 64 MiB 或与声明大小不一致");
     }
 
     downloadBlob(blob, task.fileName);
@@ -1037,21 +1035,13 @@ async function startDownload(
     completedAt: null,
     abortController: null,
     strategy,
+    downloadMetadata: null,
+    downloadMetrics: null,
   };
 
   tasks = [...tasks, task];
 
-  // Choose execution method based on source and strategy
-  if (source.type !== "owned") {
-    // Shared files use backend proxy
-    executeBackendProxyDownload(task);
-  } else if (strategy === "streaming" && canUseStreaming()) {
-    // Large files with streaming support
-    executeStreamingDownload(task);
-  } else {
-    // Default in-memory download
-    executeDownload(task);
-  }
+  dispatchDownloadTask(task);
 
   return id;
 }
@@ -1219,14 +1209,7 @@ async function resumeDownload(id: string): Promise<void> {
   const updatedTask = getTask(id);
   if (!updatedTask) return;
 
-  // Choose execution method based on source and strategy
-  if (updatedTask.source.type !== "owned") {
-    executeBackendProxyDownload(updatedTask);
-  } else if (updatedTask.strategy === "streaming" && canUseStreaming()) {
-    executeStreamingDownload(updatedTask);
-  } else {
-    executeDownload(updatedTask);
-  }
+  dispatchDownloadTask(updatedTask);
 }
 
 /**
@@ -1260,20 +1243,14 @@ async function retryDownload(id: string): Promise<void> {
     error: null,
     downloadedChunks: 0,
     progress: 0,
+    downloadMetrics: null,
   });
 
   // Get fresh task reference after update
   const updatedTask = getTask(id);
   if (!updatedTask) return;
 
-  // Choose execution method based on source and strategy
-  if (updatedTask.source.type !== "owned") {
-    executeBackendProxyDownload(updatedTask);
-  } else if (updatedTask.strategy === "streaming" && canUseStreaming()) {
-    executeStreamingDownload(updatedTask);
-  } else {
-    executeDownload(updatedTask);
-  }
+  dispatchDownloadTask(updatedTask);
 }
 
 /**
@@ -1392,6 +1369,8 @@ async function restoreTasks(): Promise<void> {
         // Restored tasks use in-memory strategy since we've already downloaded some chunks
         // (streaming doesn't support resuming from partial chunks)
         strategy: "inmemory",
+        downloadMetadata: null,
+        downloadMetrics: null,
       };
 
       tasks = [...tasks, task];

--- a/platform-frontend/src/lib/utils/boundedDownloader.test.ts
+++ b/platform-frontend/src/lib/utils/boundedDownloader.test.ts
@@ -1,0 +1,659 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { describe, expect, it } from "vitest";
+import type { FileDownloadMetadataVO } from "$api/types";
+
+import {
+  executeBoundedDownload,
+  executeLegacyFallbackDownload,
+  LEGACY_MAX_CIPHER_PART_BYTES,
+  resolveDownloadFormat,
+} from "./boundedDownloader";
+import { bytesToHex } from "./downloadIntegrity";
+import { DownloadMetricsTracker } from "./downloadMetrics";
+import { MemoryDownloadSink, type DownloadSink } from "./downloadSink";
+
+/** 构造可观察 abort/close 语义的测试 sink。 */
+function trackingSink(): DownloadSink & {
+  aborted: boolean;
+  closed: boolean;
+} {
+  const state = { aborted: false, closed: false };
+  return {
+    supportsRandomAccess: true,
+    aborted: state.aborted,
+    closed: state.closed,
+    async write() {},
+    async writeAt() {},
+    async close() {
+      state.closed = true;
+      this.closed = true;
+    },
+    async abort() {
+      state.aborted = true;
+      this.aborted = true;
+    },
+  };
+}
+
+function base64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function base64url(bytes: Uint8Array): string {
+  return base64(bytes)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function responseFor(bytes: Uint8Array, sizes = [1, 5, 2]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let offset = 0;
+      let index = 0;
+      while (offset < bytes.length) {
+        const size = Math.min(
+          sizes[index++ % sizes.length],
+          bytes.length - offset,
+        );
+        controller.enqueue(bytes.slice(offset, offset + size));
+        offset += size;
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: { "content-length": String(bytes.length) },
+  });
+}
+
+function part(index: number, bytes: Uint8Array, url: string) {
+  const digest = `sha256:${bytesToHex(sha256(bytes))}`;
+  return {
+    index,
+    size: bytes.length,
+    downloadUrl: url,
+    expiresAtEpochSeconds: 2_000_000_000,
+    storagePath: `part/${index}`,
+    plainHash: digest,
+    cipherHash: digest,
+    checksumAlgorithm: "SHA-256",
+  };
+}
+
+/** 按后端 ObjectMapper 的字母序和 NON_NULL 规则构造 canonical manifest。 */
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== null && entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalValue(entry)]),
+  );
+}
+
+/** 为下载 metadata fixture 计算与后端一致的 canonical JSON/hash。 */
+function withCanonicalManifest(
+  metadata: Omit<
+    FileDownloadMetadataVO,
+    "canonicalManifestJson" | "manifestHash"
+  > & {
+    manifestHash?: string;
+    initialKey?: string | undefined;
+  },
+): FileDownloadMetadataVO {
+  const format = metadata.encryption?.formatVersion;
+  const totalSize = metadata.parts.reduce(
+    (sum, current) =>
+      sum + (format === 2 ? (current.plainSize ?? 0) : current.size),
+    0,
+  );
+  const payload = canonicalValue({
+    schema: metadata.manifestSchemaId,
+    fileHash: metadata.fileHash,
+    hashAlgorithm: metadata.hashAlgorithm,
+    chunkSize: metadata.chunkSize,
+    totalSize,
+    encryptionAlgorithm: metadata.encryptionAlgorithm,
+    storageBackend: metadata.storageBackend,
+    encryption: metadata.encryption,
+    chunks: metadata.parts.map((current) => ({
+      index: current.index,
+      plainHash: current.plainHash,
+      cipherHash: current.cipherHash,
+      size: current.size,
+      storagePath: current.storagePath,
+      storageBackend: current.storageBackend ?? metadata.storageBackend,
+      etag: current.etag,
+      checksumAlgorithm: current.checksumAlgorithm ?? "SHA-256",
+      plainSize: current.plainSize,
+      frameCount: current.frameCount,
+    })),
+  });
+  const canonicalManifestJson = JSON.stringify(payload);
+  return {
+    ...metadata,
+    manifestHash: `sha256:${bytesToHex(
+      sha256(new TextEncoder().encode(canonicalManifestJson)),
+    )}`,
+    canonicalManifestJson,
+  };
+}
+
+/** 重新计算测试中被篡改 canonical JSON 的摘要。 */
+function hashManifestJson(value: string): string {
+  return `sha256:${bytesToHex(sha256(new TextEncoder().encode(value)))}`;
+}
+
+async function encryptLegacyChunk(
+  plaintext: Uint8Array,
+  key: Uint8Array,
+  nextKey: Uint8Array,
+): Promise<Uint8Array> {
+  const iv = Uint8Array.from({ length: 12 }, (_, index) => index + 11);
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    "raw",
+    key as unknown as BufferSource,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+  const ciphertext = new Uint8Array(
+    await globalThis.crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: iv as unknown as BufferSource },
+      cryptoKey,
+      plaintext as unknown as BufferSource,
+    ),
+  );
+  const header = new Uint8Array([0x52, 0x50, 1, 1]);
+  const hash = `\n--HASH--\n${base64url(sha256(plaintext))}`;
+  const next = `\n--NEXT_KEY--\n${base64(nextKey)}`;
+  const encoded = new Uint8Array(
+    header.length + iv.length + ciphertext.length + hash.length + next.length,
+  );
+  let offset = 0;
+  encoded.set(header, offset);
+  offset += header.length;
+  encoded.set(iv, offset);
+  offset += iv.length;
+  encoded.set(ciphertext, offset);
+  offset += ciphertext.length;
+  encoded.set(new TextEncoder().encode(hash), offset);
+  offset += hash.length;
+  encoded.set(new TextEncoder().encode(next), offset);
+  return encoded;
+}
+
+describe("boundedDownloader", () => {
+  it("should stream NONE parts with length and hash verification", async () => {
+    const first = new TextEncoder().encode("hello ");
+    const second = new TextEncoder().encode("world");
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "file-hash",
+      fileName: "hello.txt",
+      fileSize: first.length + second.length,
+      contentType: "text/plain",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "NONE",
+      storageBackend: "S3",
+      chunkSize: first.length,
+      totalChunks: 2,
+      parts: [part(0, first, "u0"), part(1, second, "u1")],
+    });
+    const sink = new MemoryDownloadSink(metadata.fileSize, 64 * 1024 * 1024);
+    const responses = new Map([
+      ["u0", responseFor(first)],
+      ["u1", responseFor(second)],
+    ]);
+    const metrics = await executeBoundedDownload({
+      metadata,
+      sink,
+      metrics: new DownloadMetricsTracker(),
+      fetchImpl: async (url) => responses.get(String(url))!,
+    });
+    expect(metrics.bytesWritten).toBe(metadata.fileSize);
+    expect(new TextDecoder().decode(sink.getData())).toBe("hello world");
+  });
+
+  it("should reject reordered metadata parts instead of sorting them", async () => {
+    const first = new TextEncoder().encode("a");
+    const second = new TextEncoder().encode("b");
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "file-hash",
+      fileName: "reordered.txt",
+      fileSize: 2,
+      contentType: "text/plain",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "NONE",
+      storageBackend: "S3",
+      chunkSize: 1,
+      totalChunks: 2,
+      parts: [part(0, first, "u0"), part(1, second, "u1")],
+    });
+    metadata.parts = [metadata.parts[1], metadata.parts[0]];
+    const sink = trackingSink();
+
+    await expect(
+      executeBoundedDownload({
+        metadata,
+        sink,
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("分片顺序");
+    expect(sink.aborted).toBe(true);
+  });
+
+  it("should bind canonical chunk storage evidence and reject an etag drift", async () => {
+    const bytes = new TextEncoder().encode("etag-bound");
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "file-hash",
+      fileName: "etag.txt",
+      fileSize: bytes.length,
+      contentType: "text/plain",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "NONE",
+      storageBackend: "S3",
+      chunkSize: bytes.length,
+      totalChunks: 1,
+      parts: [{ ...part(0, bytes, "u0"), etag: "etag-a" }],
+    });
+    metadata.parts[0].etag = "etag-b";
+    const sink = trackingSink();
+
+    await expect(
+      executeBoundedDownload({
+        metadata,
+        sink,
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("etag");
+    expect(sink.aborted).toBe(true);
+  });
+
+  it("should reject case-insensitive secret fields injected into canonical manifest", async () => {
+    const bytes = new TextEncoder().encode("secret-check");
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "file-hash",
+      fileName: "secret.txt",
+      fileSize: bytes.length,
+      contentType: "text/plain",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "NONE",
+      storageBackend: "S3",
+      chunkSize: bytes.length,
+      totalChunks: 1,
+      parts: [part(0, bytes, "u0")],
+    });
+    const injected = JSON.parse(metadata.canonicalManifestJson) as Record<
+      string,
+      unknown
+    >;
+    injected.audit = { Wrapped_DATA_Key: "secret-material" };
+    const canonicalManifestJson = JSON.stringify(canonicalValue(injected));
+    metadata.canonicalManifestJson = canonicalManifestJson;
+    metadata.manifestHash = hashManifestJson(canonicalManifestJson);
+    const sink = trackingSink();
+
+    await expect(
+      executeBoundedDownload({
+        metadata,
+        sink,
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("密钥材料");
+    expect(sink.aborted).toBe(true);
+  });
+
+  it("should abort a bounded sink when cancellation wins before close", async () => {
+    const bytes = new TextEncoder().encode("cancel-before-close");
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "file-hash",
+      fileName: "cancel.txt",
+      fileSize: bytes.length,
+      contentType: "text/plain",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "NONE",
+      storageBackend: "S3",
+      chunkSize: bytes.length,
+      totalChunks: 1,
+      parts: [part(0, bytes, "u0")],
+    });
+    const controller = new AbortController();
+    const sink = trackingSink();
+
+    await expect(
+      executeBoundedDownload({
+        metadata,
+        sink,
+        signal: controller.signal,
+        fetchImpl: async () => responseFor(bytes),
+        onPartComplete: () => controller.abort(),
+      }),
+    ).rejects.toThrow("Download cancelled");
+    expect(sink.aborted).toBe(true);
+    expect(sink.closed).toBe(false);
+  });
+
+  it("should abort a legacy sink when cancellation wins before close", async () => {
+    const bytes = new TextEncoder().encode("legacy-cancel");
+    const controller = new AbortController();
+    const sink = trackingSink();
+
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: bytes.length,
+        totalChunks: 1,
+        encrypted: false,
+        sink,
+        signal: controller.signal,
+        fetchImpl: async () => responseFor(bytes),
+        onPartComplete: () => controller.abort(),
+      }),
+    ).rejects.toThrow("Download cancelled");
+    expect(sink.aborted).toBe(true);
+    expect(sink.closed).toBe(false);
+  });
+
+  it("should abort an empty legacy download when already cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const sink = trackingSink();
+
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: [],
+        fileSize: 0,
+        totalChunks: 0,
+        encrypted: false,
+        sink,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("Download cancelled");
+    expect(sink.aborted).toBe(true);
+    expect(sink.closed).toBe(false);
+  });
+
+  it("should preserve the v1 ring-key order while writing last part by offset", async () => {
+    const plaintext0 = new TextEncoder().encode("first");
+    const plaintext1 = new TextEncoder().encode("second!");
+    const key0 = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+    const key1 = Uint8Array.from({ length: 32 }, (_, index) => index + 33);
+    const cipher0 = await encryptLegacyChunk(plaintext0, key0, key1);
+    const cipher1 = await encryptLegacyChunk(plaintext1, key1, key0);
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "file-hash",
+      fileName: "legacy.txt",
+      fileSize: plaintext0.length + plaintext1.length,
+      contentType: "text/plain",
+      initialKey: base64(key1),
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "AES-GCM",
+      storageBackend: "S3",
+      chunkSize: plaintext0.length,
+      totalChunks: 2,
+      parts: [
+        {
+          ...part(0, cipher0, "u0"),
+          plainHash: `sha256:${bytesToHex(sha256(plaintext0))}`,
+          plainSize: plaintext0.length,
+        },
+        {
+          ...part(1, cipher1, "u1"),
+          plainHash: `sha256:${bytesToHex(sha256(plaintext1))}`,
+          plainSize: plaintext1.length,
+        },
+      ],
+    });
+    const sink = new MemoryDownloadSink(metadata.fileSize, 64 * 1024 * 1024);
+    const responses = new Map([
+      ["u0", responseFor(cipher0, [3, 1, 9])],
+      ["u1", responseFor(cipher1, [2, 4, 1])],
+    ]);
+    await executeBoundedDownload({
+      metadata,
+      sink,
+      fetchImpl: async (url) => responses.get(String(url))!,
+    });
+    expect(new TextDecoder().decode(sink.getData())).toBe("firstsecond!");
+  });
+
+  it("should reject legacy parts above the hard cap before fetching", async () => {
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "h",
+      fileName: "x",
+      fileSize: 1,
+      contentType: "application/octet-stream",
+      initialKey: base64(new Uint8Array(32)),
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "AES-GCM",
+      storageBackend: "S3",
+      chunkSize: 1,
+      totalChunks: 1,
+      parts: [
+        {
+          ...part(0, new Uint8Array([1]), "u0"),
+          size: LEGACY_MAX_CIPHER_PART_BYTES + 1,
+        },
+      ],
+    });
+    const sink = new MemoryDownloadSink(1, 64);
+    const fetchMock = async () => {
+      throw new Error("must not fetch");
+    };
+    await expect(
+      executeBoundedDownload({ metadata, sink, fetchImpl: fetchMock }),
+    ).rejects.toThrow("兼容读取上限");
+  });
+
+  it("should stream no-manifest plain parts without buffering the full file", async () => {
+    const first = new TextEncoder().encode("legacy ");
+    const second = new TextEncoder().encode("plain");
+    const sink = new MemoryDownloadSink(first.length + second.length, 64);
+    const responses = new Map([
+      ["u0", responseFor(first, [2, 1])],
+      ["u1", responseFor(second, [1, 3])],
+    ]);
+    const metrics = await executeLegacyFallbackDownload({
+      urls: ["u0", "u1"],
+      fileSize: first.length + second.length,
+      totalChunks: 2,
+      encrypted: false,
+      sink,
+      fetchImpl: async (url) => responses.get(String(url))!,
+    });
+    expect(metrics.currentBufferedBytes).toBe(0);
+    expect(metrics.partsCompleted).toBe(2);
+    expect(new TextDecoder().decode(sink.getData())).toBe("legacy plain");
+  });
+
+  it("should decrypt no-manifest v1 parts with a bounded per-part reader", async () => {
+    const plaintext0 = new TextEncoder().encode("alpha");
+    const plaintext1 = new TextEncoder().encode("omega!");
+    const key0 = Uint8Array.from({ length: 32 }, (_, index) => index + 3);
+    const key1 = Uint8Array.from({ length: 32 }, (_, index) => index + 37);
+    const cipher0 = await encryptLegacyChunk(plaintext0, key0, key1);
+    const cipher1 = await encryptLegacyChunk(plaintext1, key1, key0);
+    const sink = new MemoryDownloadSink(
+      plaintext0.length + plaintext1.length,
+      64,
+    );
+    const responses = new Map([
+      ["u0", responseFor(cipher0, [3, 5, 2])],
+      ["u1", responseFor(cipher1, [1, 4, 7])],
+    ]);
+    const metrics = await executeLegacyFallbackDownload({
+      urls: ["u0", "u1"],
+      fileSize: plaintext0.length + plaintext1.length,
+      totalChunks: 2,
+      initialKey: base64(key1),
+      encrypted: true,
+      sink,
+      fetchImpl: async (url) => responses.get(String(url))!,
+    });
+    expect(metrics.currentBufferedBytes).toBe(0);
+    expect(metrics.partsCompleted).toBe(2);
+    expect(new TextDecoder().decode(sink.getData())).toBe("alphaomega!");
+  });
+
+  it("should reject a no-manifest v1 Content-Length above the legacy cap", async () => {
+    const sink = new MemoryDownloadSink(1, 64);
+    const response = new Response(new Uint8Array([1]), {
+      headers: {
+        "content-length": String(LEGACY_MAX_CIPHER_PART_BYTES + 1),
+      },
+    });
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        initialKey: base64(new Uint8Array(32)),
+        encrypted: true,
+        sink,
+        fetchImpl: async () => response,
+      }),
+    ).rejects.toThrow("兼容读取上限");
+  });
+
+  it("should reject NONE plainSize drift before reading the body", async () => {
+    const bytes = new TextEncoder().encode("plain");
+    const metadata = withCanonicalManifest({
+      fileId: "f",
+      fileHash: "h",
+      fileName: "plain.txt",
+      fileSize: bytes.length,
+      contentType: "text/plain",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "NONE",
+      storageBackend: "S3",
+      chunkSize: bytes.length,
+      totalChunks: 1,
+      parts: [{ ...part(0, bytes, "u0"), plainSize: bytes.length - 1 }],
+    });
+    await expect(
+      executeBoundedDownload({
+        metadata,
+        sink: new MemoryDownloadSink(bytes.length, 64),
+        fetchImpl: async () => responseFor(bytes),
+      }),
+    ).rejects.toThrow("明文尺寸与对象尺寸不一致");
+  });
+
+  it("should abort the sink when manifest validation fails before fetching", async () => {
+    const sink = trackingSink();
+    await expect(
+      executeBoundedDownload({
+        metadata: {
+          fileId: "f",
+          fileHash: "h",
+          fileName: "invalid.bin",
+          fileSize: 1,
+          contentType: "application/octet-stream",
+          initialKey: undefined,
+          manifestSchemaId: "v1",
+          manifestHash: "sha256:00",
+          canonicalManifestJson: "{}",
+          hashAlgorithm: "SHA-256",
+          encryptionAlgorithm: "NONE",
+          storageBackend: "S3",
+          chunkSize: 1,
+          totalChunks: 0,
+          parts: [],
+        },
+        sink,
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("文件或分片数量无效");
+    expect(sink.aborted).toBe(true);
+    expect(sink.closed).toBe(false);
+  });
+
+  it("should abort the sink when legacy fallback parameters are invalid", async () => {
+    const sink = trackingSink();
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: [],
+        fileSize: 1,
+        totalChunks: 0,
+        encrypted: false,
+        sink,
+      }),
+    ).rejects.toThrow("历史下载缺少分片 URL");
+    expect(sink.aborted).toBe(true);
+    expect(sink.closed).toBe(false);
+  });
+
+  it("should reject unknown format versions", () => {
+    expect(() =>
+      resolveDownloadFormat({
+        encryptionAlgorithm: "AES-GCM",
+        encryption: { formatVersion: 3 },
+      } as never),
+    ).toThrow("不支持的下载格式版本");
+  });
+
+  it("should reject unknown algorithms and algorithm/version conflicts", () => {
+    expect(() =>
+      resolveDownloadFormat({
+        encryptionAlgorithm: "UNKNOWN-AEAD",
+      } as never),
+    ).toThrow("不支持的下载加密算法");
+    expect(() =>
+      resolveDownloadFormat({
+        encryptionAlgorithm: "AES-GCM",
+        encryption: { formatVersion: 0 },
+      } as never),
+    ).toThrow("下载加密算法与 formatVersion 冲突");
+    expect(() =>
+      resolveDownloadFormat({
+        encryptionAlgorithm: "FRAMED_AEAD_V2",
+        encryption: { formatVersion: 1 },
+      } as never),
+    ).toThrow("下载加密算法与 formatVersion 冲突");
+    expect(() =>
+      resolveDownloadFormat({
+        encryptionAlgorithm: "AES-GCM",
+        encryption: { formatVersion: 2 },
+      } as never),
+    ).toThrow("下载加密算法与 formatVersion 冲突");
+  });
+});

--- a/platform-frontend/src/lib/utils/boundedDownloader.test.ts
+++ b/platform-frontend/src/lib/utils/boundedDownloader.test.ts
@@ -1,5 +1,5 @@
 import { sha256 } from "@noble/hashes/sha2.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { FileDownloadMetadataVO } from "$api/types";
 
 import {
@@ -11,6 +11,15 @@ import {
 import { bytesToHex } from "./downloadIntegrity";
 import { DownloadMetricsTracker } from "./downloadMetrics";
 import { MemoryDownloadSink, type DownloadSink } from "./downloadSink";
+import {
+  buildFramedAad,
+  deriveFramedKeyMaterial,
+  FRAMED_AEAD_AAD_SCHEMA,
+  FRAMED_AEAD_FORMAT_VERSION,
+  FRAMED_AEAD_SUITE,
+  FRAMED_AEAD_TAG_BYTES,
+  MIN_FRAME_PLAIN_BYTES,
+} from "./framedAead";
 
 /** 构造可观察 abort/close 语义的测试 sink。 */
 function trackingSink(): DownloadSink & {
@@ -64,6 +73,28 @@ function responseFor(bytes: Uint8Array, sizes = [1, 5, 2]): Response {
   });
   return new Response(stream, {
     headers: { "content-length": String(bytes.length) },
+  });
+}
+
+/** 构造可控制响应声明长度和 reader cancel 行为的流式响应。 */
+function responseFromChunks(
+  chunks: Uint8Array[],
+  declaredLength?: number,
+  cancel?: (reason?: unknown) => void | Promise<void>,
+  close = true,
+): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      if (close) controller.close();
+    },
+    cancel,
+  });
+  return new Response(stream, {
+    headers:
+      declaredLength == null
+        ? undefined
+        : { "content-length": String(declaredLength) },
   });
 }
 
@@ -149,7 +180,7 @@ function hashManifestJson(value: string): string {
 async function encryptLegacyChunk(
   plaintext: Uint8Array,
   key: Uint8Array,
-  nextKey: Uint8Array,
+  nextKey: Uint8Array | null,
 ): Promise<Uint8Array> {
   const iv = Uint8Array.from({ length: 12 }, (_, index) => index + 11);
   const cryptoKey = await globalThis.crypto.subtle.importKey(
@@ -168,7 +199,7 @@ async function encryptLegacyChunk(
   );
   const header = new Uint8Array([0x52, 0x50, 1, 1]);
   const hash = `\n--HASH--\n${base64url(sha256(plaintext))}`;
-  const next = `\n--NEXT_KEY--\n${base64(nextKey)}`;
+  const next = nextKey ? `\n--NEXT_KEY--\n${base64(nextKey)}` : "";
   const encoded = new Uint8Array(
     header.length + iv.length + ciphertext.length + hash.length + next.length,
   );
@@ -183,6 +214,145 @@ async function encryptLegacyChunk(
   offset += hash.length;
   encoded.set(new TextEncoder().encode(next), offset);
   return encoded;
+}
+
+/** 原地修改 canonical JSON，并同步刷新 manifest 摘要。 */
+function mutateCanonicalManifest(
+  metadata: FileDownloadMetadataVO,
+  mutate: (manifest: Record<string, unknown>) => void,
+): void {
+  const manifest = JSON.parse(metadata.canonicalManifestJson) as Record<
+    string,
+    unknown
+  >;
+  mutate(manifest);
+  metadata.canonicalManifestJson = JSON.stringify(canonicalValue(manifest));
+  metadata.manifestHash = hashManifestJson(metadata.canonicalManifestJson);
+}
+
+/** 构造单分片 NONE metadata，便于覆盖失败关闭分支。 */
+function plainMetadata(bytes = new Uint8Array([1, 2])): FileDownloadMetadataVO {
+  return withCanonicalManifest({
+    fileId: "plain-file",
+    fileHash: "plain-hash",
+    fileName: "plain.bin",
+    fileSize: bytes.length,
+    contentType: "application/octet-stream",
+    initialKey: undefined,
+    manifestSchemaId: "v1",
+    manifestHash: "sha256:00",
+    hashAlgorithm: "SHA-256",
+    encryptionAlgorithm: "NONE",
+    storageBackend: "S3",
+    chunkSize: Math.max(bytes.length, 1),
+    totalChunks: 1,
+    parts: [part(0, bytes, "u0")],
+  });
+}
+
+/** 写入测试用 uint32 大端字段。 */
+function writeUint32(bytes: Uint8Array, offset: number, value: number): void {
+  new DataView(bytes.buffer).setUint32(offset, value, false);
+}
+
+/** 构造可被完整认证的一帧 framed v2 下载 fixture。 */
+async function framedMetadataFixture(): Promise<{
+  metadata: FileDownloadMetadataVO;
+  encoded: Uint8Array;
+  plaintext: Uint8Array;
+}> {
+  const plaintext = new TextEncoder().encode("bounded framed payload");
+  const fileNonce = Uint8Array.from({ length: 16 }, (_, index) => index + 1);
+  const fileDek = Uint8Array.from({ length: 32 }, (_, index) => index + 33);
+  const material = deriveFramedKeyMaterial({
+    fileDek,
+    fileNonce,
+    chunkIndex: 0,
+    frameIndex: 0,
+  });
+  const aad = buildFramedAad({
+    fileNonce,
+    chunkIndex: 0,
+    chunkCount: 1,
+    frameIndex: 0,
+    frameCount: 1,
+    plainLength: plaintext.length,
+    chunkPlainSize: plaintext.length,
+  });
+  const cryptoKey = await globalThis.crypto.subtle.importKey(
+    "raw",
+    material.key as unknown as BufferSource,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"],
+  );
+  const ciphertext = new Uint8Array(
+    await globalThis.crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv: material.nonce as unknown as BufferSource,
+        additionalData: aad as unknown as BufferSource,
+        tagLength: FRAMED_AEAD_TAG_BYTES * 8,
+      },
+      cryptoKey,
+      plaintext as unknown as BufferSource,
+    ),
+  );
+  const header = new Uint8Array(44);
+  header.set(new TextEncoder().encode("RPF2"), 0);
+  header[4] = FRAMED_AEAD_FORMAT_VERSION;
+  header[5] = 1;
+  writeUint32(header, 8, 0);
+  writeUint32(header, 12, 1);
+  writeUint32(header, 16, MIN_FRAME_PLAIN_BYTES);
+  writeUint32(header, 20, 1);
+  writeUint32(header, 24, plaintext.length);
+  header.set(fileNonce, 28);
+  const frameHeader = new Uint8Array(12);
+  writeUint32(frameHeader, 0, 0);
+  writeUint32(frameHeader, 4, plaintext.length);
+  writeUint32(frameHeader, 8, ciphertext.length);
+  const encoded = new Uint8Array(
+    header.length + frameHeader.length + ciphertext.length,
+  );
+  encoded.set(header, 0);
+  encoded.set(frameHeader, header.length);
+  encoded.set(ciphertext, header.length + frameHeader.length);
+
+  const encryption = {
+    formatVersion: FRAMED_AEAD_FORMAT_VERSION,
+    algorithmSuite: FRAMED_AEAD_SUITE,
+    fileNonce: base64(fileNonce),
+    framePlainSize: MIN_FRAME_PLAIN_BYTES,
+    keyDerivation: "HKDF-SHA256",
+    nonceDerivation: "HKDF-SHA256",
+    aadSchema: FRAMED_AEAD_AAD_SCHEMA,
+    tagSize: FRAMED_AEAD_TAG_BYTES,
+  };
+  const framedPart = {
+    ...part(0, encoded, "u0"),
+    plainHash: `sha256:${bytesToHex(sha256(plaintext))}`,
+    plainSize: plaintext.length,
+    frameCount: 1,
+  };
+  const metadata = withCanonicalManifest({
+    fileId: "framed-file",
+    fileHash: "framed-hash",
+    fileName: "framed.bin",
+    fileSize: plaintext.length,
+    contentType: "application/octet-stream",
+    initialKey: base64(fileDek),
+    manifestSchemaId: "v1",
+    manifestHash: "sha256:00",
+    hashAlgorithm: "SHA-256",
+    encryptionAlgorithm: "FRAMED_AEAD_V2",
+    storageBackend: "S3",
+    chunkSize: MIN_FRAME_PLAIN_BYTES,
+    totalChunks: 1,
+    parts: [framedPart],
+    encryption,
+  });
+  return { metadata, encoded, plaintext };
 }
 
 describe("boundedDownloader", () => {
@@ -218,6 +388,200 @@ describe("boundedDownloader", () => {
     });
     expect(metrics.bytesWritten).toBe(metadata.fileSize);
     expect(new TextDecoder().decode(sink.getData())).toBe("hello world");
+  });
+
+  it("should authenticate a framed v2 part through the bounded dispatcher", async () => {
+    const fixture = await framedMetadataFixture();
+    const sink = new MemoryDownloadSink(fixture.plaintext.length, 1024);
+
+    const metrics = await executeBoundedDownload({
+      metadata: fixture.metadata,
+      expectedFileHash: fixture.metadata.fileHash,
+      sink,
+      fetchImpl: async () => responseFor(fixture.encoded, [1, 7, 31]),
+    });
+
+    expect(metrics).toMatchObject({
+      currentBufferedBytes: 0,
+      framesAuthenticated: 1,
+      partsCompleted: 1,
+      bytesWritten: fixture.plaintext.length,
+    });
+    expect(Array.from(sink.getData())).toEqual(Array.from(fixture.plaintext));
+  });
+
+  it("should fail closed on canonical manifest shape and binding drift", async () => {
+    const cases: Array<{
+      expected: string;
+      prepare: (metadata: FileDownloadMetadataVO) => void;
+    }> = [
+      {
+        expected: "缺少 canonical manifest JSON",
+        prepare: (metadata) => {
+          metadata.canonicalManifestJson = " ";
+        },
+      },
+      {
+        expected: "fileHash 与任务不一致",
+        prepare: (metadata) => {
+          metadata.fileHash = "";
+        },
+      },
+      {
+        expected: "canonical manifest JSON 无效",
+        prepare: (metadata) => {
+          metadata.canonicalManifestJson = "{";
+          metadata.manifestHash = hashManifestJson("{");
+        },
+      },
+      {
+        expected: "canonical manifest 不是有效对象",
+        prepare: (metadata) => {
+          metadata.canonicalManifestJson = "[]";
+          metadata.manifestHash = hashManifestJson("[]");
+        },
+      },
+      {
+        expected: "字段 schema 与 metadata 不一致",
+        prepare: (metadata) => {
+          mutateCanonicalManifest(metadata, (manifest) => {
+            manifest.schema = "other-schema";
+          });
+        },
+      },
+      {
+        expected: "字段 chunkSize 与 metadata 不一致",
+        prepare: (metadata) => {
+          mutateCanonicalManifest(metadata, (manifest) => {
+            manifest.chunkSize = "2";
+          });
+        },
+      },
+      {
+        expected: "字段 encryptionAlgorithm 不应存在",
+        prepare: (metadata) => {
+          metadata.encryptionAlgorithm = undefined;
+        },
+      },
+      {
+        expected: "manifest 明文总量与文件大小不一致",
+        prepare: (metadata) => {
+          metadata.fileSize += 1;
+        },
+      },
+      {
+        expected: "manifest 分片数量与 metadata 不一致",
+        prepare: (metadata) => {
+          mutateCanonicalManifest(metadata, (manifest) => {
+            manifest.chunks = [];
+          });
+        },
+      },
+      {
+        expected: "manifest encryption 与 metadata 不一致",
+        prepare: (metadata) => {
+          mutateCanonicalManifest(metadata, (manifest) => {
+            manifest.encryption = {};
+          });
+        },
+      },
+      {
+        expected: "字段 etag 与 metadata 不一致",
+        prepare: (metadata) => {
+          metadata.parts[0].etag = "etag-after-signing";
+        },
+      },
+    ];
+
+    for (const scenario of cases) {
+      const metadata = plainMetadata();
+      scenario.prepare(metadata);
+      const sink = trackingSink();
+      await expect(
+        executeBoundedDownload({
+          metadata,
+          expectedFileHash: "plain-hash",
+          sink,
+          fetchImpl: async () => {
+            throw new Error("must not fetch");
+          },
+        }),
+      ).rejects.toThrow(scenario.expected);
+      expect(sink.aborted).toBe(true);
+    }
+
+    const framedFixture = await framedMetadataFixture();
+    mutateCanonicalManifest(framedFixture.metadata, (manifest) => {
+      delete manifest.encryption;
+    });
+    await expect(
+      executeBoundedDownload({
+        metadata: framedFixture.metadata,
+        sink: trackingSink(),
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("缺少 encryption 描述");
+
+    const missingPlainSize = (await framedMetadataFixture()).metadata;
+    delete missingPlainSize.parts[0].plainSize;
+    await expect(
+      executeBoundedDownload({
+        metadata: missingPlainSize,
+        sink: trackingSink(),
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("manifest 分片总量无效");
+  });
+
+  it("should cancel untrusted NONE responses on network and length violations", async () => {
+    const oversizedChunk = new Uint8Array(1024 * 1024 + 1);
+    const cases = [
+      {
+        metadata: plainMetadata(oversizedChunk),
+        chunks: [oversizedChunk],
+        declaredLength: oversizedChunk.byteLength,
+        keepOpen: true,
+        expected: "网络读取块超过有界下载上限",
+      },
+      {
+        metadata: plainMetadata(new Uint8Array([1])),
+        chunks: [new Uint8Array([1, 2])],
+        declaredLength: undefined,
+        keepOpen: true,
+        expected: "超过 manifest 声明大小",
+      },
+      {
+        metadata: plainMetadata(new Uint8Array([1, 2])),
+        chunks: [new Uint8Array([1])],
+        declaredLength: undefined,
+        keepOpen: false,
+        expected: "长度与 manifest 不一致",
+      },
+    ];
+
+    for (const scenario of cases) {
+      let cancelled = false;
+      const response = responseFromChunks(
+        scenario.chunks,
+        scenario.declaredLength,
+        () => {
+          cancelled = true;
+        },
+        !scenario.keepOpen,
+      );
+      await expect(
+        executeBoundedDownload({
+          metadata: scenario.metadata,
+          sink: trackingSink(),
+          fetchImpl: async () => response,
+        }),
+      ).rejects.toThrow(scenario.expected);
+      if (scenario.keepOpen) expect(cancelled).toBe(true);
+    }
   });
 
   it("should reject reordered metadata parts instead of sorting them", async () => {
@@ -287,45 +651,66 @@ describe("boundedDownloader", () => {
     expect(sink.aborted).toBe(true);
   });
 
-  it("should reject case-insensitive secret fields injected into canonical manifest", async () => {
-    const bytes = new TextEncoder().encode("secret-check");
-    const metadata = withCanonicalManifest({
-      fileId: "f",
-      fileHash: "file-hash",
-      fileName: "secret.txt",
-      fileSize: bytes.length,
-      contentType: "text/plain",
-      initialKey: undefined,
-      manifestSchemaId: "v1",
-      manifestHash: "sha256:00",
-      hashAlgorithm: "SHA-256",
-      encryptionAlgorithm: "NONE",
-      storageBackend: "S3",
-      chunkSize: bytes.length,
-      totalChunks: 1,
-      parts: [part(0, bytes, "u0")],
-    });
-    const injected = JSON.parse(metadata.canonicalManifestJson) as Record<
-      string,
-      unknown
-    >;
-    injected.audit = { Wrapped_DATA_Key: "secret-material" };
-    const canonicalManifestJson = JSON.stringify(canonicalValue(injected));
-    metadata.canonicalManifestJson = canonicalManifestJson;
-    metadata.manifestHash = hashManifestJson(canonicalManifestJson);
-    const sink = trackingSink();
+  it.each([
+    "KEY",
+    "key-s",
+    "Secret",
+    "INITIAL-Key",
+    "file_DEK",
+    "data-key",
+    "encrypted.DATA.key",
+    "Wrapped_DATA_Key",
+    "decrypt-key",
+    "Decryption_Key",
+    "encryption.KEY",
+    "file-key",
+    "file.DATA.key",
+    "wrapping-IV",
+    "KMS_key_ID",
+    "private-key",
+    "secret.KEY",
+  ])(
+    "should reject normalized secret field %s injected into canonical manifest",
+    async (secretField) => {
+      const bytes = new TextEncoder().encode("secret-check");
+      const metadata = withCanonicalManifest({
+        fileId: "f",
+        fileHash: "file-hash",
+        fileName: "secret.txt",
+        fileSize: bytes.length,
+        contentType: "text/plain",
+        initialKey: undefined,
+        manifestSchemaId: "v1",
+        manifestHash: "sha256:00",
+        hashAlgorithm: "SHA-256",
+        encryptionAlgorithm: "NONE",
+        storageBackend: "S3",
+        chunkSize: bytes.length,
+        totalChunks: 1,
+        parts: [part(0, bytes, "u0")],
+      });
+      const injected = JSON.parse(metadata.canonicalManifestJson) as Record<
+        string,
+        unknown
+      >;
+      injected.audit = { [secretField]: "secret-material" };
+      const canonicalManifestJson = JSON.stringify(canonicalValue(injected));
+      metadata.canonicalManifestJson = canonicalManifestJson;
+      metadata.manifestHash = hashManifestJson(canonicalManifestJson);
+      const sink = trackingSink();
 
-    await expect(
-      executeBoundedDownload({
-        metadata,
-        sink,
-        fetchImpl: async () => {
-          throw new Error("must not fetch");
-        },
-      }),
-    ).rejects.toThrow("密钥材料");
-    expect(sink.aborted).toBe(true);
-  });
+      await expect(
+        executeBoundedDownload({
+          metadata,
+          sink,
+          fetchImpl: async () => {
+            throw new Error("must not fetch");
+          },
+        }),
+      ).rejects.toThrow("密钥材料");
+      expect(sink.aborted).toBe(true);
+    },
+  );
 
   it("should abort a bounded sink when cancellation wins before close", async () => {
     const bytes = new TextEncoder().encode("cancel-before-close");
@@ -620,6 +1005,210 @@ describe("boundedDownloader", () => {
     ).rejects.toThrow("历史下载缺少分片 URL");
     expect(sink.aborted).toBe(true);
     expect(sink.closed).toBe(false);
+  });
+
+  it("should retry transient object failures but fail fast on expired URLs", async () => {
+    vi.useFakeTimers();
+    try {
+      const bytes = new Uint8Array([7]);
+      let attempts = 0;
+      const download = executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: false,
+        sink: new MemoryDownloadSink(1, 64),
+        fetchImpl: async () => {
+          attempts++;
+          return attempts < 3
+            ? new Response(null, { status: 503 })
+            : responseFor(bytes);
+        },
+      });
+
+      await vi.runAllTimersAsync();
+      await expect(download).resolves.toMatchObject({ bytesWritten: 1 });
+      expect(attempts).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    let expiredAttempts = 0;
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["expired"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: false,
+        sink: trackingSink(),
+        fetchImpl: async () => {
+          expiredAttempts++;
+          return new Response(null, { status: 403 });
+        },
+      }),
+    ).rejects.toThrow("下载地址已过期");
+    expect(expiredAttempts).toBe(1);
+  });
+
+  it("should enforce legacy fallback response bounds before decryption or commit", async () => {
+    const plainCases = [
+      {
+        fileSize: 1,
+        response: () => responseFromChunks([new Uint8Array([1])], 2),
+        expected: "超过文件声明大小",
+      },
+      {
+        fileSize: 1,
+        response: () =>
+          responseFromChunks([new Uint8Array([1, 2])], undefined, undefined),
+        expected: "超过文件声明大小",
+      },
+      {
+        fileSize: 2,
+        response: () => responseFromChunks([new Uint8Array([1])], 2),
+        expected: "长度与响应声明不一致",
+      },
+      {
+        fileSize: 1,
+        response: () => responseFromChunks([]),
+        expected: "历史明文分片为空",
+      },
+    ];
+    for (const scenario of plainCases) {
+      await expect(
+        executeLegacyFallbackDownload({
+          urls: ["u0"],
+          fileSize: scenario.fileSize,
+          totalChunks: 1,
+          encrypted: false,
+          sink: trackingSink(),
+          fetchImpl: async () => scenario.response(),
+        }),
+      ).rejects.toThrow(scenario.expected);
+    }
+
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: true,
+        sink: trackingSink(),
+        fetchImpl: async () => responseFromChunks([new Uint8Array([1])], 2),
+        initialKey: base64(new Uint8Array(32)),
+      }),
+    ).rejects.toThrow("长度与响应声明不一致");
+
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: true,
+        sink: trackingSink(),
+        fetchImpl: async () => responseFromChunks([new Uint8Array([1, 2])], 1),
+        initialKey: base64(new Uint8Array(32)),
+      }),
+    ).rejects.toThrow("超过响应声明大小");
+  });
+
+  it("should reject legacy key and random-access contract violations", async () => {
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: true,
+        sink: trackingSink(),
+      }),
+    ).rejects.toThrow("缺少 initialKey");
+
+    const sequentialSink: DownloadSink = {
+      ...trackingSink(),
+      supportsRandomAccess: false,
+    };
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: true,
+        initialKey: base64(new Uint8Array(32)),
+        sink: sequentialSink,
+      }),
+    ).rejects.toThrow("支持随机写入");
+
+    const metadata = withCanonicalManifest({
+      fileId: "legacy-file",
+      fileHash: "legacy-hash",
+      fileName: "legacy.bin",
+      fileSize: 1,
+      contentType: "application/octet-stream",
+      initialKey: undefined,
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "AES-GCM",
+      storageBackend: "S3",
+      chunkSize: 1,
+      totalChunks: 1,
+      parts: [part(0, new Uint8Array([1]), "u0")],
+    });
+    await expect(
+      executeBoundedDownload({
+        metadata,
+        sink: trackingSink(),
+        fetchImpl: async () => {
+          throw new Error("must not fetch");
+        },
+      }),
+    ).rejects.toThrow("缺少 initialKey");
+  });
+
+  it("should reject leaked buffers or mismatched write accounting before close", async () => {
+    const bytes = new Uint8Array([1]);
+    const leakedMetrics = new DownloadMetricsTracker();
+    leakedMetrics.acquire(1);
+    await expect(
+      executeBoundedDownload({
+        metadata: plainMetadata(bytes),
+        sink: new MemoryDownloadSink(1, 64),
+        metrics: leakedMetrics,
+        fetchImpl: async () => responseFor(bytes),
+      }),
+    ).rejects.toThrow("下载缓冲区未释放");
+
+    const mismatchedMetrics = new DownloadMetricsTracker();
+    mismatchedMetrics.wrote(1);
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["u0"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: false,
+        sink: new MemoryDownloadSink(1, 64),
+        metrics: mismatchedMetrics,
+        fetchImpl: async () => responseFor(bytes),
+      }),
+    ).rejects.toThrow("写入长度不一致");
+  });
+
+  it.each([
+    [{ encryption: { formatVersion: 0 } }, "NONE"],
+    [{ encryptionAlgorithm: " none " }, "NONE"],
+    [
+      {
+        encryptionAlgorithm: "framed_aead_v2",
+        encryption: { formatVersion: 2 },
+      },
+      "FRAMED_V2",
+    ],
+    [
+      { encryptionAlgorithm: "CHACHA20", encryption: { formatVersion: 1 } },
+      "LEGACY_V1",
+    ],
+  ])("should resolve supported download contracts", (metadata, expected) => {
+    expect(resolveDownloadFormat(metadata as never)).toBe(expected);
   });
 
   it("should reject unknown format versions", () => {

--- a/platform-frontend/src/lib/utils/boundedDownloader.test.ts
+++ b/platform-frontend/src/lib/utils/boundedDownloader.test.ts
@@ -410,6 +410,54 @@ describe("boundedDownloader", () => {
     expect(Array.from(sink.getData())).toEqual(Array.from(fixture.plaintext));
   });
 
+  it.each([
+    {
+      name: "unknown suite",
+      expected: "不支持的 framed AEAD 下载合同",
+      prepare: (metadata: FileDownloadMetadataVO) => {
+        if (!metadata.encryption) throw new Error("fixture 缺少加密描述");
+        metadata.encryption.algorithmSuite = "OTHER-SUITE";
+      },
+    },
+    {
+      name: "undersized frame",
+      expected: "不支持的 framed AEAD 下载合同",
+      prepare: (metadata: FileDownloadMetadataVO) => {
+        if (!metadata.encryption) throw new Error("fixture 缺少加密描述");
+        metadata.encryption.framePlainSize = 1;
+      },
+    },
+    {
+      name: "invalid file nonce",
+      expected: "framed AEAD fileNonce 必须为 16 字节",
+      prepare: (metadata: FileDownloadMetadataVO) => {
+        if (!metadata.encryption) throw new Error("fixture 缺少加密描述");
+        metadata.encryption.fileNonce = base64(new Uint8Array([1]));
+      },
+    },
+  ])(
+    "should reject framed v2 $name before fetching",
+    async ({ expected, prepare }) => {
+      const fixture = await framedMetadataFixture();
+      prepare(fixture.metadata);
+      const sink = trackingSink();
+      const fetchMock = vi.fn(async () => {
+        throw new Error("must not fetch");
+      });
+
+      await expect(
+        executeBoundedDownload({
+          metadata: fixture.metadata,
+          sink,
+          fetchImpl: fetchMock,
+        }),
+      ).rejects.toThrow(expected);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(sink.aborted).toBe(true);
+      expect(sink.closed).toBe(false);
+    },
+  );
+
   it("should fail closed on canonical manifest shape and binding drift", async () => {
     const cases: Array<{
       expected: string;
@@ -788,7 +836,7 @@ describe("boundedDownloader", () => {
 
   it("should preserve the v1 ring-key order while writing last part by offset", async () => {
     const plaintext0 = new TextEncoder().encode("first");
-    const plaintext1 = new TextEncoder().encode("second!");
+    const plaintext1 = new TextEncoder().encode("tail!");
     const key0 = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
     const key1 = Uint8Array.from({ length: 32 }, (_, index) => index + 33);
     const cipher0 = await encryptLegacyChunk(plaintext0, key0, key1);
@@ -830,7 +878,7 @@ describe("boundedDownloader", () => {
       sink,
       fetchImpl: async (url) => responses.get(String(url))!,
     });
-    expect(new TextDecoder().decode(sink.getData())).toBe("firstsecond!");
+    expect(new TextDecoder().decode(sink.getData())).toBe("firsttail!");
   });
 
   it("should reject legacy parts above the hard cap before fetching", async () => {
@@ -862,6 +910,81 @@ describe("boundedDownloader", () => {
     await expect(
       executeBoundedDownload({ metadata, sink, fetchImpl: fetchMock }),
     ).rejects.toThrow("兼容读取上限");
+  });
+
+  it.each([
+    { name: "gap", plainSizes: [4, 6] },
+    { name: "overlap", plainSizes: [6, 4] },
+  ])(
+    "should reject legacy v1 $name ranges before fetching",
+    async ({ plainSizes }) => {
+      const firstCipher = new Uint8Array([1]);
+      const secondCipher = new Uint8Array([2]);
+      const metadata = withCanonicalManifest({
+        fileId: "legacy-range-file",
+        fileHash: "legacy-range-hash",
+        fileName: "legacy-range.bin",
+        fileSize: 10,
+        contentType: "application/octet-stream",
+        initialKey: base64(new Uint8Array(32)),
+        manifestSchemaId: "v1",
+        manifestHash: "sha256:00",
+        hashAlgorithm: "SHA-256",
+        encryptionAlgorithm: "AES-GCM",
+        storageBackend: "S3",
+        chunkSize: 5,
+        totalChunks: 2,
+        parts: [
+          { ...part(0, firstCipher, "u0"), plainSize: plainSizes[0] },
+          { ...part(1, secondCipher, "u1"), plainSize: plainSizes[1] },
+        ],
+      });
+      const sink = trackingSink();
+      const fetchMock = vi.fn(async () => {
+        throw new Error("must not fetch");
+      });
+
+      await expect(
+        executeBoundedDownload({ metadata, sink, fetchImpl: fetchMock }),
+      ).rejects.toThrow("明文范围不连续或尺寸不一致");
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(sink.aborted).toBe(true);
+    },
+  );
+
+  it("should reject legacy v1 range overflow before fetching", async () => {
+    const metadata = withCanonicalManifest({
+      fileId: "legacy-overflow-file",
+      fileHash: "legacy-overflow-hash",
+      fileName: "legacy-overflow.bin",
+      fileSize: Number.MAX_SAFE_INTEGER,
+      contentType: "application/octet-stream",
+      initialKey: base64(new Uint8Array(32)),
+      manifestSchemaId: "v1",
+      manifestHash: "sha256:00",
+      hashAlgorithm: "SHA-256",
+      encryptionAlgorithm: "AES-GCM",
+      storageBackend: "S3",
+      chunkSize: Number.MAX_SAFE_INTEGER,
+      totalChunks: 2,
+      parts: [
+        {
+          ...part(0, new Uint8Array([1]), "u0"),
+          plainSize: Number.MAX_SAFE_INTEGER,
+        },
+        { ...part(1, new Uint8Array([2]), "u1"), plainSize: 1 },
+      ],
+    });
+    const sink = trackingSink();
+    const fetchMock = vi.fn(async () => {
+      throw new Error("must not fetch");
+    });
+
+    await expect(
+      executeBoundedDownload({ metadata, sink, fetchImpl: fetchMock }),
+    ).rejects.toThrow("明文范围无效");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sink.aborted).toBe(true);
   });
 
   it("should stream no-manifest plain parts without buffering the full file", async () => {
@@ -1012,6 +1135,7 @@ describe("boundedDownloader", () => {
     try {
       const bytes = new Uint8Array([7]);
       let attempts = 0;
+      let transientBodiesCancelled = 0;
       const download = executeLegacyFallbackDownload({
         urls: ["u0"],
         fileSize: 1,
@@ -1020,20 +1144,30 @@ describe("boundedDownloader", () => {
         sink: new MemoryDownloadSink(1, 64),
         fetchImpl: async () => {
           attempts++;
-          return attempts < 3
-            ? new Response(null, { status: 503 })
-            : responseFor(bytes);
+          if (attempts < 3) {
+            return new Response(
+              new ReadableStream({
+                cancel() {
+                  transientBodiesCancelled++;
+                },
+              }),
+              { status: 503 },
+            );
+          }
+          return responseFor(bytes);
         },
       });
 
       await vi.runAllTimersAsync();
       await expect(download).resolves.toMatchObject({ bytesWritten: 1 });
       expect(attempts).toBe(3);
+      expect(transientBodiesCancelled).toBe(2);
     } finally {
       vi.useRealTimers();
     }
 
     let expiredAttempts = 0;
+    let expiredBodyCancelled = 0;
     await expect(
       executeLegacyFallbackDownload({
         urls: ["expired"],
@@ -1043,11 +1177,44 @@ describe("boundedDownloader", () => {
         sink: trackingSink(),
         fetchImpl: async () => {
           expiredAttempts++;
-          return new Response(null, { status: 403 });
+          return new Response(
+            new ReadableStream({
+              cancel() {
+                expiredBodyCancelled++;
+              },
+            }),
+            { status: 403 },
+          );
         },
       }),
     ).rejects.toThrow("下载地址已过期");
     expect(expiredAttempts).toBe(1);
+    expect(expiredBodyCancelled).toBe(1);
+
+    let notFoundAttempts = 0;
+    let notFoundBodyCancelled = 0;
+    await expect(
+      executeLegacyFallbackDownload({
+        urls: ["not-found"],
+        fileSize: 1,
+        totalChunks: 1,
+        encrypted: false,
+        sink: trackingSink(),
+        fetchImpl: async () => {
+          notFoundAttempts++;
+          return new Response(
+            new ReadableStream({
+              cancel() {
+                notFoundBodyCancelled++;
+              },
+            }),
+            { status: 404 },
+          );
+        },
+      }),
+    ).rejects.toThrow("分片 1 下载失败: 404");
+    expect(notFoundAttempts).toBe(1);
+    expect(notFoundBodyCancelled).toBe(1);
   });
 
   it("should enforce legacy fallback response bounds before decryption or commit", async () => {

--- a/platform-frontend/src/lib/utils/boundedDownloader.ts
+++ b/platform-frontend/src/lib/utils/boundedDownloader.ts
@@ -4,7 +4,11 @@ import type {
   FileDownloadPartVO,
 } from "$api/types";
 import { decryptChunk } from "./crypto";
-import { downloadFramedPart, MAX_FRAMES_PER_PART } from "./framedAead";
+import {
+  downloadFramedPart,
+  MAX_FRAMES_PER_PART,
+  validateFramedEncryption,
+} from "./framedAead";
 import { assertSha256, createSha256 } from "./downloadIntegrity";
 import {
   DownloadMetricsTracker,
@@ -369,32 +373,52 @@ async function fetchDownloadUrl(
   signal: AbortSignal | undefined,
   fetchImpl: typeof fetch,
 ): Promise<Response> {
+  /** 释放失败响应体，避免重试时遗留未消费的网络流。 */
+  const cancelErrorResponse = async (response: Response): Promise<void> => {
+    if (!response.body) return;
+    try {
+      await response.body.cancel("download request failed");
+    } catch {
+      // 响应体可能已由浏览器关闭，不能覆盖原始下载错误。
+    }
+  };
+
   let lastError: Error | null = null;
   for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
     if (signal?.aborted) throw new Error("Download cancelled");
+
+    let response: Response;
     try {
-      const response = await fetchImpl(url, { signal });
-      if (response.status === 401 || response.status === 403) {
-        throw new Error("下载地址已过期，请重新发起下载");
-      }
-      if (response.ok) return response;
-      const error = new Error(`分片 ${index + 1} 下载失败: ${response.status}`);
-      if (response.status < 500 || attempt === MAX_FETCH_ATTEMPTS) {
-        throw error;
-      }
-      lastError = error;
+      response = await fetchImpl(url, { signal });
     } catch (error) {
       if (signal?.aborted) {
         throw new Error("Download cancelled", { cause: error });
       }
-      lastError = error as Error;
-      if (
-        lastError.message.includes("下载地址已过期") ||
-        attempt === MAX_FETCH_ATTEMPTS
-      ) {
+      lastError =
+        error instanceof Error ? error : new Error(String(error ?? "网络错误"));
+      if (attempt === MAX_FETCH_ATTEMPTS) {
         throw lastError;
       }
+      await new Promise((resolve) =>
+        setTimeout(resolve, 200 * 2 ** (attempt - 1)),
+      );
+      continue;
     }
+
+    if (response.status === 401 || response.status === 403) {
+      await cancelErrorResponse(response);
+      throw new Error("下载地址已过期，请重新发起下载");
+    }
+    if (response.ok) return response;
+
+    const error = new Error(`分片 ${index + 1} 下载失败: ${response.status}`);
+    // 只有 5xx 才属于可重试的 HTTP 失败；4xx 立即失败，避免无效重试。
+    if (response.status < 500 || attempt === MAX_FETCH_ATTEMPTS) {
+      await cancelErrorResponse(response);
+      throw error;
+    }
+    await cancelErrorResponse(response);
+    lastError = error;
     await new Promise((resolve) =>
       setTimeout(resolve, 200 * 2 ** (attempt - 1)),
     );
@@ -688,16 +712,62 @@ function resolveLegacyPlainRange(
     metadata.fileSize - position,
   );
   const size = part.plainSize ?? inferredSize;
+  const end = position + size;
   if (
     !Number.isSafeInteger(position) ||
     position < 0 ||
     !Number.isSafeInteger(size) ||
     size <= 0 ||
-    position + size > metadata.fileSize
+    !Number.isSafeInteger(end) ||
+    end > metadata.fileSize
   ) {
     throw new Error("历史加密分片明文范围无效");
   }
   return { position, size };
+}
+
+/**
+ * 校验历史 v1 分片的明文范围连续覆盖整个文件，拒绝 gap、overlap 和尺寸漂移。
+ *
+ * v1 需要按固定分片偏移随机写入；FileSystem sink 不会替调用方检查稀疏区间，
+ * 因此必须在发起网络请求前确认每个可选 plainSize 都与上传计划一致。
+ */
+function validateLegacyPlainRanges(
+  metadata: FileDownloadMetadataVO,
+  parts: FileDownloadPartVO[],
+): Array<{ position: number; size: number }> {
+  if (
+    !Number.isSafeInteger(metadata.chunkSize) ||
+    metadata.chunkSize <= 0 ||
+    !Number.isSafeInteger(metadata.fileSize) ||
+    metadata.fileSize <= 0
+  ) {
+    throw new Error("历史加密文件范围合同无效");
+  }
+
+  const ranges: Array<{ position: number; size: number }> = [];
+  let nextPosition = 0;
+  for (const part of parts) {
+    const range = resolveLegacyPlainRange(metadata, part);
+    const expectedSize = Math.min(
+      metadata.chunkSize,
+      metadata.fileSize - range.position,
+    );
+    if (
+      range.position !== nextPosition ||
+      range.size !== expectedSize ||
+      !Number.isSafeInteger(nextPosition + range.size)
+    ) {
+      throw new Error("历史加密分片明文范围不连续或尺寸不一致");
+    }
+    nextPosition += range.size;
+    ranges.push(range);
+  }
+
+  if (nextPosition !== metadata.fileSize) {
+    throw new Error("历史加密分片明文范围未覆盖完整文件");
+  }
+  return ranges;
 }
 
 /** 执行历史 v1 环形密钥链兼容下载。 */
@@ -721,6 +791,8 @@ async function downloadLegacyFile(params: {
       throw new Error("历史加密分片超过兼容读取上限");
     }
   }
+  // 先验证所有随机写入范围，避免下载后才发现稀疏或重叠输出。
+  const plainRanges = validateLegacyPlainRanges(params.metadata, params.parts);
 
   let completed = 0;
   const lastPart = params.parts.at(-1)!;
@@ -738,7 +810,7 @@ async function downloadLegacyFile(params: {
   let firstKey: string;
   try {
     const result = await decryptChunk(lastCipher, params.metadata.initialKey);
-    const range = resolveLegacyPlainRange(params.metadata, lastPart);
+    const range = plainRanges.at(-1)!;
     await writeLegacyPlaintext({
       plaintext: result.plaintext,
       embeddedHash: result.hash,
@@ -770,7 +842,7 @@ async function downloadLegacyFile(params: {
     });
     try {
       const result = await decryptChunk(ciphertext, currentKey);
-      const range = resolveLegacyPlainRange(params.metadata, part);
+      const range = plainRanges[index];
       await writeLegacyPlaintext({
         plaintext: result.plaintext,
         embeddedHash: result.hash,
@@ -995,6 +1067,13 @@ export async function executeBoundedDownload(
   try {
     const parts = validateParts(options.metadata);
     const format = resolveDownloadFormat(options.metadata);
+    // 在签发/请求任何对象 URL 前完成 v2 suite、frame 和 nonce 合同校验。
+    if (format === "FRAMED_V2") {
+      if (!options.metadata.encryption) {
+        throw new Error("framed AEAD 文件缺少加密描述");
+      }
+      validateFramedEncryption(options.metadata.encryption);
+    }
     validateCanonicalManifest(
       options.metadata,
       parts,

--- a/platform-frontend/src/lib/utils/boundedDownloader.ts
+++ b/platform-frontend/src/lib/utils/boundedDownloader.ts
@@ -27,12 +27,24 @@ const LEGACY_ENCRYPTION_ALGORITHMS = new Set([
   "CHACHA20-POLY1305",
 ]);
 const MANIFEST_SECRET_KEYS = new Set([
+  "key",
+  "keys",
+  "secret",
   "initialkey",
   "filedek",
   "dek",
   "datakey",
   "encrypteddatakey",
   "wrappeddatakey",
+  "decryptkey",
+  "decryptionkey",
+  "encryptionkey",
+  "filekey",
+  "filedatakey",
+  "wrappingiv",
+  "kmskeyid",
+  "privatekey",
+  "secretkey",
 ]);
 
 export type DownloadFormat = "NONE" | "LEGACY_V1" | "FRAMED_V2";

--- a/platform-frontend/src/lib/utils/boundedDownloader.ts
+++ b/platform-frontend/src/lib/utils/boundedDownloader.ts
@@ -1,0 +1,1070 @@
+import type {
+  ChunkManifestEncryption,
+  FileDownloadMetadataVO,
+  FileDownloadPartVO,
+} from "$api/types";
+import { decryptChunk } from "./crypto";
+import { downloadFramedPart, MAX_FRAMES_PER_PART } from "./framedAead";
+import { assertSha256, createSha256 } from "./downloadIntegrity";
+import {
+  DownloadMetricsTracker,
+  type DownloadStreamMetrics,
+} from "./downloadMetrics";
+import type { DownloadSink } from "./downloadSink";
+import {
+  assertContentLength,
+  requireResponseReader,
+} from "./downloadStreamReader";
+
+export const LEGACY_MAX_CIPHER_PART_BYTES = 80 * 1024 * 1024 + 4 * 1024;
+export const MAX_PARTS_PER_FILE = 10_000;
+const MAX_NETWORK_CHUNK_BYTES = 1 * 1024 * 1024;
+const MAX_FETCH_ATTEMPTS = 3;
+const LEGACY_ENCRYPTION_ALGORITHMS = new Set([
+  "AES-GCM",
+  "AES-256-GCM",
+  "CHACHA20",
+  "CHACHA20-POLY1305",
+]);
+const MANIFEST_SECRET_KEYS = new Set([
+  "initialkey",
+  "filedek",
+  "dek",
+  "datakey",
+  "encrypteddatakey",
+  "wrappeddatakey",
+]);
+
+export type DownloadFormat = "NONE" | "LEGACY_V1" | "FRAMED_V2";
+
+export interface BoundedDownloadOptions {
+  metadata: FileDownloadMetadataVO;
+  /** 调用任务中已确认的文件 hash，用于阻止跨文件 metadata 替换。 */
+  expectedFileHash?: string;
+  sink: DownloadSink;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+  metrics?: DownloadMetricsTracker;
+  onPartComplete?: (completed: number, total: number) => void;
+}
+
+/** 无 manifest 历史接口使用的有界下载参数。 */
+export interface LegacyFallbackDownloadOptions {
+  urls: string[];
+  fileSize: number;
+  totalChunks: number;
+  initialKey?: string | null;
+  encrypted: boolean;
+  sink: DownloadSink;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+  metrics?: DownloadMetricsTracker;
+  onPartComplete?: (completed: number, total: number) => void;
+}
+
+/** 按 metadata 明确选择 NONE、历史 v1 或 framed v2。 */
+export function resolveDownloadFormat(
+  metadata: FileDownloadMetadataVO,
+): DownloadFormat {
+  const algorithm = metadata.encryptionAlgorithm?.trim().toUpperCase();
+  const version = metadata.encryption?.formatVersion;
+  if (version === 0) {
+    if (algorithm != null && algorithm !== "NONE") {
+      throw new Error("下载加密算法与 formatVersion 冲突");
+    }
+    return "NONE";
+  }
+  if (algorithm === "NONE") {
+    if (version != null) {
+      throw new Error("下载加密算法与 formatVersion 冲突");
+    }
+    return "NONE";
+  }
+  if (version === 2) {
+    if (algorithm !== "FRAMED_AEAD_V2") {
+      throw new Error("下载加密算法与 formatVersion 冲突");
+    }
+    return "FRAMED_V2";
+  }
+  if (version == null || version === 1) {
+    if (algorithm == null || LEGACY_ENCRYPTION_ALGORITHMS.has(algorithm)) {
+      return "LEGACY_V1";
+    }
+    if (algorithm === "FRAMED_AEAD_V2") {
+      throw new Error("下载加密算法与 formatVersion 冲突");
+    }
+    throw new Error(`不支持的下载加密算法: ${algorithm}`);
+  }
+  throw new Error(`不支持的下载格式版本: ${version}`);
+}
+
+/** 校验 parts 有序、连续且数量与 metadata 一致。 */
+function validateParts(metadata: FileDownloadMetadataVO): FileDownloadPartVO[] {
+  if (
+    !Number.isSafeInteger(metadata.fileSize) ||
+    metadata.fileSize < 0 ||
+    !Number.isSafeInteger(metadata.totalChunks) ||
+    metadata.totalChunks <= 0 ||
+    metadata.totalChunks > MAX_PARTS_PER_FILE ||
+    metadata.parts.length !== metadata.totalChunks
+  ) {
+    throw new Error("下载 metadata 的文件或分片数量无效");
+  }
+  // metadata.parts 已是后端承诺的有序视图；排序会把重排攻击静默恢复成“合法”顺序。
+  const parts = [...metadata.parts];
+  for (let index = 0; index < parts.length; index++) {
+    const part = parts[index];
+    if (
+      part.index !== index ||
+      !Number.isSafeInteger(part.size) ||
+      part.size <= 0 ||
+      !part.downloadUrl
+    ) {
+      throw new Error("下载 metadata 的分片顺序或大小无效");
+    }
+    if (
+      part.plainSize != null &&
+      (!Number.isSafeInteger(part.plainSize) || part.plainSize <= 0)
+    ) {
+      throw new Error("下载 metadata 的明文分片大小无效");
+    }
+    if (
+      part.frameCount != null &&
+      (!Number.isSafeInteger(part.frameCount) ||
+        part.frameCount <= 0 ||
+        part.frameCount > MAX_FRAMES_PER_PART)
+    ) {
+      throw new Error("下载 metadata 的 frame 数量无效");
+    }
+    if (
+      part.storageBackend != null &&
+      typeof part.storageBackend !== "string"
+    ) {
+      throw new Error("下载 metadata 的存储后端无效");
+    }
+    if (part.etag != null && typeof part.etag !== "string") {
+      throw new Error("下载 metadata 的 ETag 无效");
+    }
+  }
+  return parts;
+}
+
+type ManifestRecord = Record<string, unknown>;
+
+/** 将未知 JSON 值收窄为普通对象。 */
+function asManifestRecord(value: unknown, label: string): ManifestRecord {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} 不是有效对象`);
+  }
+  return value as ManifestRecord;
+}
+
+/** 校验 canonical manifest 中的必需字符串字段。 */
+function requireManifestString(
+  record: ManifestRecord,
+  key: string,
+  expected: string,
+): void {
+  if (record[key] !== expected) {
+    throw new Error(`下载 manifest 字段 ${key} 与 metadata 不一致`);
+  }
+}
+
+/** 校验 canonical manifest 中的安全整数字段。 */
+function requireManifestInteger(
+  record: ManifestRecord,
+  key: string,
+  expected: number,
+): void {
+  if (!Number.isSafeInteger(record[key]) || record[key] !== expected) {
+    throw new Error(`下载 manifest 字段 ${key} 与 metadata 不一致`);
+  }
+}
+
+/** 校验可选字段在 canonical JSON 中按 NON_NULL 规则出现。 */
+function requireOptionalManifestValue(
+  record: ManifestRecord,
+  key: string,
+  expected: string | number | null | undefined,
+): void {
+  const hasValue = Object.prototype.hasOwnProperty.call(record, key);
+  if (expected == null) {
+    if (hasValue) {
+      throw new Error(`下载 manifest 字段 ${key} 不应存在`);
+    }
+    return;
+  }
+  if (!hasValue || record[key] !== expected) {
+    throw new Error(`下载 manifest 字段 ${key} 与 metadata 不一致`);
+  }
+}
+
+/** 拒绝 canonical manifest 中意外出现的密钥材料字段。 */
+function rejectManifestSecrets(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(rejectManifestSecrets);
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  for (const [key, nested] of Object.entries(value)) {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (MANIFEST_SECRET_KEYS.has(normalizedKey)) {
+      throw new Error("canonical manifest 不得包含密钥材料");
+    }
+    rejectManifestSecrets(nested);
+  }
+}
+
+/** 在提交下载输出前重新检查取消状态，避免取消后仍 close 成功。 */
+function throwIfDownloadCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error("Download cancelled");
+  }
+}
+
+/**
+ * 在请求对象 URL 前校验 canonical manifest 的 hash、文件绑定和分片合同。
+ * canonical JSON 由后端 canonicalizer 生成，前端只接受与 metadata 完全一致的视图。
+ */
+function validateCanonicalManifest(
+  metadata: FileDownloadMetadataVO,
+  parts: FileDownloadPartVO[],
+  format: DownloadFormat,
+  expectedFileHash?: string,
+): void {
+  if (!metadata.canonicalManifestJson?.trim()) {
+    throw new Error("下载 metadata 缺少 canonical manifest JSON");
+  }
+  if (
+    !metadata.fileHash ||
+    (expectedFileHash && metadata.fileHash !== expectedFileHash)
+  ) {
+    throw new Error("下载 metadata 的 fileHash 与任务不一致");
+  }
+  const manifestBytes = new TextEncoder().encode(
+    metadata.canonicalManifestJson,
+  );
+  const manifestDigest = createSha256();
+  manifestDigest.update(manifestBytes);
+  assertSha256(manifestDigest.digest(), metadata.manifestHash, "manifest");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(metadata.canonicalManifestJson);
+  } catch {
+    throw new Error("下载 metadata 的 canonical manifest JSON 无效");
+  }
+  rejectManifestSecrets(parsed);
+  const root = asManifestRecord(parsed, "canonical manifest");
+  requireManifestString(root, "schema", metadata.manifestSchemaId);
+  requireManifestString(root, "fileHash", metadata.fileHash);
+  requireManifestString(root, "hashAlgorithm", metadata.hashAlgorithm);
+  requireManifestInteger(root, "chunkSize", metadata.chunkSize);
+  if (metadata.encryptionAlgorithm == null) {
+    requireOptionalManifestValue(root, "encryptionAlgorithm", null);
+  } else {
+    requireManifestString(
+      root,
+      "encryptionAlgorithm",
+      metadata.encryptionAlgorithm,
+    );
+  }
+  requireManifestString(root, "storageBackend", metadata.storageBackend);
+
+  const expectedTotalSize = parts.reduce((sum, part) => {
+    const value = format === "FRAMED_V2" ? (part.plainSize ?? -1) : part.size;
+    if (
+      !Number.isSafeInteger(value) ||
+      value <= 0 ||
+      !Number.isSafeInteger(sum + value)
+    ) {
+      throw new Error("下载 manifest 分片总量无效");
+    }
+    return sum + value;
+  }, 0);
+  const rootTotalSize = root.totalSize;
+  if (
+    !Number.isSafeInteger(rootTotalSize) ||
+    rootTotalSize !== expectedTotalSize
+  ) {
+    throw new Error("下载 manifest 总大小与 metadata 不一致");
+  }
+  if (format !== "LEGACY_V1" && rootTotalSize !== metadata.fileSize) {
+    throw new Error("下载 manifest 明文总量与文件大小不一致");
+  }
+
+  const manifestChunks = root.chunks;
+  if (
+    !Array.isArray(manifestChunks) ||
+    manifestChunks.length !== parts.length
+  ) {
+    throw new Error("下载 manifest 分片数量与 metadata 不一致");
+  }
+  for (let index = 0; index < parts.length; index++) {
+    const part = parts[index];
+    const chunk = asManifestRecord(
+      manifestChunks[index],
+      `canonical manifest chunk ${index}`,
+    );
+    requireManifestInteger(chunk, "index", index);
+    requireManifestString(chunk, "plainHash", part.plainHash);
+    requireManifestString(chunk, "cipherHash", part.cipherHash);
+    requireManifestInteger(chunk, "size", part.size);
+    requireManifestString(chunk, "storagePath", part.storagePath);
+    requireManifestString(
+      chunk,
+      "storageBackend",
+      part.storageBackend ?? metadata.storageBackend,
+    );
+    requireManifestString(
+      chunk,
+      "checksumAlgorithm",
+      part.checksumAlgorithm ?? "SHA-256",
+    );
+    requireOptionalManifestValue(chunk, "etag", part.etag);
+    requireOptionalManifestValue(chunk, "plainSize", part.plainSize);
+    requireOptionalManifestValue(chunk, "frameCount", part.frameCount);
+  }
+
+  const manifestEncryption = Object.prototype.hasOwnProperty.call(
+    root,
+    "encryption",
+  )
+    ? asManifestRecord(root.encryption, "canonical manifest encryption")
+    : null;
+  if (metadata.encryption == null) {
+    if (manifestEncryption !== null) {
+      throw new Error("下载 manifest encryption 与 metadata 不一致");
+    }
+  } else {
+    if (manifestEncryption === null) {
+      throw new Error("下载 manifest 缺少 encryption 描述");
+    }
+    for (const [key, value] of Object.entries(metadata.encryption)) {
+      requireOptionalManifestValue(
+        manifestEncryption,
+        key,
+        value as string | number | null | undefined,
+      );
+    }
+  }
+}
+
+/** 对预签名 URL 执行有限网络重试，401/403 直接要求刷新 metadata。 */
+async function fetchDownloadUrl(
+  url: string,
+  index: number,
+  signal: AbortSignal | undefined,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    if (signal?.aborted) throw new Error("Download cancelled");
+    try {
+      const response = await fetchImpl(url, { signal });
+      if (response.status === 401 || response.status === 403) {
+        throw new Error("下载地址已过期，请重新发起下载");
+      }
+      if (response.ok) return response;
+      const error = new Error(`分片 ${index + 1} 下载失败: ${response.status}`);
+      if (response.status < 500 || attempt === MAX_FETCH_ATTEMPTS) {
+        throw error;
+      }
+      lastError = error;
+    } catch (error) {
+      if (signal?.aborted) {
+        throw new Error("Download cancelled", { cause: error });
+      }
+      lastError = error as Error;
+      if (
+        lastError.message.includes("下载地址已过期") ||
+        attempt === MAX_FETCH_ATTEMPTS
+      ) {
+        throw lastError;
+      }
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, 200 * 2 ** (attempt - 1)),
+    );
+  }
+  throw lastError ?? new Error("分片下载失败");
+}
+
+/** 对带 manifest 的分片调用有界 URL 获取逻辑。 */
+async function fetchPart(
+  part: FileDownloadPartVO,
+  signal: AbortSignal | undefined,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  return fetchDownloadUrl(part.downloadUrl, part.index, signal, fetchImpl);
+}
+
+/** 读取没有 manifest 尺寸证据的历史密文分片，并强制执行硬上限。 */
+async function readLegacyCipherResponse(params: {
+  response: Response;
+  signal?: AbortSignal;
+  metrics: DownloadMetricsTracker;
+}): Promise<Uint8Array> {
+  const rawLength = params.response.headers.get("content-length");
+  const declaredLength = rawLength == null ? null : Number(rawLength);
+  if (
+    declaredLength != null &&
+    (!Number.isSafeInteger(declaredLength) ||
+      declaredLength < 0 ||
+      declaredLength > LEGACY_MAX_CIPHER_PART_BYTES)
+  ) {
+    throw new Error("历史加密分片超过兼容读取上限");
+  }
+
+  const reader = requireResponseReader(params.response);
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  let result: Uint8Array | null = null;
+  try {
+    while (true) {
+      if (params.signal?.aborted) throw new Error("Download cancelled");
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      if (value.byteLength > MAX_NETWORK_CHUNK_BYTES) {
+        throw new Error("网络读取块超过有界下载上限");
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > LEGACY_MAX_CIPHER_PART_BYTES) {
+        throw new Error("历史加密分片超过兼容读取上限");
+      }
+      if (declaredLength != null && totalBytes > declaredLength) {
+        throw new Error("历史加密分片超过响应声明大小");
+      }
+      params.metrics.acquire(value.byteLength);
+      chunks.push(value);
+    }
+    if (declaredLength != null && totalBytes !== declaredLength) {
+      throw new Error("历史加密分片长度与响应声明不一致");
+    }
+    result = new Uint8Array(totalBytes);
+    params.metrics.acquire(result.byteLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.byteLength;
+      params.metrics.release(chunk.byteLength);
+    }
+    chunks.length = 0;
+    return result;
+  } catch (error) {
+    if (result) {
+      params.metrics.release(result.byteLength);
+    }
+    for (const chunk of chunks) {
+      params.metrics.release(chunk.byteLength);
+    }
+    chunks.length = 0;
+    try {
+      await reader.cancel(error);
+    } catch {
+      // reader 已结束时忽略取消错误。
+    }
+    throw error;
+  }
+}
+
+/** 将无 manifest 的历史明文响应按总文件大小增量写入 sink。 */
+async function streamLegacyPlainResponse(params: {
+  response: Response;
+  remainingBytes: number;
+  sink: DownloadSink;
+  metrics: DownloadMetricsTracker;
+  signal?: AbortSignal;
+}): Promise<number> {
+  const rawLength = params.response.headers.get("content-length");
+  const declaredLength = rawLength == null ? null : Number(rawLength);
+  if (
+    declaredLength != null &&
+    (!Number.isSafeInteger(declaredLength) ||
+      declaredLength < 0 ||
+      declaredLength > params.remainingBytes)
+  ) {
+    throw new Error("历史明文分片超过文件声明大小");
+  }
+  const reader = requireResponseReader(params.response);
+  let totalBytes = 0;
+  try {
+    while (true) {
+      if (params.signal?.aborted) throw new Error("Download cancelled");
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      if (value.byteLength > MAX_NETWORK_CHUNK_BYTES) {
+        throw new Error("网络读取块超过有界下载上限");
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > params.remainingBytes) {
+        throw new Error("历史明文分片超过文件声明大小");
+      }
+      params.metrics.acquire(value.byteLength);
+      try {
+        await params.sink.write(value);
+        params.metrics.wrote(value.byteLength);
+      } finally {
+        params.metrics.release(value.byteLength);
+      }
+    }
+    if (declaredLength != null && totalBytes !== declaredLength) {
+      throw new Error("历史明文分片长度与响应声明不一致");
+    }
+    return totalBytes;
+  } catch (error) {
+    try {
+      await reader.cancel(error);
+    } catch {
+      // reader 已结束时忽略取消错误。
+    }
+    throw error;
+  }
+}
+
+/** 增量下载 NONE part，边读边校验长度/摘要并背压写入 sink。 */
+async function downloadPlainPart(params: {
+  response: Response;
+  part: FileDownloadPartVO;
+  sink: DownloadSink;
+  metrics: DownloadMetricsTracker;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (
+    params.part.plainSize != null &&
+    params.part.plainSize !== params.part.size
+  ) {
+    throw new Error("未加密分片明文尺寸与对象尺寸不一致");
+  }
+  assertContentLength(params.response, params.part.size);
+  const reader = requireResponseReader(params.response);
+  const hash = createSha256();
+  let totalBytes = 0;
+  try {
+    while (true) {
+      if (params.signal?.aborted) throw new Error("Download cancelled");
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      if (value.byteLength > MAX_NETWORK_CHUNK_BYTES) {
+        throw new Error("网络读取块超过有界下载上限");
+      }
+      params.metrics.acquire(value.byteLength);
+      try {
+        totalBytes += value.byteLength;
+        if (totalBytes > params.part.size) {
+          throw new Error("未加密分片超过 manifest 声明大小");
+        }
+        hash.update(value);
+        await params.sink.write(value);
+        params.metrics.wrote(value.byteLength);
+      } finally {
+        params.metrics.release(value.byteLength);
+      }
+    }
+  } catch (error) {
+    try {
+      await reader.cancel(error);
+    } catch {
+      // reader 已关闭时忽略取消错误。
+    }
+    throw error;
+  }
+  if (totalBytes !== params.part.size) {
+    throw new Error("未加密分片长度与 manifest 不一致");
+  }
+  const digest = hash.digest();
+  assertSha256(digest, params.part.cipherHash, "密文分片");
+  assertSha256(digest, params.part.plainHash, "明文分片");
+  params.metrics.completedPart();
+}
+
+/** 在明确硬上限内读取一个历史 v1 密文 part。 */
+async function downloadLegacyCipherPart(params: {
+  response: Response;
+  part: FileDownloadPartVO;
+  metrics: DownloadMetricsTracker;
+  signal?: AbortSignal;
+}): Promise<Uint8Array> {
+  if (params.part.size > LEGACY_MAX_CIPHER_PART_BYTES) {
+    throw new Error("历史加密分片超过兼容读取上限");
+  }
+  assertContentLength(params.response, params.part.size);
+  const reader = requireResponseReader(params.response);
+  const data = new Uint8Array(params.part.size);
+  params.metrics.acquire(data.byteLength);
+  const hash = createSha256();
+  let offset = 0;
+  try {
+    while (true) {
+      if (params.signal?.aborted) throw new Error("Download cancelled");
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      if (value.byteLength > MAX_NETWORK_CHUNK_BYTES) {
+        throw new Error("网络读取块超过有界下载上限");
+      }
+      params.metrics.acquire(value.byteLength);
+      try {
+        const end = offset + value.byteLength;
+        if (end > data.byteLength) {
+          throw new Error("历史加密分片超过 manifest 声明大小");
+        }
+        data.set(value, offset);
+        hash.update(value);
+        offset = end;
+      } finally {
+        params.metrics.release(value.byteLength);
+      }
+    }
+    if (offset !== data.byteLength) {
+      throw new Error("历史加密分片长度与 manifest 不一致");
+    }
+    assertSha256(hash.digest(), params.part.cipherHash, "历史密文分片");
+    return data;
+  } catch (error) {
+    params.metrics.release(data.byteLength);
+    try {
+      await reader.cancel(error);
+    } catch {
+      // reader 已关闭时忽略取消错误。
+    }
+    throw error;
+  }
+}
+
+/** 校验 v1 明文摘要并写入原始文件偏移。 */
+async function writeLegacyPlaintext(params: {
+  plaintext: Uint8Array;
+  embeddedHash: string | null;
+  part: FileDownloadPartVO;
+  position: number;
+  expectedPlainSize: number;
+  sink: DownloadSink;
+  metrics: DownloadMetricsTracker;
+}): Promise<void> {
+  params.metrics.acquire(params.plaintext.byteLength);
+  try {
+    if (params.plaintext.byteLength !== params.expectedPlainSize) {
+      throw new Error("历史加密分片明文长度不一致");
+    }
+    const hash = createSha256();
+    hash.update(params.plaintext);
+    const digest = hash.digest();
+    assertSha256(digest, params.part.plainHash, "历史明文分片");
+    if (params.embeddedHash) {
+      assertSha256(digest, params.embeddedHash, "历史内嵌明文分片");
+    }
+    await params.sink.writeAt(params.position, params.plaintext);
+    params.metrics.wrote(params.plaintext.byteLength);
+    params.metrics.completedPart();
+  } finally {
+    params.metrics.release(params.plaintext.byteLength);
+  }
+}
+
+/** 计算历史 v1 part 的明文偏移和声明长度。 */
+function resolveLegacyPlainRange(
+  metadata: FileDownloadMetadataVO,
+  part: FileDownloadPartVO,
+): { position: number; size: number } {
+  const position = part.index * metadata.chunkSize;
+  const inferredSize = Math.min(
+    metadata.chunkSize,
+    metadata.fileSize - position,
+  );
+  const size = part.plainSize ?? inferredSize;
+  if (
+    !Number.isSafeInteger(position) ||
+    position < 0 ||
+    !Number.isSafeInteger(size) ||
+    size <= 0 ||
+    position + size > metadata.fileSize
+  ) {
+    throw new Error("历史加密分片明文范围无效");
+  }
+  return { position, size };
+}
+
+/** 执行历史 v1 环形密钥链兼容下载。 */
+async function downloadLegacyFile(params: {
+  metadata: FileDownloadMetadataVO;
+  parts: FileDownloadPartVO[];
+  sink: DownloadSink;
+  metrics: DownloadMetricsTracker;
+  signal?: AbortSignal;
+  fetchImpl: typeof fetch;
+  onPartComplete?: (completed: number, total: number) => void;
+}): Promise<void> {
+  if (!params.sink.supportsRandomAccess && params.metadata.fileSize > 0) {
+    throw new Error("历史加密下载需要支持随机写入的临时文件");
+  }
+  if (!params.metadata.initialKey) {
+    throw new Error("历史加密文件缺少 initialKey");
+  }
+  for (const part of params.parts) {
+    if (part.size > LEGACY_MAX_CIPHER_PART_BYTES) {
+      throw new Error("历史加密分片超过兼容读取上限");
+    }
+  }
+
+  let completed = 0;
+  const lastPart = params.parts.at(-1)!;
+  const lastResponse = await fetchPart(
+    lastPart,
+    params.signal,
+    params.fetchImpl,
+  );
+  const lastCipher = await downloadLegacyCipherPart({
+    response: lastResponse,
+    part: lastPart,
+    metrics: params.metrics,
+    signal: params.signal,
+  });
+  let firstKey: string;
+  try {
+    const result = await decryptChunk(lastCipher, params.metadata.initialKey);
+    const range = resolveLegacyPlainRange(params.metadata, lastPart);
+    await writeLegacyPlaintext({
+      plaintext: result.plaintext,
+      embeddedHash: result.hash,
+      part: lastPart,
+      position: range.position,
+      expectedPlainSize: range.size,
+      sink: params.sink,
+      metrics: params.metrics,
+    });
+    if (params.parts.length > 1 && !result.nextKey) {
+      throw new Error("历史最后分片缺少首分片密钥");
+    }
+    firstKey = result.nextKey ?? params.metadata.initialKey;
+  } finally {
+    params.metrics.release(lastCipher.byteLength);
+  }
+  completed++;
+  params.onPartComplete?.(completed, params.parts.length);
+
+  let currentKey = firstKey;
+  for (let index = 0; index < params.parts.length - 1; index++) {
+    const part = params.parts[index];
+    const response = await fetchPart(part, params.signal, params.fetchImpl);
+    const ciphertext = await downloadLegacyCipherPart({
+      response,
+      part,
+      metrics: params.metrics,
+      signal: params.signal,
+    });
+    try {
+      const result = await decryptChunk(ciphertext, currentKey);
+      const range = resolveLegacyPlainRange(params.metadata, part);
+      await writeLegacyPlaintext({
+        plaintext: result.plaintext,
+        embeddedHash: result.hash,
+        part,
+        position: range.position,
+        expectedPlainSize: range.size,
+        sink: params.sink,
+        metrics: params.metrics,
+      });
+      if (index < params.parts.length - 2 && !result.nextKey) {
+        throw new Error(`历史分片 ${index} 缺少下一分片密钥`);
+      }
+      currentKey = result.nextKey ?? currentKey;
+    } finally {
+      params.metrics.release(ciphertext.byteLength);
+    }
+    completed++;
+    params.onPartComplete?.(completed, params.parts.length);
+  }
+}
+
+/** 校验历史分片内嵌摘要并按固定明文偏移写入 sink。 */
+async function writeLegacyPlaintextWithoutManifest(params: {
+  plaintext: Uint8Array;
+  embeddedHash: string | null;
+  position: number;
+  sink: DownloadSink;
+  metrics: DownloadMetricsTracker;
+}): Promise<void> {
+  if (!Number.isSafeInteger(params.position) || params.position < 0) {
+    throw new Error("历史加密分片写入偏移无效");
+  }
+  params.metrics.acquire(params.plaintext.byteLength);
+  try {
+    if (params.embeddedHash) {
+      const digest = createSha256();
+      digest.update(params.plaintext);
+      assertSha256(digest.digest(), params.embeddedHash, "历史内嵌明文分片");
+    }
+    await params.sink.writeAt(params.position, params.plaintext);
+    params.metrics.wrote(params.plaintext.byteLength);
+  } finally {
+    params.metrics.release(params.plaintext.byteLength);
+  }
+}
+
+/** 无 manifest 时按 URL 顺序或 v1 环形密钥链执行有界下载。 */
+export async function executeLegacyFallbackDownload(
+  options: LegacyFallbackDownloadOptions,
+): Promise<DownloadStreamMetrics> {
+  const metrics = options.metrics ?? new DownloadMetricsTracker();
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  try {
+    if (
+      !Number.isSafeInteger(options.fileSize) ||
+      options.fileSize < 0 ||
+      !Number.isSafeInteger(options.totalChunks) ||
+      options.totalChunks < 0 ||
+      options.totalChunks > 10_000 ||
+      options.urls.length !== options.totalChunks
+    ) {
+      throw new Error("历史下载参数中的文件大小或分片数量无效");
+    }
+    if (options.totalChunks === 0 && options.fileSize !== 0) {
+      throw new Error("历史下载缺少分片 URL");
+    }
+    if (options.totalChunks === 0) {
+      throwIfDownloadCancelled(options.signal);
+      await options.sink.close();
+      return metrics.snapshot();
+    }
+    if (!options.encrypted) {
+      let written = 0;
+      for (let index = 0; index < options.urls.length; index++) {
+        const response = await fetchDownloadUrl(
+          options.urls[index],
+          index,
+          options.signal,
+          fetchImpl,
+        );
+        const partBytes = await streamLegacyPlainResponse({
+          response,
+          remainingBytes: options.fileSize - written,
+          sink: options.sink,
+          metrics,
+          signal: options.signal,
+        });
+        if (partBytes === 0 && options.fileSize > 0) {
+          throw new Error("历史明文分片为空");
+        }
+        written += partBytes;
+        metrics.completedPart();
+        options.onPartComplete?.(index + 1, options.totalChunks);
+      }
+      if (written !== options.fileSize) {
+        throw new Error(
+          `历史明文总长度不一致: 期望 ${options.fileSize}，实际 ${written}`,
+        );
+      }
+    } else {
+      if (!options.initialKey) {
+        throw new Error("历史加密文件缺少 initialKey");
+      }
+      if (!options.sink.supportsRandomAccess && options.fileSize > 0) {
+        throw new Error("历史加密下载需要支持随机写入的临时文件");
+      }
+
+      const lastIndex = options.totalChunks - 1;
+      const lastResponse = await fetchDownloadUrl(
+        options.urls[lastIndex],
+        lastIndex,
+        options.signal,
+        fetchImpl,
+      );
+      const lastCipher = await readLegacyCipherResponse({
+        response: lastResponse,
+        signal: options.signal,
+        metrics,
+      });
+      let lastPlainLength = 0;
+      let currentKey = options.initialKey;
+      try {
+        const result = await decryptChunk(lastCipher, options.initialKey);
+        lastPlainLength = result.plaintext.byteLength;
+        const lastPosition = options.fileSize - lastPlainLength;
+        if (lastPosition < 0) {
+          throw new Error("历史最后分片明文超过文件声明大小");
+        }
+        await writeLegacyPlaintextWithoutManifest({
+          plaintext: result.plaintext,
+          embeddedHash: result.hash,
+          position: lastPosition,
+          sink: options.sink,
+          metrics,
+        });
+        if (options.totalChunks > 1 && !result.nextKey) {
+          throw new Error("历史最后分片缺少首分片密钥");
+        }
+        currentKey = result.nextKey ?? currentKey;
+      } finally {
+        metrics.release(lastCipher.byteLength);
+      }
+      metrics.completedPart();
+      options.onPartComplete?.(1, options.totalChunks);
+
+      let position = 0;
+      for (let index = 0; index < lastIndex; index++) {
+        const response = await fetchDownloadUrl(
+          options.urls[index],
+          index,
+          options.signal,
+          fetchImpl,
+        );
+        const ciphertext = await readLegacyCipherResponse({
+          response,
+          signal: options.signal,
+          metrics,
+        });
+        try {
+          const result = await decryptChunk(ciphertext, currentKey);
+          const nextPosition = position + result.plaintext.byteLength;
+          if (nextPosition > options.fileSize - lastPlainLength) {
+            throw new Error("历史加密分片明文超过文件声明范围");
+          }
+          await writeLegacyPlaintextWithoutManifest({
+            plaintext: result.plaintext,
+            embeddedHash: result.hash,
+            position,
+            sink: options.sink,
+            metrics,
+          });
+          position = nextPosition;
+          if (index < lastIndex - 1 && !result.nextKey) {
+            throw new Error(`历史分片 ${index} 缺少下一分片密钥`);
+          }
+          currentKey = result.nextKey ?? currentKey;
+        } finally {
+          metrics.release(ciphertext.byteLength);
+        }
+        metrics.completedPart();
+        options.onPartComplete?.(index + 2, options.totalChunks);
+      }
+      if (position + lastPlainLength !== options.fileSize) {
+        throw new Error(
+          `历史加密明文总长度不一致: 期望 ${options.fileSize}，实际 ${position + lastPlainLength}`,
+        );
+      }
+    }
+
+    const snapshot = metrics.snapshot();
+    if (snapshot.currentBufferedBytes !== 0) {
+      throw new Error(
+        `历史下载缓冲区未释放: ${snapshot.currentBufferedBytes} bytes`,
+      );
+    }
+    if (snapshot.bytesWritten !== options.fileSize) {
+      throw new Error(
+        `历史下载写入长度不一致: 期望 ${options.fileSize}，实际 ${snapshot.bytesWritten}`,
+      );
+    }
+    throwIfDownloadCancelled(options.signal);
+    await options.sink.close();
+    return metrics.snapshot();
+  } catch (error) {
+    try {
+      await options.sink.abort(error);
+    } catch {
+      // abort 失败不覆盖原始下载错误。
+    }
+    throw error;
+  }
+}
+
+/** 执行有界下载；只有全部 part 校验完成后才 close sink。 */
+export async function executeBoundedDownload(
+  options: BoundedDownloadOptions,
+): Promise<DownloadStreamMetrics> {
+  const metrics = options.metrics ?? new DownloadMetricsTracker();
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  try {
+    const parts = validateParts(options.metadata);
+    const format = resolveDownloadFormat(options.metadata);
+    validateCanonicalManifest(
+      options.metadata,
+      parts,
+      format,
+      options.expectedFileHash,
+    );
+    if (format === "NONE") {
+      const totalCipherSize = parts.reduce((sum, part) => sum + part.size, 0);
+      if (totalCipherSize !== options.metadata.fileSize) {
+        throw new Error("未加密分片总长度与文件大小不一致");
+      }
+      for (let index = 0; index < parts.length; index++) {
+        const part = parts[index];
+        const response = await fetchPart(part, options.signal, fetchImpl);
+        await downloadPlainPart({
+          response,
+          part,
+          sink: options.sink,
+          metrics,
+          signal: options.signal,
+        });
+        options.onPartComplete?.(index + 1, parts.length);
+      }
+    } else if (format === "FRAMED_V2") {
+      const encryption = options.metadata.encryption as ChunkManifestEncryption;
+      if (!options.metadata.initialKey) {
+        throw new Error("framed AEAD 文件缺少 file DEK");
+      }
+      const totalPlainSize = parts.reduce(
+        (sum, part) => sum + (part.plainSize ?? -1),
+        0,
+      );
+      if (totalPlainSize !== options.metadata.fileSize) {
+        throw new Error("framed AEAD 明文总长度与文件大小不一致");
+      }
+      for (let index = 0; index < parts.length; index++) {
+        const part = parts[index];
+        const response = await fetchPart(part, options.signal, fetchImpl);
+        await downloadFramedPart({
+          response,
+          part,
+          partCount: parts.length,
+          encryption,
+          fileDekBase64: options.metadata.initialKey,
+          sink: options.sink,
+          metrics,
+          signal: options.signal,
+        });
+        options.onPartComplete?.(index + 1, parts.length);
+      }
+    } else {
+      await downloadLegacyFile({
+        metadata: options.metadata,
+        parts,
+        sink: options.sink,
+        metrics,
+        signal: options.signal,
+        fetchImpl,
+        onPartComplete: options.onPartComplete,
+      });
+    }
+
+    const snapshot = metrics.snapshot();
+    if (snapshot.currentBufferedBytes !== 0) {
+      throw new Error(
+        `下载缓冲区未释放: ${snapshot.currentBufferedBytes} bytes`,
+      );
+    }
+    if (snapshot.bytesWritten !== options.metadata.fileSize) {
+      throw new Error(
+        `下载明文总长度不一致: 期望 ${options.metadata.fileSize}，实际 ${snapshot.bytesWritten}`,
+      );
+    }
+    throwIfDownloadCancelled(options.signal);
+    await options.sink.close();
+    return metrics.snapshot();
+  } catch (error) {
+    try {
+      await options.sink.abort(error);
+    } catch {
+      // abort 失败不覆盖原始下载错误。
+    }
+    throw error;
+  }
+}

--- a/platform-frontend/src/lib/utils/crypto.ts
+++ b/platform-frontend/src/lib/utils/crypto.ts
@@ -123,16 +123,19 @@ async function decryptAesGcm(
 ): Promise<Uint8Array> {
   const key = await crypto.subtle.importKey(
     "raw",
-    new Uint8Array(keyBytes).buffer as ArrayBuffer,
+    new Uint8Array(keyBytes) as unknown as BufferSource,
     { name: "AES-GCM" },
     false,
     ["decrypt"],
   );
 
   const decrypted = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv: new Uint8Array(iv).buffer as ArrayBuffer },
+    {
+      name: "AES-GCM",
+      iv: new Uint8Array(iv) as unknown as BufferSource,
+    },
     key,
-    new Uint8Array(ciphertext).buffer as ArrayBuffer,
+    new Uint8Array(ciphertext) as unknown as BufferSource,
   );
 
   return new Uint8Array(decrypted);

--- a/platform-frontend/src/lib/utils/downloadIntegrity.test.ts
+++ b/platform-frontend/src/lib/utils/downloadIntegrity.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import {
+  assertSha256,
+  bytesToHex,
+  createSha256,
+  decodeBase64,
+  equalBytes,
+  parseExpectedSha256,
+} from "./downloadIntegrity";
+
+describe("download integrity helpers", () => {
+  it("should hash incrementally and accept canonical sha256 forms", () => {
+    const digest = sha256(new TextEncoder().encode("abc"));
+    const incremental = createSha256();
+    incremental.update(new Uint8Array([97, 98]));
+    incremental.update(new Uint8Array([99]));
+    expect(bytesToHex(incremental.digest())).toBe(bytesToHex(digest));
+    expect(parseExpectedSha256(`sha256:${bytesToHex(digest)}`)).toEqual(digest);
+    expect(parseExpectedSha256(btoa(String.fromCharCode(...digest)))).toEqual(
+      digest,
+    );
+    assertSha256(digest, `sha256:${bytesToHex(digest)}`, "测试");
+  });
+
+  it("should decode base64url and reject mismatched digests", () => {
+    expect(Array.from(decodeBase64("AQI-_w"))).toEqual([1, 2, 62, 255]);
+    expect(equalBytes(new Uint8Array([1]), new Uint8Array([1]))).toBe(true);
+    expect(equalBytes(new Uint8Array([1]), new Uint8Array([2]))).toBe(false);
+    expect(() => assertSha256(new Uint8Array(32), "sha256:00", "测试")).toThrow(
+      "Base64 数据格式无效",
+    );
+  });
+});

--- a/platform-frontend/src/lib/utils/downloadIntegrity.test.ts
+++ b/platform-frontend/src/lib/utils/downloadIntegrity.test.ts
@@ -28,8 +28,35 @@ describe("download integrity helpers", () => {
     expect(Array.from(decodeBase64("AQI-_w"))).toEqual([1, 2, 62, 255]);
     expect(equalBytes(new Uint8Array([1]), new Uint8Array([1]))).toBe(true);
     expect(equalBytes(new Uint8Array([1]), new Uint8Array([2]))).toBe(false);
+    expect(equalBytes(new Uint8Array([1]), new Uint8Array([1, 2]))).toBe(false);
     expect(() => assertSha256(new Uint8Array(32), "sha256:00", "测试")).toThrow(
       "Base64 数据格式无效",
+    );
+    expect(() =>
+      assertSha256(new Uint8Array(32), `sha256:${"01".repeat(32)}`, "测试"),
+    ).toThrow("测试 SHA-256 校验失败");
+  });
+
+  it("should reject non-canonical base64 and invalid digest lengths", () => {
+    const invalidBase64 = [
+      " AQI=",
+      "AQI===",
+      "A",
+      "AQI==",
+      "AQI-_w==",
+      "AQI+/w",
+      "!!!!",
+    ];
+
+    for (const value of invalidBase64) {
+      expect(() => decodeBase64(value)).toThrow("Base64 数据格式无效");
+    }
+
+    expect(() => parseExpectedSha256("AQI=")).toThrow(
+      "manifest SHA-256 摘要长度无效",
+    );
+    expect(parseExpectedSha256("AA".repeat(32))).toEqual(
+      new Uint8Array(32).fill(0xaa),
     );
   });
 });

--- a/platform-frontend/src/lib/utils/downloadIntegrity.ts
+++ b/platform-frontend/src/lib/utils/downloadIntegrity.ts
@@ -1,0 +1,93 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+
+/** 将摘要字节编码为小写十六进制。 */
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+/** 解码标准或 URL-safe Base64，拒绝非规范输入。 */
+export function decodeBase64(value: string): Uint8Array {
+  if (value !== value.trim()) {
+    throw new Error("Base64 数据格式无效");
+  }
+  const paddingIndex = value.indexOf("=");
+  const unpadded = paddingIndex === -1 ? value : value.slice(0, paddingIndex);
+  const padding = paddingIndex === -1 ? "" : value.slice(paddingIndex);
+  if (
+    !/^[A-Za-z0-9+/_-]*$/.test(unpadded) ||
+    !/^={0,2}$/.test(padding) ||
+    unpadded.length % 4 === 1 ||
+    (padding.length > 0 && (unpadded.length + padding.length) % 4 !== 0) ||
+    (padding.length > 0 && value.includes("-")) ||
+    (padding.length > 0 && value.includes("_"))
+  ) {
+    throw new Error("Base64 数据格式无效");
+  }
+  const normalized = unpadded.replace(/-/g, "+").replace(/_/g, "/");
+  const requiredPadding = (4 - (normalized.length % 4)) % 4;
+  if (padding.length !== 0 && padding.length !== requiredPadding) {
+    throw new Error("Base64 数据格式无效");
+  }
+  const padded = normalized + "=".repeat(requiredPadding);
+  try {
+    const decoded = Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+    const binary = String.fromCharCode(...decoded);
+    const canonicalStandard = btoa(binary);
+    const canonicalUrl = canonicalStandard
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+    if (value !== canonicalStandard && value !== canonicalUrl) {
+      throw new Error("non-canonical Base64");
+    }
+    return decoded;
+  } catch {
+    throw new Error("Base64 数据格式无效");
+  }
+}
+
+/** 解析 manifest 中允许的 SHA-256 十六进制或 Base64 表示。 */
+export function parseExpectedSha256(value: string): Uint8Array {
+  const trimmed = value.trim();
+  const hex = trimmed.startsWith("sha256:")
+    ? trimmed.slice("sha256:".length)
+    : trimmed;
+  if (/^[0-9a-fA-F]{64}$/.test(hex)) {
+    return Uint8Array.from(hex.match(/.{2}/g) ?? [], (pair) =>
+      Number.parseInt(pair, 16),
+    );
+  }
+  const decoded = decodeBase64(trimmed);
+  if (decoded.byteLength !== 32) {
+    throw new Error("manifest SHA-256 摘要长度无效");
+  }
+  return decoded;
+}
+
+/** 使用固定循环比较摘要，避免依赖字符串编码差异。 */
+export function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index++) {
+    difference |= left[index] ^ right[index];
+  }
+  return difference === 0;
+}
+
+/** 校验实际 SHA-256 是否匹配 manifest 声明。 */
+export function assertSha256(
+  actual: Uint8Array,
+  expected: string,
+  label: string,
+): void {
+  if (!equalBytes(actual, parseExpectedSha256(expected))) {
+    throw new Error(`${label} SHA-256 校验失败`);
+  }
+}
+
+/** 创建支持增量 update/digest 的 SHA-256 实例。 */
+export function createSha256() {
+  return sha256.create();
+}

--- a/platform-frontend/src/lib/utils/downloadMetrics.test.ts
+++ b/platform-frontend/src/lib/utils/downloadMetrics.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { DownloadMetricsTracker } from "./downloadMetrics";
+
+describe("download metrics tracker", () => {
+  it("should track peak buffers, authenticated frames, parts, and writes", () => {
+    const tracker = new DownloadMetricsTracker();
+
+    tracker.acquire(4);
+    tracker.acquire(3);
+    tracker.release(5);
+    tracker.authenticatedFrame();
+    tracker.completedPart();
+    tracker.wrote(6);
+
+    const snapshot = tracker.snapshot();
+    expect(snapshot).toEqual({
+      currentBufferedBytes: 2,
+      peakBufferedBytes: 7,
+      framesAuthenticated: 1,
+      partsCompleted: 1,
+      bytesWritten: 6,
+    });
+    snapshot.currentBufferedBytes = 99;
+    expect(tracker.snapshot().currentBufferedBytes).toBe(2);
+  });
+
+  it.each([[-1], [1.5], [Number.MAX_SAFE_INTEGER + 1]])(
+    "should reject invalid buffer byte counts: %s",
+    (bytes) => {
+      expect(() => new DownloadMetricsTracker().acquire(bytes)).toThrow(
+        "无效的下载缓冲区大小",
+      );
+      expect(() => new DownloadMetricsTracker().release(bytes)).toThrow(
+        "无效的下载缓冲区大小",
+      );
+    },
+  );
+
+  it("should reject release imbalance and invalid write byte counts", () => {
+    expect(() => new DownloadMetricsTracker().release(1)).toThrow(
+      "下载缓冲区计数失衡",
+    );
+    expect(() => new DownloadMetricsTracker().wrote(-1)).toThrow(
+      "无效的下载写入大小",
+    );
+    expect(() => new DownloadMetricsTracker().wrote(0.5)).toThrow(
+      "无效的下载写入大小",
+    );
+  });
+});

--- a/platform-frontend/src/lib/utils/downloadMetrics.ts
+++ b/platform-frontend/src/lib/utils/downloadMetrics.ts
@@ -1,0 +1,65 @@
+/** 有界下载期间暴露给测试与诊断的应用层指标。 */
+export interface DownloadStreamMetrics {
+  currentBufferedBytes: number;
+  peakBufferedBytes: number;
+  framesAuthenticated: number;
+  partsCompleted: number;
+  bytesWritten: number;
+}
+
+/** 统一记录 parser、解密器与 sink 之间的短生命周期缓冲。 */
+export class DownloadMetricsTracker {
+  private readonly metrics: DownloadStreamMetrics = {
+    currentBufferedBytes: 0,
+    peakBufferedBytes: 0,
+    framesAuthenticated: 0,
+    partsCompleted: 0,
+    bytesWritten: 0,
+  };
+
+  /** 记录新持有的缓冲区字节数。 */
+  acquire(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new Error("无效的下载缓冲区大小");
+    }
+    this.metrics.currentBufferedBytes += bytes;
+    this.metrics.peakBufferedBytes = Math.max(
+      this.metrics.peakBufferedBytes,
+      this.metrics.currentBufferedBytes,
+    );
+  }
+
+  /** 释放已经消费的缓冲区字节数。 */
+  release(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new Error("无效的下载缓冲区大小");
+    }
+    this.metrics.currentBufferedBytes -= bytes;
+    if (this.metrics.currentBufferedBytes < 0) {
+      throw new Error("下载缓冲区计数失衡");
+    }
+  }
+
+  /** 记录一个通过 AEAD tag 验证的 frame。 */
+  authenticatedFrame(): void {
+    this.metrics.framesAuthenticated++;
+  }
+
+  /** 记录一个完成长度与哈希校验的 part。 */
+  completedPart(): void {
+    this.metrics.partsCompleted++;
+  }
+
+  /** 记录已经写入临时 sink 的明文字节。 */
+  wrote(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) {
+      throw new Error("无效的下载写入大小");
+    }
+    this.metrics.bytesWritten += bytes;
+  }
+
+  /** 返回不可变指标快照。 */
+  snapshot(): DownloadStreamMetrics {
+    return { ...this.metrics };
+  }
+}

--- a/platform-frontend/src/lib/utils/downloadSink.test.ts
+++ b/platform-frontend/src/lib/utils/downloadSink.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createFileSystemDownloadSink,
+  FileSystemDownloadSink,
+  MemoryDownloadSink,
+} from "./downloadSink";
+
+describe("download sinks", () => {
+  it("should commit an empty file without synthetic writes", async () => {
+    const sink = new MemoryDownloadSink(0, 64);
+    await sink.close();
+    expect(sink.getData()).toHaveLength(0);
+  });
+
+  it("should keep random writes bounded and reject holes on close", async () => {
+    const sink = new MemoryDownloadSink(4, 64);
+    await sink.writeAt(2, new Uint8Array([3, 4]));
+    await expect(sink.close()).rejects.toThrow("下载长度不完整");
+    await sink.writeAt(0, new Uint8Array([1, 2]));
+    await sink.close();
+    expect(Array.from(sink.getData())).toEqual([1, 2, 3, 4]);
+  });
+
+  it("should enforce the fallback size cap and abort output", async () => {
+    expect(() => new MemoryDownloadSink(65, 64)).toThrow("64 MiB");
+    const sink = new MemoryDownloadSink(2, 64);
+    await sink.write(new Uint8Array([1, 2]));
+    await sink.abort();
+    expect(() => sink.getData()).toThrow("尚未成功提交");
+  });
+
+  it("should wrap a transactional file writable", async () => {
+    const writable = {
+      write: vi.fn(async () => {}),
+      seek: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+      abort: vi.fn(async () => {}),
+    };
+    const sink = await createFileSystemDownloadSink({
+      createWritable: vi.fn(async () => writable),
+    });
+    expect(sink).toBeInstanceOf(FileSystemDownloadSink);
+    await sink.write(new Uint8Array([1, 2]));
+    await sink.writeAt(4, new Uint8Array([3]));
+    await sink.close();
+    await sink.abort("ignored after close");
+    expect(writable.write).toHaveBeenCalledTimes(2);
+    expect(writable.seek).toHaveBeenCalledWith(4);
+    expect(writable.close).toHaveBeenCalledTimes(1);
+    expect(writable.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reject a handle without transactional abort", async () => {
+    await expect(
+      createFileSystemDownloadSink({
+        createWritable: vi.fn(async () => ({
+          write: vi.fn(),
+          seek: vi.fn(),
+          close: vi.fn(),
+        })),
+      }),
+    ).rejects.toThrow("事务性文件写入");
+  });
+});

--- a/platform-frontend/src/lib/utils/downloadSink.ts
+++ b/platform-frontend/src/lib/utils/downloadSink.ts
@@ -1,0 +1,184 @@
+/** 浏览器下载写入目标的最小事务接口。 */
+export interface DownloadSink {
+  readonly supportsRandomAccess: boolean;
+  write(data: Uint8Array): Promise<void>;
+  writeAt(position: number, data: Uint8Array): Promise<void>;
+  close(): Promise<void>;
+  abort(reason?: unknown): Promise<void>;
+}
+
+interface WritableFileStreamLike {
+  write(data: BufferSource | Blob | string): Promise<void>;
+  seek(position: number): Promise<void>;
+  close(): Promise<void>;
+  abort(reason?: unknown): Promise<void>;
+}
+
+interface WritableFileHandleLike {
+  createWritable(): Promise<WritableFileStreamLike>;
+}
+
+/** 将字节复制到独立 ArrayBuffer，避免 SharedArrayBuffer 类型与生命周期问题。 */
+function toArrayBuffer(data: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(data);
+  return buffer;
+}
+
+/** 包装 File System Access writable，直到 close 才提交临时文件。 */
+export class FileSystemDownloadSink implements DownloadSink {
+  readonly supportsRandomAccess = true;
+
+  constructor(private readonly writable: WritableFileStreamLike) {}
+
+  /** 顺序写入已经校验或认证的数据。 */
+  async write(data: Uint8Array): Promise<void> {
+    await this.writable.write(toArrayBuffer(data));
+  }
+
+  /** 定位到指定明文偏移后写入历史 v1 分片。 */
+  async writeAt(position: number, data: Uint8Array): Promise<void> {
+    if (!Number.isSafeInteger(position) || position < 0) {
+      throw new Error("无效的下载写入偏移");
+    }
+    await this.writable.seek(position);
+    await this.writable.write(toArrayBuffer(data));
+  }
+
+  /** 提交已完整校验的下载文件。 */
+  async close(): Promise<void> {
+    await this.writable.close();
+  }
+
+  /** 放弃未完成输出，避免部分文件被当成成功结果。 */
+  async abort(reason?: unknown): Promise<void> {
+    await this.writable.abort(reason);
+  }
+}
+
+/** 创建并校验 File System Access 下载目标。 */
+export async function createFileSystemDownloadSink(
+  fileHandle: unknown,
+): Promise<FileSystemDownloadSink> {
+  const candidate = fileHandle as Partial<WritableFileHandleLike> | null;
+  if (!candidate || typeof candidate.createWritable !== "function") {
+    throw new Error("下载文件句柄无效");
+  }
+
+  const writable = await candidate.createWritable();
+  if (
+    typeof writable.write !== "function" ||
+    typeof writable.seek !== "function" ||
+    typeof writable.close !== "function" ||
+    typeof writable.abort !== "function"
+  ) {
+    throw new Error("浏览器不支持事务性文件写入");
+  }
+  return new FileSystemDownloadSink(writable);
+}
+
+/** 小文件内存回退 sink；创建时即按声明大小限制总内存。 */
+export class MemoryDownloadSink implements DownloadSink {
+  readonly supportsRandomAccess = true;
+  private readonly data: Uint8Array;
+  private position = 0;
+  private writtenRanges: Array<{ start: number; end: number }> = [];
+  private closed = false;
+  private aborted = false;
+
+  constructor(
+    private readonly expectedSize: number,
+    maxBytes: number,
+  ) {
+    if (
+      !Number.isSafeInteger(expectedSize) ||
+      expectedSize < 0 ||
+      expectedSize > maxBytes
+    ) {
+      throw new Error("文件超过浏览器 64 MiB 内存回退上限");
+    }
+    this.data = new Uint8Array(expectedSize);
+  }
+
+  /** 在当前顺序偏移写入数据。 */
+  async write(data: Uint8Array): Promise<void> {
+    await this.writeAt(this.position, data);
+    this.position += data.byteLength;
+  }
+
+  /** 在固定范围内写入数据，越界时立即失败。 */
+  async writeAt(position: number, data: Uint8Array): Promise<void> {
+    this.ensureWritable();
+    const end = position + data.byteLength;
+    if (
+      !Number.isSafeInteger(position) ||
+      position < 0 ||
+      !Number.isSafeInteger(end) ||
+      end > this.expectedSize
+    ) {
+      throw new Error("下载数据超出声明文件大小");
+    }
+    this.data.set(data, position);
+    this.recordWrittenRange(position, end);
+  }
+
+  /** 只有完整写满声明大小时才提交内存结果。 */
+  async close(): Promise<void> {
+    this.ensureWritable();
+    const complete =
+      (this.expectedSize === 0 && this.writtenRanges.length === 0) ||
+      (this.writtenRanges.length === 1 &&
+        this.writtenRanges[0]?.start === 0 &&
+        this.writtenRanges[0]?.end === this.expectedSize);
+    if (!complete) {
+      const writtenBytes = this.writtenRanges.reduce(
+        (sum, range) => sum + range.end - range.start,
+        0,
+      );
+      throw new Error(
+        `下载长度不完整: 期望 ${this.expectedSize}，实际 ${writtenBytes}`,
+      );
+    }
+    this.closed = true;
+  }
+
+  /** 标记内存输出已放弃并清零。 */
+  async abort(): Promise<void> {
+    if (this.aborted) return;
+    this.aborted = true;
+    this.data.fill(0);
+  }
+
+  /** 返回已提交的内存文件数据。 */
+  getData(): Uint8Array {
+    if (!this.closed || this.aborted) {
+      throw new Error("下载尚未成功提交");
+    }
+    return this.data;
+  }
+
+  /** 校验 sink 仍可写入。 */
+  private ensureWritable(): void {
+    if (this.closed || this.aborted) {
+      throw new Error("下载写入目标已关闭");
+    }
+  }
+
+  /** 合并已写区间，用于识别随机写入留下的空洞。 */
+  private recordWrittenRange(start: number, end: number): void {
+    if (start === end) return;
+    const ranges = [...this.writtenRanges, { start, end }].sort(
+      (left, right) => left.start - right.start,
+    );
+    const merged: Array<{ start: number; end: number }> = [];
+    for (const range of ranges) {
+      const last = merged.at(-1);
+      if (!last || range.start > last.end) {
+        merged.push({ ...range });
+      } else {
+        last.end = Math.max(last.end, range.end);
+      }
+    }
+    this.writtenRanges = merged;
+  }
+}

--- a/platform-frontend/src/lib/utils/downloadStreamReader.test.ts
+++ b/platform-frontend/src/lib/utils/downloadStreamReader.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { DownloadMetricsTracker } from "./downloadMetrics";
+import { DownloadStreamReader } from "./downloadStreamReader";
+
+function responseFromChunks(chunks: number[][]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(new Uint8Array(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream);
+}
+
+describe("DownloadStreamReader", () => {
+  it("should read exact bytes across arbitrary network boundaries", async () => {
+    const metrics = new DownloadMetricsTracker();
+    const response = responseFromChunks([[0, 1], [2], [3, 4, 5]]);
+    const reader = new DownloadStreamReader(
+      response.body!.getReader(),
+      metrics,
+    );
+    const first = await reader.readExact(5, "header");
+    expect(Array.from(first)).toEqual([0, 1, 2, 3, 4]);
+    reader.release(first);
+    await expect(reader.assertEof()).rejects.toThrow("尾部字节");
+    expect(metrics.snapshot().currentBufferedBytes).toBe(0);
+  });
+
+  it("should reject oversized network chunks and release reader state", async () => {
+    const metrics = new DownloadMetricsTracker();
+    const response = responseFromChunks([[1, 2, 3, 4, 5]]);
+    const reader = new DownloadStreamReader(
+      response.body!.getReader(),
+      metrics,
+      undefined,
+      4,
+    );
+    await expect(reader.readExact(1, "byte")).rejects.toThrow("有界下载上限");
+    expect(metrics.snapshot().currentBufferedBytes).toBe(0);
+  });
+
+  it("should track peak buffering and cancel safely", async () => {
+    const metrics = new DownloadMetricsTracker();
+    const response = responseFromChunks([[1, 2]]);
+    const reader = new DownloadStreamReader(
+      response.body!.getReader(),
+      metrics,
+    );
+    const data = await reader.readExact(2, "bytes");
+    expect(metrics.snapshot().peakBufferedBytes).toBeGreaterThanOrEqual(2);
+    reader.release(data);
+    await reader.cancel("done");
+    expect(metrics.snapshot().currentBufferedBytes).toBe(0);
+  });
+});

--- a/platform-frontend/src/lib/utils/downloadStreamReader.ts
+++ b/platform-frontend/src/lib/utils/downloadStreamReader.ts
@@ -1,0 +1,140 @@
+import type { DownloadMetricsTracker } from "./downloadMetrics";
+
+interface IncrementalHash {
+  update(data: Uint8Array): IncrementalHash;
+}
+
+// 网络块上限保持在 1MiB，避免与 framed ciphertext/明文缓冲叠加后失控。
+const DEFAULT_MAX_NETWORK_CHUNK_BYTES = 1 * 1024 * 1024;
+
+/** 在任意网络分块边界上提供有界 readExact 与 EOF 校验。 */
+export class DownloadStreamReader {
+  private current: Uint8Array | null = null;
+  private currentOffset = 0;
+  private ended = false;
+
+  constructor(
+    private readonly reader: ReadableStreamDefaultReader<Uint8Array>,
+    private readonly metrics: DownloadMetricsTracker,
+    private readonly hash?: IncrementalHash,
+    private readonly maxNetworkChunkBytes = DEFAULT_MAX_NETWORK_CHUNK_BYTES,
+  ) {}
+
+  /** 精确读取指定字节数，并把消费字节计入可选摘要。 */
+  async readExact(length: number, label: string): Promise<Uint8Array> {
+    if (!Number.isSafeInteger(length) || length < 0) {
+      throw new Error(`${label} 长度无效`);
+    }
+
+    const output = new Uint8Array(length);
+    this.metrics.acquire(length);
+    let written = 0;
+    try {
+      while (written < length) {
+        await this.ensureCurrentChunk();
+        if (!this.current) {
+          throw new Error(`${label} 被截断`);
+        }
+
+        const available = this.current.byteLength - this.currentOffset;
+        const take = Math.min(available, length - written);
+        const slice = this.current.subarray(
+          this.currentOffset,
+          this.currentOffset + take,
+        );
+        output.set(slice, written);
+        this.hash?.update(slice);
+        written += take;
+        this.currentOffset += take;
+        this.releaseCurrentIfConsumed();
+      }
+      return output;
+    } catch (error) {
+      this.metrics.release(length);
+      throw error;
+    }
+  }
+
+  /** 释放 readExact 返回值对应的缓冲计数。 */
+  release(data: Uint8Array): void {
+    this.metrics.release(data.byteLength);
+  }
+
+  /** 确认协议声明结束后没有任何尾部字节。 */
+  async assertEof(): Promise<void> {
+    await this.ensureCurrentChunk();
+    if (this.current) {
+      const trailing = this.current.subarray(this.currentOffset);
+      this.hash?.update(trailing);
+      this.releaseCurrent();
+      throw new Error("加密分片包含未声明的尾部字节");
+    }
+  }
+
+  /** 取消底层 reader，并释放尚未消费的网络缓冲。 */
+  async cancel(reason?: unknown): Promise<void> {
+    this.releaseCurrent();
+    try {
+      await this.reader.cancel(reason);
+    } catch {
+      // reader 可能已被 fetch 关闭，取消失败不覆盖原始错误。
+    }
+  }
+
+  /** 获取下一段非空网络数据。 */
+  private async ensureCurrentChunk(): Promise<void> {
+    while (!this.current && !this.ended) {
+      const { done, value } = await this.reader.read();
+      if (done) {
+        this.ended = true;
+        return;
+      }
+      if (!value || value.byteLength === 0) continue;
+      if (value.byteLength > this.maxNetworkChunkBytes) {
+        await this.reader.cancel("network chunk exceeds bounded limit");
+        throw new Error("网络读取块超过有界下载上限");
+      }
+      this.current = value;
+      this.currentOffset = 0;
+      this.metrics.acquire(value.byteLength);
+    }
+  }
+
+  /** 当前网络块消费完毕后立即释放引用与指标。 */
+  private releaseCurrentIfConsumed(): void {
+    if (this.current && this.currentOffset === this.current.byteLength) {
+      this.releaseCurrent();
+    }
+  }
+
+  /** 释放当前网络读取块。 */
+  private releaseCurrent(): void {
+    if (!this.current) return;
+    this.metrics.release(this.current.byteLength);
+    this.current = null;
+    this.currentOffset = 0;
+  }
+}
+
+/** 获取可流式读取的响应体，缺失时失败关闭。 */
+export function requireResponseReader(
+  response: Response,
+): ReadableStreamDefaultReader<Uint8Array> {
+  if (!response.body) {
+    throw new Error("浏览器未提供流式响应体");
+  }
+  return response.body.getReader();
+}
+
+/** 校验 HTTP Content-Length 与 manifest 声明一致。 */
+export function assertContentLength(
+  response: Response,
+  expected: number,
+): void {
+  const raw = response.headers.get("content-length");
+  if (!raw) return;
+  const actual = Number(raw);
+  if (!Number.isSafeInteger(actual) || actual < 0 || actual !== expected) {
+    throw new Error(`下载响应长度不匹配: 期望 ${expected}，实际 ${raw}`);
+  }
+}

--- a/platform-frontend/src/lib/utils/fileSize.test.ts
+++ b/platform-frontend/src/lib/utils/fileSize.test.ts
@@ -5,6 +5,7 @@ import {
   LARGE_FILE_WARNING_THRESHOLD,
   STREAMING_RECOMMENDED_THRESHOLD,
   MAX_SAFE_INMEMORY_SIZE,
+  VERY_LARGE_FILE_THRESHOLD,
   MAX_DOWNLOADABLE_SIZE,
   classifyFileSize,
   formatFileSize,
@@ -41,8 +42,10 @@ describe("fileSize utilities", () => {
     expect(classifyFileSize(STREAMING_RECOMMENDED_THRESHOLD)).toBe("medium");
     expect(classifyFileSize(STREAMING_RECOMMENDED_THRESHOLD + 1)).toBe("large");
 
-    expect(classifyFileSize(MAX_SAFE_INMEMORY_SIZE)).toBe("large");
-    expect(classifyFileSize(MAX_SAFE_INMEMORY_SIZE + 1)).toBe("very_large");
+    expect(classifyFileSize(MAX_SAFE_INMEMORY_SIZE)).toBe("small");
+    expect(classifyFileSize(MAX_SAFE_INMEMORY_SIZE + 1)).toBe("medium");
+    expect(classifyFileSize(VERY_LARGE_FILE_THRESHOLD)).toBe("large");
+    expect(classifyFileSize(VERY_LARGE_FILE_THRESHOLD + 1)).toBe("very_large");
 
     expect(classifyFileSize(MAX_DOWNLOADABLE_SIZE)).toBe("very_large");
     expect(classifyFileSize(MAX_DOWNLOADABLE_SIZE + 1)).toBe("too_large");
@@ -126,7 +129,7 @@ describe("fileSize utilities", () => {
     expect(large.warningMessage).not.toBeNull();
   });
 
-  it("should fall back to in-memory for large files when streaming is unavailable", () => {
+  it("should reject large files when streaming is unavailable", () => {
     const large = decideDownloadStrategy(STREAMING_RECOMMENDED_THRESHOLD + 1, {
       fileSystemAccess: false,
       streams: false,
@@ -134,10 +137,10 @@ describe("fileSize utilities", () => {
       indexedDB: true,
       blob: true,
     });
-    expect(large.strategy).toBe("inmemory");
-    expect(large.canProceed).toBe(true);
+    expect(large.strategy).toBe("backend_proxy");
+    expect(large.canProceed).toBe(false);
     expect(large.requiresUserConfirmation).toBe(true);
-    expect(large.warningMessage).toContain("2GB");
+    expect(large.warningMessage).toContain("64 MiB");
   });
 
   it("should warn on medium files for low-memory devices", () => {
@@ -151,10 +154,10 @@ describe("fileSize utilities", () => {
     expect(medium.strategy).toBe("streaming");
     expect(medium.canProceed).toBe(true);
     expect(medium.requiresUserConfirmation).toBe(true);
-    expect(medium.warningMessage).toContain("2GB");
+    expect(medium.warningMessage).toContain("written directly to disk");
   });
 
-  it("should allow medium files without confirmation for normal devices", () => {
+  it("should reject medium files when streaming is unavailable", () => {
     const medium = decideDownloadStrategy(LARGE_FILE_WARNING_THRESHOLD + 1, {
       fileSystemAccess: false,
       streams: false,
@@ -162,10 +165,10 @@ describe("fileSize utilities", () => {
       indexedDB: true,
       blob: true,
     });
-    expect(medium.strategy).toBe("inmemory");
-    expect(medium.canProceed).toBe(true);
-    expect(medium.requiresUserConfirmation).toBe(false);
-    expect(medium.warningMessage).toBeNull();
+    expect(medium.strategy).toBe("backend_proxy");
+    expect(medium.canProceed).toBe(false);
+    expect(medium.requiresUserConfirmation).toBe(true);
+    expect(medium.warningMessage).toContain("64 MiB");
   });
 
   it("should run a pre-download check with detected capabilities", () => {

--- a/platform-frontend/src/lib/utils/fileSize.ts
+++ b/platform-frontend/src/lib/utils/fileSize.ts
@@ -11,23 +11,23 @@ export const GB = 1024 * 1024 * 1024;
 /** 1 MB in bytes */
 export const MB = 1024 * 1024;
 
-/**
- * Maximum safe file size for in-memory download (Blob-based)
- * Beyond this, we need streaming download to avoid memory issues
- */
-export const MAX_SAFE_INMEMORY_SIZE = 2 * GB;
+/** 无文件选择器时允许的内存回退硬上限。 */
+export const MAX_SAFE_INMEMORY_SIZE = 64 * MB;
 
 /**
  * File size threshold for warning the user before download
  * Files above this size may cause issues on some devices
  */
-export const LARGE_FILE_WARNING_THRESHOLD = 500 * MB;
+export const LARGE_FILE_WARNING_THRESHOLD = MAX_SAFE_INMEMORY_SIZE;
 
 /**
  * File size threshold where streaming is strongly recommended
  * At this size, in-memory download will likely fail on most devices
  */
-export const STREAMING_RECOMMENDED_THRESHOLD = 1 * GB;
+export const STREAMING_RECOMMENDED_THRESHOLD = 500 * MB;
+
+/** 超大文件分级阈值，仅用于提示文案，不放宽内存回退。 */
+export const VERY_LARGE_FILE_THRESHOLD = 2 * GB;
 
 /**
  * Absolute maximum file size we support for download
@@ -54,7 +54,7 @@ export function classifyFileSize(sizeInBytes: number): FileSizeCategory {
   if (sizeInBytes <= STREAMING_RECOMMENDED_THRESHOLD) {
     return "medium";
   }
-  if (sizeInBytes <= MAX_SAFE_INMEMORY_SIZE) {
+  if (sizeInBytes <= VERY_LARGE_FILE_THRESHOLD) {
     return "large";
   }
   if (sizeInBytes <= MAX_DOWNLOADABLE_SIZE) {
@@ -170,7 +170,7 @@ export function decideDownloadStrategy(
     };
   }
 
-  // Small files - always use in-memory
+  // 小文件可以使用受控内存回退。
   if (category === "small") {
     return {
       strategy: "inmemory",
@@ -216,39 +216,32 @@ export function decideDownloadStrategy(
         reason: "Large file, using streaming for reliability",
       };
     }
-    // Fall back to in-memory with warning
-    const memoryWarning = capabilities.deviceMemory
-      ? ` Your device has ${capabilities.deviceMemory}GB of memory.`
-      : "";
     return {
-      strategy: "inmemory",
+      strategy: "backend_proxy",
       requiresUserConfirmation: true,
-      warningMessage: `This file (${formattedSize}) is large and may cause performance issues or fail.${memoryWarning} For better large file support, try Chrome or Edge.`,
-      canProceed: true,
-      reason: "Large file, falling back to in-memory (no streaming support)",
+      warningMessage: `This file (${formattedSize}) exceeds the 64 MiB browser fallback limit. Use Chrome or Edge and choose a save location.`,
+      canProceed: false,
+      reason: "Large file but browser does not support bounded saving",
     };
   }
 
-  // Medium files - use in-memory with optional warning
+  // 超过内存回退上限时必须使用文件系统流式写入。
   if (category === "medium") {
-    // Check if device memory is low
-    const lowMemory =
-      capabilities.deviceMemory && capabilities.deviceMemory < 4;
-    if (lowMemory) {
+    if (canStream) {
       return {
-        strategy: canStream ? "streaming" : "inmemory",
+        strategy: "streaming",
         requiresUserConfirmation: true,
-        warningMessage: `This file (${formattedSize}) may be challenging for your device with ${capabilities.deviceMemory}GB memory.`,
+        warningMessage: `This file (${formattedSize}) will be written directly to disk.`,
         canProceed: true,
-        reason: "Medium file on low-memory device",
+        reason: "File exceeds the in-memory fallback limit",
       };
     }
     return {
-      strategy: "inmemory",
-      requiresUserConfirmation: false,
-      warningMessage: null,
-      canProceed: true,
-      reason: "Medium file, in-memory download should work",
+      strategy: "backend_proxy",
+      requiresUserConfirmation: true,
+      warningMessage: `This file (${formattedSize}) exceeds the 64 MiB browser fallback limit. Use Chrome or Edge and choose a save location.`,
+      canProceed: false,
+      reason: "Browser does not support bounded large-file saving",
     };
   }
 

--- a/platform-frontend/src/lib/utils/framedAead.test.ts
+++ b/platform-frontend/src/lib/utils/framedAead.test.ts
@@ -1,0 +1,251 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFramedAad,
+  deriveFramedKeyMaterial,
+  downloadFramedPart,
+  FRAMED_AEAD_AAD_SCHEMA,
+  FRAMED_AEAD_FORMAT_VERSION,
+  FRAMED_AEAD_SUITE,
+  FRAMED_AEAD_TAG_BYTES,
+} from "./framedAead";
+import { bytesToHex } from "./downloadIntegrity";
+import { DownloadMetricsTracker } from "./downloadMetrics";
+import { MemoryDownloadSink } from "./downloadSink";
+
+const FRAME_SIZE = 64 * 1024;
+const fileNonce = Uint8Array.from({ length: 16 }, (_, index) => index + 1);
+const fileDek = Uint8Array.from({ length: 32 }, (_, index) => 0xa0 + index);
+
+function writeUint32(bytes: Uint8Array, offset: number, value: number): void {
+  new DataView(bytes.buffer).setUint32(offset, value, false);
+}
+
+async function makeFixture(): Promise<{
+  encoded: Uint8Array;
+  plaintext: Uint8Array;
+  part: {
+    index: number;
+    size: number;
+    downloadUrl: string;
+    expiresAtEpochSeconds: number;
+    storagePath: string;
+    plainHash: string;
+    cipherHash: string;
+    checksumAlgorithm: string;
+    plainSize: number;
+    frameCount: number;
+  };
+  encryption: {
+    formatVersion: number;
+    algorithmSuite: string;
+    fileNonce: string;
+    framePlainSize: number;
+    keyDerivation: string;
+    nonceDerivation: string;
+    aadSchema: string;
+    tagSize: number;
+  };
+}> {
+  const plaintext = new Uint8Array(FRAME_SIZE + 3);
+  for (let index = 0; index < plaintext.length; index++) {
+    plaintext[index] = index % 251;
+  }
+  const frameCount = 2;
+  const encodedParts: Uint8Array[] = [];
+  const header = new Uint8Array(44);
+  header.set(new TextEncoder().encode("RPF2"), 0);
+  header[4] = 2;
+  header[5] = 1;
+  writeUint32(header, 8, 0);
+  writeUint32(header, 12, 1);
+  writeUint32(header, 16, FRAME_SIZE);
+  writeUint32(header, 20, frameCount);
+  writeUint32(header, 24, plaintext.length);
+  header.set(fileNonce, 28);
+  encodedParts.push(header);
+
+  for (let frameIndex = 0; frameIndex < frameCount; frameIndex++) {
+    const plainLength = Math.min(
+      FRAME_SIZE,
+      plaintext.length - frameIndex * FRAME_SIZE,
+    );
+    const framePlaintext = plaintext.slice(
+      frameIndex * FRAME_SIZE,
+      frameIndex * FRAME_SIZE + plainLength,
+    );
+    const material = deriveFramedKeyMaterial({
+      fileDek,
+      fileNonce,
+      chunkIndex: 0,
+      frameIndex,
+    });
+    const aad = buildFramedAad({
+      fileNonce,
+      chunkIndex: 0,
+      chunkCount: 1,
+      frameIndex,
+      frameCount,
+      plainLength,
+      chunkPlainSize: plaintext.length,
+    });
+    const key = await globalThis.crypto.subtle.importKey(
+      "raw",
+      material.key as unknown as BufferSource,
+      { name: "AES-GCM" },
+      false,
+      ["encrypt"],
+    );
+    const ciphertext = new Uint8Array(
+      await globalThis.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv: material.nonce as unknown as BufferSource,
+          additionalData: aad as unknown as BufferSource,
+          tagLength: 128,
+        },
+        key,
+        framePlaintext as unknown as BufferSource,
+      ),
+    );
+    const frameHeader = new Uint8Array(12);
+    writeUint32(frameHeader, 0, frameIndex);
+    writeUint32(frameHeader, 4, plainLength);
+    writeUint32(frameHeader, 8, ciphertext.length);
+    encodedParts.push(frameHeader, ciphertext);
+  }
+
+  const encoded = new Uint8Array(
+    encodedParts.reduce((sum, value) => sum + value.length, 0),
+  );
+  let offset = 0;
+  for (const value of encodedParts) {
+    encoded.set(value, offset);
+    offset += value.length;
+  }
+  const encryption = {
+    formatVersion: FRAMED_AEAD_FORMAT_VERSION,
+    algorithmSuite: FRAMED_AEAD_SUITE,
+    fileNonce: btoa(String.fromCharCode(...fileNonce)),
+    framePlainSize: FRAME_SIZE,
+    keyDerivation: "HKDF-SHA256",
+    nonceDerivation: "HKDF-SHA256",
+    aadSchema: FRAMED_AEAD_AAD_SCHEMA,
+    tagSize: FRAMED_AEAD_TAG_BYTES,
+  };
+  const part = {
+    index: 0,
+    size: encoded.length,
+    downloadUrl: "https://objects.test/part-0",
+    expiresAtEpochSeconds: 2_000_000_000,
+    storagePath: "tenant/part-0",
+    plainHash: `sha256:${bytesToHex(sha256(plaintext))}`,
+    cipherHash: `sha256:${bytesToHex(sha256(encoded))}`,
+    checksumAlgorithm: "SHA-256",
+    plainSize: plaintext.length,
+    frameCount,
+  };
+  return { encoded, plaintext, part, encryption };
+}
+
+function responseFromArbitraryChunks(bytes: Uint8Array): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let offset = 0;
+      const sizes = [1, 7, 31, 1024, 3, 4096];
+      let index = 0;
+      while (offset < bytes.length) {
+        const size = Math.min(
+          sizes[index++ % sizes.length],
+          bytes.length - offset,
+        );
+        controller.enqueue(bytes.slice(offset, offset + size));
+        offset += size;
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: { "content-length": String(bytes.length) },
+  });
+}
+
+describe("framedAead", () => {
+  it("should decrypt arbitrary network boundaries and write only authenticated frames", async () => {
+    const fixture = await makeFixture();
+    const sink = new MemoryDownloadSink(fixture.plaintext.length, 1 << 20);
+    const metrics = new DownloadMetricsTracker();
+    await downloadFramedPart({
+      response: responseFromArbitraryChunks(fixture.encoded),
+      part: fixture.part,
+      partCount: 1,
+      encryption: fixture.encryption,
+      fileDekBase64: btoa(String.fromCharCode(...fileDek)),
+      sink,
+      metrics,
+    });
+    expect(metrics.snapshot()).toMatchObject({
+      currentBufferedBytes: 0,
+      framesAuthenticated: 2,
+      partsCompleted: 1,
+      bytesWritten: fixture.plaintext.length,
+    });
+    await sink.close();
+    expect(Array.from(sink.getData())).toEqual(Array.from(fixture.plaintext));
+  });
+
+  it("should fail closed before writing a tampered frame", async () => {
+    const fixture = await makeFixture();
+    const tampered = fixture.encoded.slice();
+    tampered[tampered.length - 1] ^= 0xff;
+    const sink = new MemoryDownloadSink(fixture.plaintext.length, 1 << 20);
+    const metrics = new DownloadMetricsTracker();
+    await expect(
+      downloadFramedPart({
+        response: responseFromArbitraryChunks(tampered),
+        part: fixture.part,
+        partCount: 1,
+        encryption: fixture.encryption,
+        fileDekBase64: btoa(String.fromCharCode(...fileDek)),
+        sink,
+        metrics,
+      }),
+    ).rejects.toThrow("认证失败");
+    expect(metrics.snapshot()).toMatchObject({
+      currentBufferedBytes: 0,
+      framesAuthenticated: 1,
+    });
+  });
+
+  it("should cancel the response reader when the download signal is aborted", async () => {
+    const fixture = await makeFixture();
+    const controller = new AbortController();
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(streamController) {
+          streamController.enqueue(fixture.encoded.subarray(0, 44));
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    controller.abort();
+
+    await expect(
+      downloadFramedPart({
+        response,
+        part: fixture.part,
+        partCount: 1,
+        encryption: fixture.encryption,
+        fileDekBase64: btoa(String.fromCharCode(...fileDek)),
+        sink: new MemoryDownloadSink(fixture.plaintext.length, 1 << 20),
+        metrics: new DownloadMetricsTracker(),
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("Download cancelled");
+    expect(cancelled).toBe(true);
+  });
+});

--- a/platform-frontend/src/lib/utils/framedAead.ts
+++ b/platform-frontend/src/lib/utils/framedAead.ts
@@ -1,0 +1,408 @@
+import { hkdf } from "@noble/hashes/hkdf.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+import type { ChunkManifestEncryption, FileDownloadPartVO } from "$api/types";
+import type { DownloadSink } from "./downloadSink";
+import { assertSha256, createSha256, decodeBase64 } from "./downloadIntegrity";
+import type { DownloadMetricsTracker } from "./downloadMetrics";
+import {
+  assertContentLength,
+  DownloadStreamReader,
+  requireResponseReader,
+} from "./downloadStreamReader";
+
+export const FRAMED_AEAD_SUITE = "RP-AES256-GCM-FRAMED-V2";
+export const FRAMED_AEAD_AAD_SCHEMA = "cn.flying.framed-aead.aad.v2";
+export const FRAMED_AEAD_FORMAT_VERSION = 2;
+export const FRAMED_AEAD_HEADER_BYTES = 44;
+export const FRAMED_AEAD_FRAME_HEADER_BYTES = 12;
+export const FRAMED_AEAD_TAG_BYTES = 16;
+export const MIN_FRAME_PLAIN_BYTES = 64 * 1024;
+export const MAX_FRAME_PLAIN_BYTES = 4 * 1024 * 1024;
+export const MAX_FRAMES_PER_PART = 10_000;
+
+const MAGIC = new Uint8Array([0x52, 0x50, 0x46, 0x32]); // RPF2
+const ALGORITHM_ID_AES_256_GCM = 1;
+const KEY_INFO_PREFIX = new TextEncoder().encode(
+  "cn.flying.framed-aead.v2/key",
+);
+const NONCE_INFO_PREFIX = new TextEncoder().encode(
+  "cn.flying.framed-aead.v2/nonce",
+);
+const AAD_PREFIX = new TextEncoder().encode(FRAMED_AEAD_AAD_SCHEMA);
+
+interface FramedChunkHeader {
+  chunkIndex: number;
+  chunkCount: number;
+  framePlainSize: number;
+  frameCount: number;
+  chunkPlainSize: number;
+  fileNonce: Uint8Array;
+}
+
+/** 将 typed array 显式标注为 WebCrypto 的 BufferSource。 */
+function asBufferSource(bytes: Uint8Array): BufferSource {
+  return bytes as unknown as BufferSource;
+}
+
+/** 读取无符号大端 32 位整数。 */
+function readUint32(bytes: Uint8Array, offset: number): number {
+  return new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  ).getUint32(offset, false);
+}
+
+/** 写入无符号大端 32 位整数。 */
+function writeUint32(bytes: Uint8Array, offset: number, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new Error("framed AEAD 坐标超出 uint32 范围");
+  }
+  new DataView(bytes.buffer).setUint32(offset, value, false);
+}
+
+/** 拼接固定域与 frame 坐标，构造 HKDF info。 */
+function buildFrameInfo(
+  prefix: Uint8Array,
+  chunkIndex: number,
+  frameIndex: number,
+): Uint8Array {
+  const info = new Uint8Array(prefix.byteLength + 8);
+  info.set(prefix, 0);
+  writeUint32(info, prefix.byteLength, chunkIndex);
+  writeUint32(info, prefix.byteLength + 4, frameIndex);
+  return info;
+}
+
+/** 构造 Java/TypeScript 共享的规范 AAD 字节。 */
+export function buildFramedAad(params: {
+  fileNonce: Uint8Array;
+  chunkIndex: number;
+  chunkCount: number;
+  frameIndex: number;
+  frameCount: number;
+  plainLength: number;
+  chunkPlainSize: number;
+}): Uint8Array {
+  if (params.fileNonce.byteLength !== 16) {
+    throw new Error("framed AEAD fileNonce 必须为 16 字节");
+  }
+  const aad = new Uint8Array(AAD_PREFIX.byteLength + 2 + 16 + 24);
+  let offset = 0;
+  aad.set(AAD_PREFIX, offset);
+  offset += AAD_PREFIX.byteLength;
+  aad[offset++] = FRAMED_AEAD_FORMAT_VERSION;
+  aad[offset++] = ALGORITHM_ID_AES_256_GCM;
+  aad.set(params.fileNonce, offset);
+  offset += 16;
+  writeUint32(aad, offset, params.chunkIndex);
+  writeUint32(aad, offset + 4, params.chunkCount);
+  writeUint32(aad, offset + 8, params.frameIndex);
+  writeUint32(aad, offset + 12, params.frameCount);
+  writeUint32(aad, offset + 16, params.plainLength);
+  writeUint32(aad, offset + 20, params.chunkPlainSize);
+  return aad;
+}
+
+/** 从 file DEK 与 file nonce 派生单帧 key 和 nonce。 */
+export function deriveFramedKeyMaterial(params: {
+  fileDek: Uint8Array;
+  fileNonce: Uint8Array;
+  chunkIndex: number;
+  frameIndex: number;
+}): { key: Uint8Array; nonce: Uint8Array } {
+  if (params.fileDek.byteLength !== 32) {
+    throw new Error("framed AEAD file DEK 必须为 32 字节");
+  }
+  if (params.fileNonce.byteLength !== 16) {
+    throw new Error("framed AEAD fileNonce 必须为 16 字节");
+  }
+  return {
+    key: hkdf(
+      sha256,
+      params.fileDek,
+      params.fileNonce,
+      buildFrameInfo(KEY_INFO_PREFIX, params.chunkIndex, params.frameIndex),
+      32,
+    ),
+    nonce: hkdf(
+      sha256,
+      params.fileDek,
+      params.fileNonce,
+      buildFrameInfo(NONCE_INFO_PREFIX, params.chunkIndex, params.frameIndex),
+      12,
+    ),
+  };
+}
+
+/** 校验 metadata descriptor 只使用当前实现支持的 v2 套件。 */
+export function validateFramedEncryption(
+  encryption: ChunkManifestEncryption,
+): Uint8Array {
+  if (
+    encryption.formatVersion !== FRAMED_AEAD_FORMAT_VERSION ||
+    encryption.algorithmSuite !== FRAMED_AEAD_SUITE ||
+    encryption.keyDerivation !== "HKDF-SHA256" ||
+    encryption.nonceDerivation !== "HKDF-SHA256" ||
+    encryption.aadSchema !== FRAMED_AEAD_AAD_SCHEMA ||
+    encryption.tagSize !== FRAMED_AEAD_TAG_BYTES ||
+    !Number.isSafeInteger(encryption.framePlainSize) ||
+    encryption.framePlainSize < MIN_FRAME_PLAIN_BYTES ||
+    encryption.framePlainSize > MAX_FRAME_PLAIN_BYTES
+  ) {
+    throw new Error("不支持的 framed AEAD 下载合同");
+  }
+  const fileNonce = decodeBase64(encryption.fileNonce);
+  if (fileNonce.byteLength !== 16) {
+    throw new Error("framed AEAD fileNonce 必须为 16 字节");
+  }
+  return fileNonce;
+}
+
+/** 解析并校验 44 字节 chunk header。 */
+function parseChunkHeader(
+  bytes: Uint8Array,
+  expected: {
+    part: FileDownloadPartVO;
+    partCount: number;
+    encryption: ChunkManifestEncryption;
+    fileNonce: Uint8Array;
+  },
+): FramedChunkHeader {
+  for (let index = 0; index < MAGIC.byteLength; index++) {
+    if (bytes[index] !== MAGIC[index]) {
+      throw new Error("framed AEAD chunk magic 无效");
+    }
+  }
+  if (
+    bytes[4] !== FRAMED_AEAD_FORMAT_VERSION ||
+    bytes[5] !== ALGORITHM_ID_AES_256_GCM ||
+    bytes[6] !== 0 ||
+    bytes[7] !== 0
+  ) {
+    throw new Error("framed AEAD chunk 版本或算法无效");
+  }
+
+  const header: FramedChunkHeader = {
+    chunkIndex: readUint32(bytes, 8),
+    chunkCount: readUint32(bytes, 12),
+    framePlainSize: readUint32(bytes, 16),
+    frameCount: readUint32(bytes, 20),
+    chunkPlainSize: readUint32(bytes, 24),
+    fileNonce: bytes.slice(28, 44),
+  };
+  const expectedFrameCount = Math.ceil(
+    header.chunkPlainSize / header.framePlainSize,
+  );
+  if (
+    header.chunkIndex !== expected.part.index ||
+    header.chunkCount !== expected.partCount ||
+    header.framePlainSize !== expected.encryption.framePlainSize ||
+    header.frameCount !== expected.part.frameCount ||
+    header.chunkPlainSize !== expected.part.plainSize ||
+    header.frameCount !== expectedFrameCount ||
+    header.chunkPlainSize <= 0 ||
+    header.frameCount <= 0 ||
+    header.frameCount > MAX_FRAMES_PER_PART ||
+    !header.fileNonce.every((byte, index) => byte === expected.fileNonce[index])
+  ) {
+    throw new Error("framed AEAD chunk header 与 manifest 不一致");
+  }
+  return header;
+}
+
+/** 使用 WebCrypto 验证并解密单个 AES-256-GCM frame。 */
+async function decryptFrame(params: {
+  ciphertext: Uint8Array;
+  fileDek: Uint8Array;
+  header: FramedChunkHeader;
+  frameIndex: number;
+  plainLength: number;
+}): Promise<Uint8Array> {
+  const material = deriveFramedKeyMaterial({
+    fileDek: params.fileDek,
+    fileNonce: params.header.fileNonce,
+    chunkIndex: params.header.chunkIndex,
+    frameIndex: params.frameIndex,
+  });
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw",
+    asBufferSource(material.key),
+    { name: "AES-GCM" },
+    false,
+    ["decrypt"],
+  );
+  const aad = buildFramedAad({
+    fileNonce: params.header.fileNonce,
+    chunkIndex: params.header.chunkIndex,
+    chunkCount: params.header.chunkCount,
+    frameIndex: params.frameIndex,
+    frameCount: params.header.frameCount,
+    plainLength: params.plainLength,
+    chunkPlainSize: params.header.chunkPlainSize,
+  });
+  try {
+    const plaintext = await globalThis.crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: asBufferSource(material.nonce),
+        additionalData: asBufferSource(aad),
+        tagLength: FRAMED_AEAD_TAG_BYTES * 8,
+      },
+      key,
+      asBufferSource(params.ciphertext),
+    );
+    return new Uint8Array(plaintext);
+  } catch {
+    throw new Error(
+      `framed AEAD 分片 ${params.header.chunkIndex} frame ${params.frameIndex} 认证失败`,
+    );
+  }
+}
+
+/** 下载、认证并写入一个 framed AEAD part。 */
+export async function downloadFramedPart(params: {
+  response: Response;
+  part: FileDownloadPartVO;
+  partCount: number;
+  encryption: ChunkManifestEncryption;
+  fileDekBase64: string;
+  sink: DownloadSink;
+  metrics: DownloadMetricsTracker;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (
+    params.part.plainSize == null ||
+    params.part.frameCount == null ||
+    !Number.isSafeInteger(params.part.size) ||
+    params.part.size <= 0
+  ) {
+    throw new Error("framed AEAD part 缺少明文尺寸或 frame 数量");
+  }
+  assertContentLength(params.response, params.part.size);
+  const fileNonce = validateFramedEncryption(params.encryption);
+  const fileDek = decodeBase64(params.fileDekBase64);
+  if (fileDek.byteLength !== 32) {
+    throw new Error("framed AEAD file DEK 必须为 32 字节");
+  }
+
+  const cipherHash = createSha256();
+  const plainHash = createSha256();
+  const stream = new DownloadStreamReader(
+    requireResponseReader(params.response),
+    params.metrics,
+    cipherHash,
+  );
+  const throwIfAborted = (): void => {
+    if (params.signal?.aborted) {
+      throw new Error("Download cancelled");
+    }
+  };
+  const onAbort = (): void => {
+    void stream.cancel("Download cancelled");
+  };
+  params.signal?.addEventListener("abort", onAbort, { once: true });
+  let encodedLength = 0;
+  try {
+    throwIfAborted();
+    const headerBytes = await stream.readExact(
+      FRAMED_AEAD_HEADER_BYTES,
+      "framed AEAD chunk header",
+    );
+    let header: FramedChunkHeader;
+    try {
+      encodedLength += headerBytes.byteLength;
+      header = parseChunkHeader(headerBytes, {
+        part: params.part,
+        partCount: params.partCount,
+        encryption: params.encryption,
+        fileNonce,
+      });
+    } finally {
+      stream.release(headerBytes);
+    }
+
+    let plainLengthTotal = 0;
+    for (let frameIndex = 0; frameIndex < header.frameCount; frameIndex++) {
+      throwIfAborted();
+      const frameHeader = await stream.readExact(
+        FRAMED_AEAD_FRAME_HEADER_BYTES,
+        "framed AEAD frame header",
+      );
+      let declaredFrameIndex: number;
+      let plainLength: number;
+      let cipherLength: number;
+      try {
+        encodedLength += frameHeader.byteLength;
+        declaredFrameIndex = readUint32(frameHeader, 0);
+        plainLength = readUint32(frameHeader, 4);
+        cipherLength = readUint32(frameHeader, 8);
+      } finally {
+        stream.release(frameHeader);
+      }
+
+      const remainingPlain = header.chunkPlainSize - plainLengthTotal;
+      const expectedPlainLength = Math.min(
+        header.framePlainSize,
+        remainingPlain,
+      );
+      if (
+        declaredFrameIndex !== frameIndex ||
+        plainLength !== expectedPlainLength ||
+        cipherLength !== plainLength + FRAMED_AEAD_TAG_BYTES ||
+        cipherLength > MAX_FRAME_PLAIN_BYTES + FRAMED_AEAD_TAG_BYTES
+      ) {
+        throw new Error("framed AEAD frame header 与 manifest 不一致");
+      }
+
+      const ciphertext = await stream.readExact(
+        cipherLength,
+        "framed AEAD frame ciphertext",
+      );
+      encodedLength += ciphertext.byteLength;
+      try {
+        throwIfAborted();
+        const plaintext = await decryptFrame({
+          ciphertext,
+          fileDek,
+          header,
+          frameIndex,
+          plainLength,
+        });
+        params.metrics.acquire(plaintext.byteLength);
+        try {
+          if (plaintext.byteLength !== plainLength) {
+            throw new Error("framed AEAD frame 明文长度不一致");
+          }
+          throwIfAborted();
+          plainHash.update(plaintext);
+          params.metrics.authenticatedFrame();
+          await params.sink.write(plaintext);
+          params.metrics.wrote(plaintext.byteLength);
+          plainLengthTotal += plaintext.byteLength;
+        } finally {
+          params.metrics.release(plaintext.byteLength);
+        }
+      } finally {
+        stream.release(ciphertext);
+      }
+    }
+
+    await stream.assertEof();
+    if (
+      plainLengthTotal !== header.chunkPlainSize ||
+      encodedLength !== params.part.size
+    ) {
+      throw new Error("framed AEAD part 长度校验失败");
+    }
+    assertSha256(cipherHash.digest(), params.part.cipherHash, "密文分片");
+    assertSha256(plainHash.digest(), params.part.plainHash, "明文分片");
+    params.metrics.completedPart();
+  } catch (error) {
+    await stream.cancel(error);
+    throw error;
+  } finally {
+    params.signal?.removeEventListener("abort", onAbort);
+  }
+}


### PR DESCRIPTION
## Summary
- add bounded NONE, legacy v1, and framed AEAD v2 browser download paths
- add canonical manifest binding, transactional sinks, abort semantics, and 64 MiB memory fallback
- add backend framed writer/recovery contract, additive migration, OpenAPI metadata, and Chromium memory gates

## Verification
- backend JDK 21: backend-service 1114 tests passed; backend-web 401 passed, 21 environment tests skipped
- frontend: format, lint, svelte-check, 38 files / 513 tests with coverage, build, and pnpm audit passed
- Playwright Chromium: normal 4/4 and CI=1 4/4 passed
- OpenAPI artifact SHA-256: f4503d249e5d1fa29c68904a79845d501070eff7251a7f05860366838ed3c605

## Compatibility
- direct multipart remains NONE; legacy v1 reader remains available
- writer format is rollback-configurable; migration is additive and nullable

Trellis task: 07-13-roadmap-p2-2-bounded-stream-download
