### PR TITLE
test: add direct upload load and fault gates

### DIFF
--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -3,29 +3,97 @@ name: Performance Smoke
 on:
   workflow_dispatch:
     inputs:
-      include_chunk_upload:
-        description: Include chunk-upload scenario in CI smoke
+      profile:
+        description: k6 execution profile
+        required: true
+        type: choice
+        options:
+          - smoke
+          - load
+        default: smoke
+      scenario:
+        description: k6 scenario
+        required: true
+        type: choice
+        options:
+          - direct-path
+          - all
+          - file-query
+          - core-mixed
+          - chunk-upload
+        default: direct-path
+      concurrency:
+        description: Smoke VUs or load arrival rate
+        required: true
+        type: string
+        default: "1"
+      duration:
+        description: Scenario duration, for example 60s or 3m
+        required: true
+        type: string
+        default: 60s
+      environment_fingerprint:
+        description: Stable target/runtime fingerprint; blank uses the masked target and runner facts
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
+      baseline_path:
+        description: Optional checked-out direct-path-baseline.json to compare
+        required: false
+        type: string
+        default: ""
+      resource_snapshot_path:
+        description: Optional same-origin resource snapshot path under BASE_URL
+        required: false
+        type: string
+        default: ""
+      lifecycle_snapshot_path:
+        description: Optional same-origin storage lifecycle snapshot path under BASE_URL
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 jobs:
   perf-smoke:
-    name: K6 Performance Smoke
+    name: K6 ${{ inputs.profile }} / ${{ inputs.scenario }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       BASE_URL: ${{ secrets.BASE_URL }}
       TENANT_ID: ${{ secrets.TENANT_ID }}
       USERNAME: ${{ secrets.USERNAME }}
       PASSWORD: ${{ secrets.PASSWORD }}
+      K6_DOCKER_IMAGE: grafana/k6@sha256:8cd78f9d0de5f50bc8821cceecf356d5d9e839e6611c226a3fcf13c591080fbd
+      CLEANUP: "true"
+      ENVIRONMENT_FINGERPRINT: ${{ inputs.environment_fingerprint }}
+      SMOKE_FILE_QUERY_VUS: ${{ inputs.concurrency }}
+      SMOKE_CORE_MIXED_VUS: ${{ inputs.concurrency }}
+      SMOKE_CHUNK_UPLOAD_VUS: ${{ inputs.concurrency }}
+      SMOKE_DIRECT_PATH_VUS: ${{ inputs.concurrency }}
+      QUERY_RATE: ${{ inputs.concurrency }}
+      UPLOAD_RATE: ${{ inputs.concurrency }}
+      DIRECT_PATH_RATE: ${{ inputs.concurrency }}
+      SMOKE_FILE_QUERY_DURATION: ${{ inputs.duration }}
+      SMOKE_CORE_MIXED_DURATION: ${{ inputs.duration }}
+      SMOKE_CHUNK_UPLOAD_DURATION: ${{ inputs.duration }}
+      SMOKE_DIRECT_PATH_DURATION: ${{ inputs.duration }}
+      QUERY_DURATION: ${{ inputs.duration }}
+      UPLOAD_DURATION: ${{ inputs.duration }}
+      DIRECT_PATH_DURATION: ${{ inputs.duration }}
+      DIRECT_RESOURCE_SNAPSHOT_PATH: ${{ inputs.resource_snapshot_path }}
+      DIRECT_LIFECYCLE_SNAPSHOT_PATH: ${{ inputs.lifecycle_snapshot_path }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Validate required secrets
+      - name: Validate required secrets and inputs
+        shell: bash
+        env:
+          INPUT_CONCURRENCY: ${{ inputs.concurrency }}
+          INPUT_DURATION: ${{ inputs.duration }}
         run: |
           missing=0
           for name in BASE_URL TENANT_ID USERNAME PASSWORD; do
@@ -34,11 +102,20 @@ jobs:
               missing=1
             fi
           done
+          if ! [[ "$INPUT_CONCURRENCY" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::concurrency must be a positive integer"
+            missing=1
+          fi
+          if ! [[ "$INPUT_DURATION" =~ ^[1-9][0-9]*(ms|s|m|h)$ ]]; then
+            echo "::error::duration must use a positive k6 duration such as 60s or 3m"
+            missing=1
+          fi
           if [ "$missing" -ne 0 ]; then
             exit 1
           fi
 
       - name: Prepare run context
+        shell: bash
         run: |
           RUN_ID="gh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(date +%Y%m%d%H%M%S)"
           RESULT_DIR="tools/k6/results/${RUN_ID}"
@@ -46,35 +123,61 @@ jobs:
           echo "RUN_ID=$RUN_ID" >> "$GITHUB_ENV"
           echo "RESULT_DIR=$RESULT_DIR" >> "$GITHUB_ENV"
 
-      - name: Resolve CI include chunk flag
+      - name: Run digest-pinned k6 profile
+        shell: bash
         run: |
-          INCLUDE_CHUNK=false
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.include_chunk_upload }}" = "true" ]; then
-            INCLUDE_CHUNK=true
-          fi
-          echo "CI_INCLUDE_CHUNK=$INCLUDE_CHUNK" >> "$GITHUB_ENV"
+          bash tools/k6/run-local.sh \
+            --profile "${{ inputs.profile }}" \
+            --scenario "${{ inputs.scenario }}" \
+            --engine docker \
+            --run-id "$RUN_ID" \
+            --result-dir "$RESULT_DIR"
 
-      - name: Run k6 CI smoke suite
+      - name: Validate direct-path evidence
+        if: ${{ inputs.scenario == 'direct-path' || (inputs.scenario == 'all' && inputs.profile == 'load') }}
+        shell: bash
         run: |
-          docker run --rm \
-            -v "$PWD:/workspace" \
-            -w /workspace \
-            -e BASE_URL="$BASE_URL" \
-            -e TENANT_ID="$TENANT_ID" \
-            -e USERNAME="$USERNAME" \
-            -e PASSWORD="$PASSWORD" \
-            -e K6_PROFILE="smoke" \
-            -e K6_SCENARIO="all" \
-            -e CI_INCLUDE_CHUNK="$CI_INCLUDE_CHUNK" \
-            -e RUN_ID="$RUN_ID" \
-            -e RESULT_DIR="$RESULT_DIR" \
-            grafana/k6:0.49.0 \
-            run tools/k6/suites/ci-smoke.js
+          node - "$RESULT_DIR/direct-path-baseline.json" "$RESULT_DIR/direct-path-report.md" <<'NODE'
+          const fs = require('node:fs');
+          const [baselinePath, reportPath] = process.argv.slice(2);
+          if (!fs.existsSync(baselinePath) || !fs.existsSync(reportPath)) {
+            throw new Error('direct-path baseline/report artifact is missing');
+          }
+          const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+          if (baseline.evidence?.valid !== true) {
+            throw new Error(`direct-path evidence is incomplete: ${JSON.stringify(baseline.evidence)}`);
+          }
+          if (baseline.failure.flowRate !== 0 || baseline.failure.cleanupRate !== 0) {
+            throw new Error(`direct-path failure rates must be zero: ${JSON.stringify(baseline.failure)}`);
+          }
+          if (!baseline.environment?.fingerprint) {
+            throw new Error('environment fingerprint is missing');
+          }
+          for (const name of ['resourceSnapshot', 'lifecycleSnapshot']) {
+            for (const stage of ['start', 'end']) {
+              if (!['available', 'unavailable'].includes(baseline[name]?.[stage]?.status)) {
+                throw new Error(`${name}.${stage} availability must be explicit`);
+              }
+            }
+          }
+          NODE
+
+      - name: Compare same-environment baseline
+        if: ${{ inputs.baseline_path != '' && (inputs.scenario == 'direct-path' || (inputs.scenario == 'all' && inputs.profile == 'load')) }}
+        shell: bash
+        env:
+          BASELINE_PATH: ${{ inputs.baseline_path }}
+        run: |
+          test -f "$BASELINE_PATH"
+          node tools/k6/scripts/compare-direct-baseline.mjs \
+            --baseline "$BASELINE_PATH" \
+            --candidate "$RESULT_DIR/direct-path-baseline.json" \
+            --output "$RESULT_DIR/direct-path-comparison.md"
 
       - name: Upload performance artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
-          name: perf-smoke-${{ env.RUN_ID }}
+          name: perf-${{ inputs.profile }}-${{ inputs.scenario }}-${{ env.RUN_ID }}
           path: ${{ env.RESULT_DIR }}
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,6 +388,49 @@ jobs:
       - name: Run Storage Tests and MinIO Provider Contracts
         run: mvn -f platform-storage/pom.xml clean verify -Pit
 
+      - name: Require Direct Upload Fault Matrix and Load Smoke Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          required_suites = {
+              "cn.flying.storage.service.DirectUploadFaultMatrixMinioIT": 9,
+              "cn.flying.storage.service.DirectUploadLoadSmokeIT": 1,
+          }
+
+          for class_name, expected_tests in required_suites.items():
+              report = Path(
+                  "platform-storage/target/failsafe-reports/"
+                  f"TEST-{class_name}.xml"
+              )
+              if not report.is_file():
+                  sys.exit(f"Missing required Failsafe report: {report}")
+
+              suite = ET.parse(report).getroot()
+              expected_counts = {
+                  "tests": expected_tests,
+                  "skipped": 0,
+                  "failures": 0,
+                  "errors": 0,
+              }
+              for name, expected in expected_counts.items():
+                  actual = int(suite.attrib.get(name, "-1"))
+                  if actual != expected:
+                      sys.exit(
+                          f"{class_name} {name}={actual}; expected {expected}"
+                      )
+          PY
+
+      - name: Upload Direct Upload Load Smoke Evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: direct-upload-load-smoke
+          path: platform-storage/target/direct-upload-load-smoke/
+          if-no-files-found: error
+
       - name: Require Direct Upload MinIO Provider Contract Execution
         run: |
           python3 - <<'PY'

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,11 +2,11 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试覆盖（128 test files: 90 backend + 6 storage + 32 frontend）
+## 当前核心测试覆盖（244 test files: 177 backend + 27 storage + 40 frontend）
 
-> 当前后端口径拆分：`backend-common=10`、`backend-service=29`、`backend-web=51`（合计 90）。
+> 统计口径为 `*Test.java` / `*IT.java` / `*.test.ts` 文件；当前后端拆分为 `backend-common=13`、`backend-api=1`、`backend-service=75`、`backend-web=88`（合计 177）。以下长表用于说明代表性覆盖，不作为完整文件清单。
 
-### 后端单元测试（backend-common，10 个测试类）
+### 后端单元测试（backend-common，代表性测试类）
 
 | 测试类 | 覆盖范围 |
 |--------|----------|
@@ -21,7 +21,7 @@
 | DistributedRateLimiterPerformanceTest | 限流性能基准 |
 | DistributedLockAspectTest | 分布式锁 AOP 切面 |
 
-### 后端单元测试（backend-service，29 个测试类）
+### 后端单元测试（backend-service，代表性测试类）
 
 | 测试类 | 覆盖范围 |
 |--------|----------|
@@ -56,7 +56,7 @@
 | QuotaRolloutAuditServiceImplTest | 配额灰度审计服务 |
 | IntegrityCheckServiceTest | 存储完整性校验（S3 存在性 + DB-链上哈希一致性） |
 
-### 后端测试（backend-web，51 个测试文件）
+### 后端测试（backend-web，代表性测试文件）
 
 #### 控制器集成测试
 
@@ -125,7 +125,7 @@
 | BaseControllerIntegrationTest | 控制器集成测试基类 |
 | OpenApiContractExportTest | OpenAPI 契约导出与稳定性校验 |
 
-### 前端测试（platform-frontend，32 个测试文件）
+### 前端测试（platform-frontend，代表性测试文件）
 
 #### API 层测试
 
@@ -268,6 +268,46 @@ mvn -f platform-storage/pom.xml test
 - **S3 客户端**: 使用 Mockito Mock `S3Client`
 - **Redis**: 使用内嵌 Redis 或 Mock `RedisTemplate`
 - **事件发布**: Mock `ApplicationEventPublisher`
+
+#### 直传真实故障矩阵与负载 smoke
+
+PR 的存储事实源不是外部部署环境，而是固定版本 Testcontainers：三套数据面独立的 MinIO、Redis/Redisson 与两条独立 Toxiproxy 路径。执行命令：
+
+```bash
+mvn -f platform-storage/pom.xml clean verify -Pit
+```
+
+CI 必须精确校验以下 Failsafe XML，`skipped/failures/errors` 均为 `0`：
+
+| 测试类 | tests | 责任 |
+|--------|------:|------|
+| `DirectUploadPromotionMinioIT` | 8 | copy/stream/CORS、degraded repair、dead letter、complete/abort/cleanup、receipt restart |
+| `DirectUploadRedisLifecycleIT` | 7 | 多客户端 receipt、fence、tombstone 生命周期 |
+| `DirectUploadFaultMatrixMinioIT` | 9 | F01-F06、F12-F14 的真实 provider/network 故障 |
+| `DirectUploadLoadSmokeIT` | 1 | 4 并发、8 次迭代、资源与 lifecycle 报告、零残留 |
+
+F07、F09-F11 复用既有真实 MinIO/Redis 测试和确定性 service tests，不重复创建慢测试；F08 在矩阵中通过真实 repair callback + Toxiproxy timeout 断言 `RETRYABLE_DEFERRED`。`DirectUploadFaultMatrixMinioIT` 类注释维护完整 F01-F14 traceability。
+
+`DirectUploadLoadSmokeIT` 产物：
+
+- `platform-storage/target/direct-upload-load-smoke/report.json`
+- `platform-storage/target/direct-upload-load-smoke/report.md`
+
+PR 硬门禁是零失败、零对象/Redis 残留、有界 deadline 与资源预算；吞吐和紧时延只记录，不作为共享 runner 的生产 SLA。96 MiB 对象 / 80 MiB heap 的对象级边界仍由以下独立 fork 证明：
+
+```bash
+mvn -f platform-storage/pom.xml verify -Pdirect-upload-constrained-heap
+```
+
+本机无 Docker 时，真实容器命令会因环境不可用而阻塞或失败，不能表述为真实 IT 已通过；GitHub Actions 的精确 XML 断言会阻止缺报告或 skip 被误报为成功。
+
+#### 手工真实部署 direct-path k6
+
+`.github/workflows/perf-smoke.yml` 是手工外部环境验证入口，默认执行 `direct-path/smoke`。它消费现有 REST/预签名合同，执行 direct create、无平台鉴权头的 raw PUT、ETag 提交、direct complete、manifest download metadata、raw GET size/hash 复核和按 `RUN_ID` 清理。
+
+该工作流使用 digest 固定的 k6 镜像并归档 `direct-path-baseline.json`、`direct-path-report.md`、原始 summary/metrics 与 `run-meta.json`。资源或 lifecycle 端点分别记录运行开始与清理后结束的 availability；未配置时必须显示 `unavailable`，不得填充伪造的零值。direct 套件关闭日志并禁用 `url`/`name` system tags，避免预签名查询参数进入 artifact。
+
+baseline 仅在 flow/cleanup 样本、完成文件、p95/p99、吞吐和失败率完整时有效；比较器还要求环境指纹、k6 引擎/digest、profile/scenario、分片规模、executor、并发、时长和 VU pool 一致。缺指标返回 `INVALID_EVIDENCE`，负载或环境不同返回 `NOT_COMPARABLE`。外部 secrets 不参与 PR required gate。
 
 ## 5. CI 执行策略
 

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -177,6 +177,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>toxiproxy</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
+++ b/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
@@ -207,7 +207,15 @@ class DirectUploadFaultMatrixMinioIT {
         stagingTracker = mock(DirectUploadStagingTracker.class);
         receiptStore = mock(DirectUploadPromotionReceiptStore.class);
         operationIntentStore = mock(DirectUploadOperationIntentStore.class);
-        operationIntent = mock(DirectUploadOperationIntentStore.OperationIntent.class);
+        operationIntent = new DirectUploadOperationIntentStore.OperationIntent(
+                "storage:direct-upload:operation-intent:v1:test",
+                "storage:direct-upload:operation-intent:v1:test:fence",
+                "v1|COMPLETE|" + "a".repeat(64) + "|" + "b".repeat(64),
+                DirectUploadOperationIntentStore.OperationMode.COMPLETE,
+                "a".repeat(64),
+                "b".repeat(64),
+                1L
+        );
         storageProperties = new StorageProperties();
         storageProperties.getReplication().setFactor(3);
         storageProperties.getReplication().setQuorum("2");
@@ -253,8 +261,12 @@ class DirectUploadFaultMatrixMinioIT {
                 for (S3Client client : caseClients) {
                     client.close();
                 }
-                executor.shutdownNow();
-                meterRegistry.close();
+                if (executor != null) {
+                    executor.shutdownNow();
+                }
+                if (meterRegistry != null) {
+                    meterRegistry.close();
+                }
             }
         }
     }

--- a/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
+++ b/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
@@ -269,7 +269,7 @@ class DirectUploadFaultMatrixMinioIT {
         String target = createBucket("f01-target");
         byte[] content = bytes("missing-staging");
         DirectUploadPartDescriptor part = descriptor(
-                "fault-f01", source, List.of(target), 1, "missing-etag", content, content.length, hash(content));
+                "fault-f01", source, List.of(target), 1, "missing-etag", content.length, hash(content));
         configureNode(source, directClient, endpoint(MINIO_A), "physical-source");
         configureNode(target, directClient, endpoint(MINIO_A), "physical-target");
 
@@ -465,7 +465,7 @@ class DirectUploadFaultMatrixMinioIT {
         String key = stagingKey("fault-f14");
         String etag = putObject(source, key, content);
         DirectUploadPartDescriptor part = descriptor(
-                "fault-f14", source, List.of(target), 1, etag, content, content.length, hash(content));
+                "fault-f14", source, List.of(target), 1, etag, content.length, hash(content));
         configureNode(source, directClient, endpoint(MINIO_A), "physical-source");
         configureNode(target, firstProxyClient, proxyEndpoint(firstProxy), "physical-target");
         storageProperties.getDirectUpload().setTransferTimeoutSeconds(1);
@@ -540,7 +540,6 @@ class DirectUploadFaultMatrixMinioIT {
                 List.of(target),
                 1,
                 declaredEtag == null ? providerEtag : declaredEtag,
-                content,
                 declaredSize,
                 declaredHash
         );
@@ -564,7 +563,6 @@ class DirectUploadFaultMatrixMinioIT {
                 List.of(source, firstTarget, secondTarget),
                 2,
                 etag,
-                content,
                 content.length,
                 hash(content)
         );
@@ -615,7 +613,6 @@ class DirectUploadFaultMatrixMinioIT {
             List<String> targets,
             int quorum,
             String etag,
-            byte[] content,
             long declaredSize,
             String declaredHash
     ) {

--- a/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
+++ b/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
@@ -287,7 +287,7 @@ class DirectUploadFaultMatrixMinioIT {
 
         assertThatThrownBy(() -> service().promote(part, DirectUploadDigestAccumulator.sha256()))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("staging is missing");
+                .hasMessageContaining("promotion receipt is required when trustworthy staging is unavailable");
 
         assertThat(objectExists(target, part.finalObjectName())).isFalse();
         verify(receiptStore, never()).recordSuccess(any(), any(), any());
@@ -350,14 +350,15 @@ class DirectUploadFaultMatrixMinioIT {
     }
 
     /**
-     * F05：三个独立目标中一个真实网络断连时，两个成功副本应满足原始 quorum 并留下降级证据。
+     * F05：三个独立目标中一个真实 TCP reset 时，两个成功副本应满足原始 quorum 并留下降级证据。
      */
     @Test
-    @DisplayName("F05 one disconnected target should keep exact quorum success and degraded evidence")
+    @DisplayName("F05 one reset target should keep exact quorum success and degraded evidence")
     void shouldSucceedAtExactQuorumWithOneDisconnectedTarget() throws Exception {
         byte[] content = bytes("exact-quorum");
         QuorumCase quorumCase = quorumCase("f05", content);
-        secondProxy.setConnectionCut(true);
+        secondProxy.toxics().resetPeer("f05-reset-upstream", ToxicDirection.UPSTREAM, 0L);
+        secondProxy.toxics().resetPeer("f05-reset-downstream", ToxicDirection.DOWNSTREAM, 0L);
 
         DirectUploadPromotionResult result = service().promote(
                 quorumCase.part(), DirectUploadDigestAccumulator.sha256());
@@ -392,7 +393,7 @@ class DirectUploadFaultMatrixMinioIT {
         assertThatThrownBy(() -> service().promote(
                 quorumCase.part(), DirectUploadDigestAccumulator.sha256()))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("quorum");
+                .hasMessageContaining("timed out");
 
         assertThat(objectExists(quorumCase.source(), quorumCase.part().stagingObjectName())).isTrue();
         verify(receiptStore, never()).recordSuccess(any(), any(), any());
@@ -487,7 +488,7 @@ class DirectUploadFaultMatrixMinioIT {
 
         assertThatThrownBy(() -> service().promote(part, DirectUploadDigestAccumulator.sha256()))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("quorum");
+                .hasMessageContaining("timed out");
 
         assertThat(Duration.ofNanos(System.nanoTime() - startedAt)).isLessThan(Duration.ofSeconds(6));
         assertThat(objectExists(source, key)).isTrue();

--- a/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
+++ b/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadFaultMatrixMinioIT.java
@@ -1,0 +1,833 @@
+package cn.flying.storage.service;
+
+import cn.flying.storage.config.NodeConfig;
+import cn.flying.storage.config.StorageProperties;
+import cn.flying.storage.core.FaultDomainManager;
+import cn.flying.storage.core.S3ClientManager;
+import cn.flying.storage.core.S3ClientManager.TopologyLease;
+import cn.flying.storage.core.S3Monitor;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.redisson.api.RedissonClient;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.containers.wait.strategy.Wait;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 使用固定 MinIO 与 Toxiproxy 验证 direct-upload 故障矩阵中的真实 provider 和网络边界。
+ *
+ * <p>矩阵追踪关系如下：</p>
+ * <ul>
+ *     <li>F01-F06、F12-F14：本类同编号测试。</li>
+ *     <li>F07：{@link DirectUploadPromotionMinioIT#shouldRecoverDegradedReplicaThroughRealRedisAndMinio()}。</li>
+ *     <li>F08：本类 F14 内的真实 repair callback timeout，及
+ *         {@link DirectUploadPromotionServiceTest#shouldTrackPartialQuorumAndKeepFailedRepairDurable()}。</li>
+ *     <li>F09：{@link DirectUploadPromotionMinioIT#shouldDeadLetterDeterministicContentMismatchThroughRealMinioAndRedis()}。</li>
+ *     <li>F10：{@link DirectUploadRedisLifecycleIT#shouldMergePromotionReceiptAcrossRealRedisClients()}
+ *         与 {@link DirectUploadPromotionMinioIT#shouldRetryFromReceiptAfterServiceRestart()}。</li>
+ *     <li>F11：{@link DirectUploadPromotionMinioIT#shouldSerializeCompleteAndAbortAcrossRealRedisLock()}
+ *         与 {@link DirectUploadPromotionMinioIT#shouldSerializeCompleteAndCleanupAcrossRealRedisLock()}。</li>
+ * </ul>
+ *
+ * <p>本类只补此前缺失的真实网络和 provider 证据，避免复制已有慢测。</p>
+ */
+@Testcontainers(disabledWithoutDocker = false)
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
+class DirectUploadFaultMatrixMinioIT {
+
+    private static final int MINIO_PORT = 9000;
+    private static final String ACCESS_KEY = "directupload";
+    private static final String SECRET_KEY = "directupload-secret-2026";
+    private static final String MINIO_IMAGE = "minio/minio:RELEASE.2024-11-07T00-52-20Z";
+    private static final String TOXIPROXY_IMAGE = "ghcr.io/shopify/toxiproxy:2.5.0";
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final GenericContainer<?> MINIO_A = minioContainer("fault-minio-a");
+
+    @Container
+    private static final GenericContainer<?> MINIO_B = minioContainer("fault-minio-b");
+
+    @Container
+    private static final GenericContainer<?> MINIO_C = minioContainer("fault-minio-c");
+
+    /**
+     * 创建具有独立数据卷和网络身份的固定版本 MinIO 容器。
+     */
+    private static GenericContainer<?> minioContainer(String networkAlias) {
+        return new GenericContainer<>(
+            DockerImageName.parse(MINIO_IMAGE))
+            .withNetwork(NETWORK)
+            .withNetworkAliases(networkAlias)
+            .withExposedPorts(MINIO_PORT)
+            .withEnv("MINIO_ROOT_USER", ACCESS_KEY)
+            .withEnv("MINIO_ROOT_PASSWORD", SECRET_KEY)
+            .withCommand("server", "/data")
+            .waitingFor(Wait.forHttp("/minio/health/ready")
+                    .forPort(MINIO_PORT)
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(90)));
+    }
+
+    @Container
+    private static final ToxiproxyContainer TOXIPROXY = new ToxiproxyContainer(
+            DockerImageName.parse(TOXIPROXY_IMAGE)
+                    .asCompatibleSubstituteFor("shopify/toxiproxy"))
+            .withNetwork(NETWORK);
+
+    private static S3Client directClient;
+    private static S3Client directBClient;
+    private static S3Client directCClient;
+    private static ToxiproxyContainer.ContainerProxy firstProxy;
+    private static ToxiproxyContainer.ContainerProxy secondProxy;
+
+    private final Set<BucketResource> buckets = new LinkedHashSet<>();
+    private final List<S3Client> caseClients = new ArrayList<>();
+    private S3Client firstProxyClient;
+    private S3Client secondProxyClient;
+    private S3ClientManager clientManager;
+    private S3Monitor s3Monitor;
+    private ConsistencyRepairService repairService;
+    private DegradedWriteTracker degradedWriteTracker;
+    private DirectUploadLockManager lockManager;
+    private DirectUploadStagingTracker stagingTracker;
+    private DirectUploadPromotionReceiptStore receiptStore;
+    private DirectUploadOperationIntentStore operationIntentStore;
+    private DirectUploadOperationIntentStore.OperationIntent operationIntent;
+    private StorageProperties storageProperties;
+    private ExecutorService executor;
+    private SimpleMeterRegistry meterRegistry;
+
+    /**
+     * 创建直连和两个彼此独立的 Toxiproxy S3 客户端。
+     */
+    @BeforeAll
+    static void createProviderClients() {
+        directClient = s3Client(endpoint(MINIO_A));
+        directBClient = s3Client(endpoint(MINIO_B));
+        directCClient = s3Client(endpoint(MINIO_C));
+        firstProxy = TOXIPROXY.getProxy("fault-minio-b", MINIO_PORT);
+        secondProxy = TOXIPROXY.getProxy("fault-minio-c", MINIO_PORT);
+    }
+
+    /**
+     * 关闭共享 provider 客户端。
+     */
+    @AfterAll
+    static void closeProviderClients() {
+        if (directClient != null) {
+            directClient.close();
+        }
+        if (directBClient != null) {
+            directBClient.close();
+        }
+        if (directCClient != null) {
+            directCClient.close();
+        }
+    }
+
+    /**
+     * 为每个故障场景创建独立客户端、编排依赖和资源边界。
+     */
+    @BeforeEach
+    void setUp() {
+        firstProxy.setConnectionCut(false);
+        secondProxy.setConnectionCut(false);
+        firstProxyClient = s3Client(proxyEndpoint(firstProxy));
+        secondProxyClient = s3Client(proxyEndpoint(secondProxy));
+        caseClients.add(firstProxyClient);
+        caseClients.add(secondProxyClient);
+
+        clientManager = mock(S3ClientManager.class);
+        TopologyLease topologyLease = mock(TopologyLease.class);
+        s3Monitor = mock(S3Monitor.class);
+        repairService = mock(ConsistencyRepairService.class);
+        degradedWriteTracker = mock(DegradedWriteTracker.class);
+        lockManager = mock(DirectUploadLockManager.class);
+        stagingTracker = mock(DirectUploadStagingTracker.class);
+        receiptStore = mock(DirectUploadPromotionReceiptStore.class);
+        operationIntentStore = mock(DirectUploadOperationIntentStore.class);
+        operationIntent = mock(DirectUploadOperationIntentStore.OperationIntent.class);
+        storageProperties = new StorageProperties();
+        storageProperties.getReplication().setFactor(3);
+        storageProperties.getReplication().setQuorum("2");
+        storageProperties.getDirectUpload().setStreamBufferBytes(8 * 1024);
+        storageProperties.getDirectUpload().setTransferTimeoutSeconds(3);
+        storageProperties.getDegradedWrite().setEnabled(true);
+        storageProperties.getDegradedWrite().setTrackForSync(true);
+        executor = Executors.newFixedThreadPool(4);
+        meterRegistry = new SimpleMeterRegistry();
+
+        when(clientManager.acquireTopologyLease()).thenReturn(topologyLease);
+        when(topologyLease.getClient(anyString())).thenAnswer(invocation ->
+                clientManager.getClient(invocation.getArgument(0)));
+        when(topologyLease.getNodeConfig(anyString())).thenAnswer(invocation ->
+                clientManager.getNodeConfig(invocation.getArgument(0)));
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(topologyLease).runIfCurrent(any(Runnable.class));
+        when(lockManager.acquire(any())).thenReturn(() -> { });
+        when(operationIntentStore.beginComplete(any())).thenReturn(operationIntent);
+        when(receiptStore.findValidated(any())).thenReturn(Optional.empty());
+        when(repairService.scheduleImmediateRepairByNodesAsync(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(false));
+    }
+
+    /**
+     * 清除 toxic、对象、测试桶和每个场景创建的客户端。
+     */
+    @AfterEach
+    void tearDown() throws IOException {
+        firstProxy.setConnectionCut(false);
+        secondProxy.setConnectionCut(false);
+        try {
+            removeAllToxics(firstProxy);
+        } finally {
+            try {
+                removeAllToxics(secondProxy);
+            } finally {
+                for (BucketResource bucket : buckets) {
+                    deleteBucket(bucket);
+                }
+                for (S3Client client : caseClients) {
+                    client.close();
+                }
+                executor.shutdownNow();
+                meterRegistry.close();
+            }
+        }
+    }
+
+    /**
+     * F01：public/sealed staging 与 receipt 均缺失时不得从残余状态推断成功。
+     */
+    @Test
+    @DisplayName("F01 missing staging and receipt should fail without final evidence")
+    void shouldFailWhenStagingAndReceiptAreMissing() throws Exception {
+        String source = createBucket("f01-source");
+        String target = createBucket("f01-target");
+        byte[] content = bytes("missing-staging");
+        DirectUploadPartDescriptor part = descriptor(
+                "fault-f01", source, List.of(target), 1, "missing-etag", content, content.length, hash(content));
+        configureNode(source, directClient, endpoint(MINIO_A), "physical-source");
+        configureNode(target, directClient, endpoint(MINIO_A), "physical-target");
+
+        assertThatThrownBy(() -> service().promote(part, DirectUploadDigestAccumulator.sha256()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("staging is missing");
+
+        assertThat(objectExists(target, part.finalObjectName())).isFalse();
+        verify(receiptStore, never()).recordSuccess(any(), any(), any());
+        verify(stagingTracker, never()).retainAfterDelete(any());
+    }
+
+    /**
+     * F02：真实 HEAD 大小与声明不一致时不得写入任何 final 副本。
+     */
+    @Test
+    @DisplayName("F02 staging size mismatch should retain source and publish no final object")
+    void shouldRejectStagingSizeMismatch() throws Exception {
+        byte[] content = bytes("size-mismatch");
+        FaultCase faultCase = singleTargetCase("f02", content, content.length + 1L, hash(content), null);
+
+        assertThatThrownBy(() -> service().promote(faultCase.part(), DirectUploadDigestAccumulator.sha256()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size mismatch");
+
+        assertThat(objectExists(faultCase.source(), faultCase.part().stagingObjectName())).isTrue();
+        assertThat(objectExists(faultCase.target(), faultCase.part().finalObjectName())).isFalse();
+        verify(receiptStore, never()).recordSuccess(any(), any(), any());
+    }
+
+    /**
+     * F03：真实 GET 内容的 SHA-256 与声明不同不得计入 quorum 或发布 receipt。
+     */
+    @Test
+    @DisplayName("F03 cipher hash mismatch should retain recovery evidence")
+    void shouldRejectCipherHashMismatch() throws Exception {
+        byte[] content = bytes("cipher-hash-real");
+        String wrongHash = hash(bytes("cipher-hash-fake"));
+        FaultCase faultCase = singleTargetCase("f03", content, content.length, wrongHash, null);
+
+        assertThatThrownBy(() -> service().promote(faultCase.part(), DirectUploadDigestAccumulator.sha256()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("checksum mismatch");
+
+        assertThat(objectExists(faultCase.source(), faultCase.part().stagingObjectName())).isTrue();
+        assertThat(objectExists(faultCase.target(), faultCase.part().finalObjectName())).isFalse();
+        verify(receiptStore, never()).recordSuccess(any(), any(), any());
+    }
+
+    /**
+     * F04：客户端提交的 ETag 与真实 HEAD 不一致时必须在 seal/final 前失败。
+     */
+    @Test
+    @DisplayName("F04 client ETag mismatch should fail before final publication")
+    void shouldRejectClientEtagMismatch() throws Exception {
+        byte[] content = bytes("etag-real");
+        FaultCase faultCase = singleTargetCase("f04", content, content.length, hash(content), "wrong-etag");
+
+        assertThatThrownBy(() -> service().promote(faultCase.part(), DirectUploadDigestAccumulator.sha256()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ETag mismatch");
+
+        assertThat(objectExists(faultCase.source(), faultCase.part().stagingObjectName())).isTrue();
+        assertThat(objectExists(faultCase.target(), faultCase.part().finalObjectName())).isFalse();
+        verify(receiptStore, never()).recordSuccess(any(), any(), any());
+    }
+
+    /**
+     * F05：三个独立目标中一个真实网络断连时，两个成功副本应满足原始 quorum 并留下降级证据。
+     */
+    @Test
+    @DisplayName("F05 one disconnected target should keep exact quorum success and degraded evidence")
+    void shouldSucceedAtExactQuorumWithOneDisconnectedTarget() throws Exception {
+        byte[] content = bytes("exact-quorum");
+        QuorumCase quorumCase = quorumCase("f05", content);
+        secondProxy.setConnectionCut(true);
+
+        DirectUploadPromotionResult result = service().promote(
+                quorumCase.part(), DirectUploadDigestAccumulator.sha256());
+
+        assertThat(result.size()).isEqualTo(content.length);
+        assertThat(objectExists(quorumCase.source(), quorumCase.part().finalObjectName())).isTrue();
+        assertThat(readObject(quorumCase.firstTarget(), quorumCase.part().finalObjectName()))
+                .containsExactly(content);
+        assertThat(objectExists(quorumCase.secondTarget(), quorumCase.part().finalObjectName())).isFalse();
+        verify(receiptStore).recordSuccess(
+                eq(quorumCase.part()),
+                argThat(nodes -> nodes.size() == 2
+                        && nodes.contains(quorumCase.source())
+                        && nodes.contains(quorumCase.firstTarget())),
+                eq(operationIntent));
+        verify(degradedWriteTracker).recordAuthoritativeDegradedWrite(
+                eq(quorumCase.part().cipherHash()), any(), eq(7L));
+        verify(stagingTracker).retainAfterDelete(quorumCase.part().stagingDescriptor());
+    }
+
+    /**
+     * F06：三个目标仅一个可达时必须失败并保留唯一 staging 恢复源。
+     */
+    @Test
+    @DisplayName("F06 two disconnected targets should fail below quorum and retain staging")
+    void shouldFailBelowQuorumWithTwoDisconnectedTargets() throws Exception {
+        byte[] content = bytes("below-quorum");
+        QuorumCase quorumCase = quorumCase("f06", content);
+        firstProxy.setConnectionCut(true);
+        secondProxy.setConnectionCut(true);
+
+        assertThatThrownBy(() -> service().promote(
+                quorumCase.part(), DirectUploadDigestAccumulator.sha256()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("quorum");
+
+        assertThat(objectExists(quorumCase.source(), quorumCase.part().stagingObjectName())).isTrue();
+        verify(receiptStore, never()).recordSuccess(any(), any(), any());
+        verify(stagingTracker, never()).retainAfterDelete(any());
+    }
+
+    /**
+     * F12：过期预签名 PUT URL 必须由真实 MinIO 拒绝且不产生可完成对象。
+     */
+    @Test
+    @DisplayName("F12 expired presigned PUT should be rejected by MinIO")
+    void shouldRejectExpiredPresignedPut() throws Exception {
+        String bucket = createBucket("f12-expired");
+        String key = "tenant/7/staging/direct-upload/fault-f12/part-0";
+        URI uploadUri;
+        try (S3Presigner presigner = s3Presigner(endpoint(MINIO_A))) {
+            uploadUri = presigner.presignPutObject(PutObjectPresignRequest.builder()
+                            .signatureDuration(Duration.ofSeconds(1))
+                            .putObjectRequest(PutObjectRequest.builder().bucket(bucket).key(key).build())
+                            .build())
+                    .url().toURI();
+        }
+        Thread.sleep(2_500L);
+
+        HttpResponse<Void> response = boundedHttpClient().send(
+                HttpRequest.newBuilder(uploadUri)
+                        .timeout(Duration.ofSeconds(5))
+                        .PUT(HttpRequest.BodyPublishers.ofByteArray(bytes("expired")))
+                        .build(),
+                HttpResponse.BodyHandlers.discarding());
+
+        assertThat(response.statusCode()).isIn(400, 403);
+        assertThat(objectExists(bucket, key)).isFalse();
+    }
+
+    /**
+     * F13：客户端上传中途断连不得留下可被 HEAD 当作完整分片的对象。
+     */
+    @Test
+    @DisplayName("F13 interrupted PUT should not publish a partial staging object")
+    void shouldDiscardInterruptedPresignedPut() throws Exception {
+        String bucket = createBucket(directBClient, "f13-interrupt");
+        String key = "tenant/7/staging/direct-upload/fault-f13/part-0";
+        firstProxy.toxics().limitData("f13-limit", ToxicDirection.UPSTREAM, 64 * 1024L);
+        URI uploadUri;
+        try (S3Presigner presigner = s3Presigner(proxyEndpoint(firstProxy))) {
+            uploadUri = presigner.presignPutObject(PutObjectPresignRequest.builder()
+                            .signatureDuration(Duration.ofMinutes(2))
+                            .putObjectRequest(PutObjectRequest.builder().bucket(bucket).key(key).build())
+                            .build())
+                    .url().toURI();
+        }
+        byte[] body = new byte[1024 * 1024];
+
+        boolean interrupted;
+        try {
+            HttpResponse<Void> response = boundedHttpClient().send(
+                    HttpRequest.newBuilder(uploadUri)
+                            .timeout(Duration.ofSeconds(5))
+                            .PUT(HttpRequest.BodyPublishers.ofByteArray(body))
+                            .build(),
+                    HttpResponse.BodyHandlers.discarding());
+            interrupted = response.statusCode() < 200 || response.statusCode() >= 300;
+        } catch (IOException expectedDisconnect) {
+            interrupted = true;
+        }
+
+        removeAllToxics(firstProxy);
+        assertThat(interrupted).isTrue();
+        awaitObjectMissing(directBClient, bucket, key, Duration.ofSeconds(5));
+    }
+
+    /**
+     * F14：provider HEAD/GET/PUT 延迟超过传输预算时必须有界失败并保留 staging。
+     */
+    @Test
+    @DisplayName("F14 storage timeout should fail within deadline and retain staging")
+    void shouldFailStorageTimeoutWithinDeadline() throws Exception {
+        byte[] content = bytes("storage-timeout");
+        String source = createBucket("f14-source");
+        String target = createBucket(directBClient, "f14-target");
+        String key = stagingKey("fault-f14");
+        String etag = putObject(source, key, content);
+        DirectUploadPartDescriptor part = descriptor(
+                "fault-f14", source, List.of(target), 1, etag, content, content.length, hash(content));
+        configureNode(source, directClient, endpoint(MINIO_A), "physical-source");
+        configureNode(target, firstProxyClient, proxyEndpoint(firstProxy), "physical-target");
+        storageProperties.getDirectUpload().setTransferTimeoutSeconds(1);
+        firstProxy.toxics().latency("f14-upstream", ToxicDirection.UPSTREAM, 1_500L);
+        firstProxy.toxics().latency("f14-downstream", ToxicDirection.DOWNSTREAM, 1_500L);
+        long startedAt = System.nanoTime();
+
+        assertThatThrownBy(() -> service().promote(part, DirectUploadDigestAccumulator.sha256()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("quorum");
+
+        assertThat(Duration.ofNanos(System.nanoTime() - startedAt)).isLessThan(Duration.ofSeconds(6));
+        assertThat(objectExists(source, key)).isTrue();
+        verify(receiptStore, never()).recordSuccess(any(), any(), any());
+
+        removeAllToxics(firstProxy);
+        shouldDeferRealRepairAfterNetworkTimeout();
+    }
+
+    /**
+     * F08：真实一致性修复经过 Toxiproxy 超时后必须返回可重试延后语义且不发布目标副本。
+     */
+    private void shouldDeferRealRepairAfterNetworkTimeout() throws Exception {
+        byte[] content = bytes("repair-timeout");
+        String source = createBucket("f08-source");
+        String target = createBucket(directBClient, "f08-target");
+        String objectName = "tenant/7/" + hash(content);
+        putObject(source, objectName, content);
+        configureNode(source, directClient, endpoint(MINIO_A), "physical-f08-source");
+        configureNode(target, firstProxyClient, proxyEndpoint(firstProxy), "physical-f08-target");
+        storageProperties.getDegradedWrite().setRepairTimeoutSeconds(1);
+        FaultDomainManager faultDomainManager = mock(FaultDomainManager.class);
+        when(faultDomainManager.areNodesOnIndependentPhysicalStorage(source, target)).thenReturn(true);
+        ConsistencyRepairService realRepair = new ConsistencyRepairService();
+        ReflectionTestUtils.setField(realRepair, "clientManager", clientManager);
+        ReflectionTestUtils.setField(realRepair, "s3Monitor", s3Monitor);
+        ReflectionTestUtils.setField(realRepair, "faultDomainManager", faultDomainManager);
+        ReflectionTestUtils.setField(realRepair, "redissonClient", mock(RedissonClient.class));
+        ReflectionTestUtils.setField(realRepair, "storageProperties", storageProperties);
+        firstProxy.toxics().latency("f08-upstream", ToxicDirection.UPSTREAM, 1_500L);
+        firstProxy.toxics().latency("f08-downstream", ToxicDirection.DOWNSTREAM, 1_500L);
+        long startedAt = System.nanoTime();
+
+        ConsistencyRepairService.ImmediateRepairResult result = realRepair
+                .scheduleImmediateRepairByNodesDetailedAsync(objectName, source, target)
+                .get(5, TimeUnit.SECONDS);
+
+        assertThat(result.status())
+                .isEqualTo(ConsistencyRepairService.ImmediateRepairStatus.RETRYABLE_DEFERRED);
+        assertThat(Duration.ofNanos(System.nanoTime() - startedAt)).isLessThan(Duration.ofSeconds(5));
+        removeAllToxics(firstProxy);
+        assertThat(objectExists(directBClient, target, objectName)).isFalse();
+    }
+
+    /**
+     * 构建单目标真实 MinIO 校验场景。
+     */
+    private FaultCase singleTargetCase(
+            String caseId,
+            byte[] content,
+            long declaredSize,
+            String declaredHash,
+            String declaredEtag
+    ) throws Exception {
+        String source = createBucket(caseId + "-source");
+        String target = createBucket(caseId + "-target");
+        String key = stagingKey("fault-" + caseId);
+        String providerEtag = putObject(source, key, content);
+        DirectUploadPartDescriptor part = descriptor(
+                "fault-" + caseId,
+                source,
+                List.of(target),
+                1,
+                declaredEtag == null ? providerEtag : declaredEtag,
+                content,
+                declaredSize,
+                declaredHash
+        );
+        configureNode(source, directClient, endpoint(MINIO_A), "physical-" + caseId + "-source");
+        configureNode(target, directClient, endpoint(MINIO_A), "physical-" + caseId + "-target");
+        return new FaultCase(source, target, part);
+    }
+
+    /**
+     * 构建三个逻辑独立目标、其中两个经过独立网络代理的 quorum 场景。
+     */
+    private QuorumCase quorumCase(String caseId, byte[] content) throws Exception {
+        String source = createBucket(caseId + "-source");
+        String firstTarget = createBucket(directBClient, caseId + "-target-b");
+        String secondTarget = createBucket(directCClient, caseId + "-target-c");
+        String sessionId = "fault-" + caseId;
+        String etag = putObject(source, stagingKey(sessionId), content);
+        DirectUploadPartDescriptor part = descriptor(
+                sessionId,
+                source,
+                List.of(source, firstTarget, secondTarget),
+                2,
+                etag,
+                content,
+                content.length,
+                hash(content)
+        );
+        configureNode(source, directClient, endpoint(MINIO_A), "physical-" + caseId + "-a");
+        configureNode(firstTarget, firstProxyClient, proxyEndpoint(firstProxy), "physical-" + caseId + "-b");
+        configureNode(secondTarget, secondProxyClient, proxyEndpoint(secondProxy), "physical-" + caseId + "-c");
+        return new QuorumCase(source, firstTarget, secondTarget, part);
+    }
+
+    /**
+     * 构建使用真实 S3 客户端和受控 lifecycle 依赖的生产提升服务。
+     */
+    private DirectUploadPromotionService service() {
+        return new DirectUploadPromotionService(
+                clientManager,
+                s3Monitor,
+                storageProperties,
+                repairService,
+                degradedWriteTracker,
+                lockManager,
+                stagingTracker,
+                receiptStore,
+                operationIntentStore,
+                executor,
+                meterRegistry
+        );
+    }
+
+    /**
+     * 建立节点到客户端、endpoint 和独立物理存储身份的映射。
+     */
+    private void configureNode(String node, S3Client client, String nodeEndpoint, String physicalStorageId) {
+        when(clientManager.getClient(node)).thenReturn(client);
+        NodeConfig nodeConfig = new NodeConfig();
+        nodeConfig.setName(node);
+        nodeConfig.setEndpoint(nodeEndpoint);
+        nodeConfig.setPhysicalStorageId(physicalStorageId);
+        when(clientManager.getNodeConfig(node)).thenReturn(nodeConfig);
+        when(s3Monitor.isNodeOnline(node)).thenReturn(true);
+    }
+
+    /**
+     * 构建合法的 direct-upload 分片描述。
+     */
+    private DirectUploadPartDescriptor descriptor(
+            String sessionId,
+            String source,
+            List<String> targets,
+            int quorum,
+            String etag,
+            byte[] content,
+            long declaredSize,
+            String declaredHash
+    ) {
+        return new DirectUploadPartDescriptor(
+                7L,
+                sessionId,
+                0,
+                source,
+                stagingKey(sessionId),
+                "tenant/7/" + declaredHash,
+                declaredSize,
+                etag,
+                declaredHash,
+                declaredHash,
+                "SHA-256",
+                targets,
+                quorum
+        );
+    }
+
+    /**
+     * 创建当前场景独占的测试桶。
+     */
+    private String createBucket(String bucket) {
+        return createBucket(directClient, bucket);
+    }
+
+    /**
+     * 在指定独立 provider 上创建场景专属桶并登记精确清理身份。
+     */
+    private String createBucket(S3Client client, String bucket) {
+        client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        buckets.add(new BucketResource(client, bucket));
+        return bucket;
+    }
+
+    /**
+     * 写入一个真实 staging 对象并返回 provider ETag。
+     */
+    private String putObject(String bucket, String key, byte[] content) {
+        return directClient.putObject(
+                PutObjectRequest.builder().bucket(bucket).key(key).build(),
+                RequestBody.fromBytes(content)
+        ).eTag();
+    }
+
+    /**
+     * 读取一个测试对象的小型内容。
+     */
+    private byte[] readObject(String bucket, String key) {
+        S3Client client = buckets.stream()
+                .filter(resource -> resource.bucket().equals(bucket))
+                .map(BucketResource::client)
+                .findFirst()
+                .orElseThrow();
+        return client.getObjectAsBytes(
+                GetObjectRequest.builder().bucket(bucket).key(key).build()).asByteArray();
+    }
+
+    /**
+     * 判断真实 provider 中指定对象是否存在。
+     */
+    private boolean objectExists(String bucket, String key) {
+        S3Client client = buckets.stream()
+                .filter(resource -> resource.bucket().equals(bucket))
+                .map(BucketResource::client)
+                .findFirst()
+                .orElseThrow();
+        return objectExists(client, bucket, key);
+    }
+
+    /**
+     * 判断指定独立 provider 中的对象是否存在。
+     */
+    private boolean objectExists(S3Client client, String bucket, String key) {
+        try {
+            client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            return true;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * 删除当前场景在测试桶中创建的全部对象并删除桶。
+     */
+    private void deleteBucket(BucketResource resource) {
+        S3Client client = resource.client();
+        String bucket = resource.bucket();
+        client.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).build())
+                .contents()
+                .forEach(object -> client.deleteObject(DeleteObjectRequest.builder()
+                        .bucket(bucket).key(object.key()).build()));
+        client.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+    }
+
+    /**
+     * 在有限时间内等待中断上传的 provider 临时状态完成回滚。
+     */
+    private void awaitObjectMissing(S3Client client, String bucket, String key, Duration timeout)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (objectExists(client, bucket, key) && System.nanoTime() < deadline) {
+            Thread.sleep(50L);
+        }
+        assertThat(objectExists(client, bucket, key)).isFalse();
+    }
+
+    /**
+     * 删除代理上的全部 toxic，保证场景间网络状态隔离。
+     */
+    private static void removeAllToxics(ToxiproxyContainer.ContainerProxy proxy) throws IOException {
+        for (var toxic : proxy.toxics().getAll()) {
+            toxic.remove();
+        }
+    }
+
+    /**
+     * 返回规范 staging object key。
+     */
+    private static String stagingKey(String sessionId) {
+        return "tenant/7/staging/direct-upload/" + sessionId + "/part-0";
+    }
+
+    /**
+     * 计算 direct-upload 合同使用的 SHA-256 内容地址。
+     */
+    private static String hash(byte[] content) throws Exception {
+        return "sha256:" + HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(content));
+    }
+
+    /**
+     * 创建确定性的 UTF-8 测试字节。
+     */
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 返回容器映射到宿主机的 endpoint。
+     */
+    private static String endpoint(GenericContainer<?> container) {
+        return "http://" + container.getHost() + ":" + container.getMappedPort(MINIO_PORT);
+    }
+
+    /**
+     * 返回 Toxiproxy 映射到宿主机的 endpoint。
+     */
+    private static String proxyEndpoint(ToxiproxyContainer.ContainerProxy proxy) {
+        return "http://" + proxy.getContainerIpAddress() + ":" + proxy.getProxyPort();
+    }
+
+    /**
+     * 创建带短连接和 socket 上界的 path-style MinIO 客户端。
+     */
+    private static S3Client s3Client(String endpoint) {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .httpClientBuilder(ApacheHttpClient.builder()
+                        .connectionTimeout(Duration.ofSeconds(2))
+                        .socketTimeout(Duration.ofSeconds(3)))
+                .build();
+    }
+
+    /**
+     * 创建与真实 direct-upload 一致的 path-style 预签名客户端。
+     */
+    private static S3Presigner s3Presigner(String endpoint) {
+        return S3Presigner.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .build();
+    }
+
+    /**
+     * 创建具有连接上界的 JDK HTTP 客户端，避免预签名故障场景无限等待连接。
+     */
+    private static HttpClient boundedHttpClient() {
+        return HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+    }
+
+    /**
+     * 保存单目标故障场景的 provider 身份。
+     */
+    private record FaultCase(String source, String target, DirectUploadPartDescriptor part) {
+    }
+
+    /**
+     * 保存三目标 quorum 故障场景的 provider 身份。
+     */
+    private record QuorumCase(
+            String source,
+            String firstTarget,
+            String secondTarget,
+            DirectUploadPartDescriptor part
+    ) {
+    }
+
+    /**
+     * 保存测试桶所属的精确 provider 身份，避免跨 provider 或全局清理。
+     */
+    private record BucketResource(S3Client client, String bucket) {
+    }
+}

--- a/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadLoadSmokeIT.java
+++ b/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadLoadSmokeIT.java
@@ -1,0 +1,897 @@
+package cn.flying.storage.service;
+
+import cn.flying.storage.config.NodeConfig;
+import cn.flying.storage.config.StorageProperties;
+import cn.flying.storage.core.S3ClientManager;
+import cn.flying.storage.core.S3ClientManager.TopologyLease;
+import cn.flying.storage.core.S3Monitor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.ThreadMXBean;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 使用固定 MinIO、真实 Redis 和小型并发负载验证 direct-upload 提升资源与清理边界。
+ */
+@Testcontainers(disabledWithoutDocker = false)
+@Timeout(value = 75, unit = TimeUnit.SECONDS)
+class DirectUploadLoadSmokeIT {
+
+    private static final int MINIO_PORT = 9000;
+    private static final int REDIS_PORT = 6379;
+    private static final int ITERATIONS = 8;
+    private static final int CONCURRENCY = 4;
+    private static final int PART_BYTES = 256 * 1024;
+    private static final String ACCESS_KEY = "directupload";
+    private static final String SECRET_KEY = "directupload-secret-2026";
+    private static final String MINIO_IMAGE = "minio/minio:RELEASE.2024-11-07T00-52-20Z";
+    private static final String REDIS_IMAGE = "redis:7.4.9-alpine";
+    private static final String SOURCE_BUCKET = "direct-load-source";
+    private static final String TARGET_BUCKET = "direct-load-target";
+    private static final String RECEIPT_KEY_PATTERN = "storage:direct-upload:promotion-receipt:v1:*";
+    private static final String EXPIRY_SET_KEY = "storage:direct-upload:staging-expiry";
+
+    @Container
+    private static final GenericContainer<?> MINIO = new GenericContainer<>(
+            DockerImageName.parse(MINIO_IMAGE))
+            .withExposedPorts(MINIO_PORT)
+            .withEnv("MINIO_ROOT_USER", ACCESS_KEY)
+            .withEnv("MINIO_ROOT_PASSWORD", SECRET_KEY)
+            .withCommand("server", "/data")
+            .waitingFor(Wait.forHttp("/minio/health/ready")
+                    .forPort(MINIO_PORT)
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofSeconds(90)));
+
+    @Container
+    private static final GenericContainer<?> REDIS = new GenericContainer<>(
+            DockerImageName.parse(REDIS_IMAGE))
+            .withExposedPorts(REDIS_PORT)
+            .waitingFor(Wait.forListeningPort());
+
+    private static S3Client minioClient;
+    private static LettuceConnectionFactory redisConnectionFactory;
+    private static StringRedisTemplate redisTemplate;
+    private static RedissonClient redissonClient;
+
+    private StorageProperties storageProperties;
+    private S3ClientManager clientManager;
+    private S3Monitor s3Monitor;
+    private ConsistencyRepairService repairService;
+    private DegradedWriteTracker degradedWriteTracker;
+    private DirectUploadPromotionService promotionService;
+    private ExecutorService promotionExecutor;
+    private SimpleMeterRegistry meterRegistry;
+
+    /**
+     * 创建真实 MinIO 与 Redis 客户端。
+     */
+    @BeforeAll
+    static void createClients() {
+        minioClient = s3Client(endpoint(MINIO));
+        redisConnectionFactory = new LettuceConnectionFactory(
+                new RedisStandaloneConfiguration(REDIS.getHost(), REDIS.getMappedPort(REDIS_PORT)));
+        redisConnectionFactory.afterPropertiesSet();
+        redisConnectionFactory.start();
+        redisTemplate = new StringRedisTemplate(redisConnectionFactory);
+        redisTemplate.afterPropertiesSet();
+
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + REDIS.getHost() + ":" + REDIS.getMappedPort(REDIS_PORT))
+                .setConnectionMinimumIdleSize(1)
+                .setConnectionPoolSize(8)
+                .setSubscriptionConnectionMinimumIdleSize(1)
+                .setSubscriptionConnectionPoolSize(2);
+        redissonClient = Redisson.create(config);
+    }
+
+    /**
+     * 关闭共享 provider 和 Redis 客户端。
+     */
+    @AfterAll
+    static void closeClients() {
+        if (minioClient != null) {
+            minioClient.close();
+        }
+        if (redissonClient != null) {
+            redissonClient.shutdown();
+        }
+        if (redisConnectionFactory != null) {
+            redisConnectionFactory.destroy();
+        }
+    }
+
+    /**
+     * 创建真实 lifecycle 依赖和单副本 direct-upload 提升服务。
+     */
+    @BeforeEach
+    void setUp() {
+        flushRedis();
+        createBucket(SOURCE_BUCKET);
+        createBucket(TARGET_BUCKET);
+        storageProperties = new StorageProperties();
+        storageProperties.getReplication().setFactor(1);
+        storageProperties.getReplication().setQuorum("1");
+        storageProperties.getDirectUpload().setStreamBufferBytes(8 * 1024);
+        storageProperties.getDirectUpload().setTransferTimeoutSeconds(15);
+
+        clientManager = mock(S3ClientManager.class);
+        TopologyLease topologyLease = mock(TopologyLease.class);
+        s3Monitor = mock(S3Monitor.class);
+        repairService = mock(ConsistencyRepairService.class);
+        degradedWriteTracker = mock(DegradedWriteTracker.class);
+        when(clientManager.acquireTopologyLease()).thenReturn(topologyLease);
+        when(topologyLease.getClient(anyString())).thenAnswer(invocation ->
+                clientManager.getClient(invocation.getArgument(0)));
+        when(topologyLease.getNodeConfig(anyString())).thenAnswer(invocation ->
+                clientManager.getNodeConfig(invocation.getArgument(0)));
+        doAnswer(invocation -> {
+            invocation.<Runnable>getArgument(0).run();
+            return null;
+        }).when(topologyLease).runIfCurrent(any(Runnable.class));
+        configureNode(SOURCE_BUCKET, "physical-load-source");
+        configureNode(TARGET_BUCKET, "physical-load-target");
+
+        DirectUploadOperationIntentStore operationIntentStore =
+                new DirectUploadOperationIntentStore(redisTemplate);
+        DirectUploadLockManager lockManager =
+                new DirectUploadLockManager(redissonClient, storageProperties);
+        DirectUploadStagingTracker stagingTracker = new DirectUploadStagingTracker(
+                redisTemplate, storageProperties, lockManager, operationIntentStore);
+        DirectUploadPromotionReceiptStore receiptStore = new DirectUploadPromotionReceiptStore(
+                redisTemplate, new ObjectMapper(), storageProperties);
+        promotionExecutor = Executors.newFixedThreadPool(CONCURRENCY);
+        meterRegistry = new SimpleMeterRegistry();
+        promotionService = new DirectUploadPromotionService(
+                clientManager,
+                s3Monitor,
+                storageProperties,
+                repairService,
+                degradedWriteTracker,
+                lockManager,
+                stagingTracker,
+                receiptStore,
+                operationIntentStore,
+                promotionExecutor,
+                meterRegistry
+        );
+    }
+
+    /**
+     * 回收当前 smoke 的对象、桶、Redis 数据和执行器。
+     */
+    @AfterEach
+    void tearDown() {
+        deleteBucket(SOURCE_BUCKET);
+        deleteBucket(TARGET_BUCKET);
+        flushRedis();
+        promotionExecutor.shutdownNow();
+        meterRegistry.close();
+    }
+
+    /**
+     * 并发提升固定小分片，记录延迟、吞吐、JVM 资源、lifecycle 和清理证据。
+     */
+    @Test
+    @DisplayName("concurrent direct-upload load smoke should remain bounded and leave no run residual")
+    void shouldProduceBoundedLoadSmokeReport() throws Exception {
+        List<LoadInput> inputs = prepareInputs();
+        ResourceSampler sampler = new ResourceSampler();
+        ExecutorService callers = Executors.newFixedThreadPool(CONCURRENCY);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<LoadResult>> futures = new ArrayList<>();
+        for (LoadInput input : inputs) {
+            futures.add(callers.submit(promotionTask(input, start)));
+        }
+
+        sampler.start();
+        long startedAt = System.nanoTime();
+        start.countDown();
+        List<LoadResult> results = new ArrayList<>();
+        long deadlineNanos = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        try {
+            for (Future<LoadResult> future : futures) {
+                long remainingNanos = Math.max(1L, deadlineNanos - System.nanoTime());
+                results.add(future.get(remainingNanos, TimeUnit.NANOSECONDS));
+            }
+        } finally {
+            callers.shutdownNow();
+            assertThat(callers.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+            sampler.close();
+        }
+        long wallNanos = System.nanoTime() - startedAt;
+
+        assertSuccessfulResults(inputs, results);
+        long receiptCountBeforeCleanup = countReceiptKeys();
+        Long tombstoneCountBeforeCleanup = redisTemplate.opsForZSet().zCard(EXPIRY_SET_KEY);
+        assertThat(receiptCountBeforeCleanup).isEqualTo(ITERATIONS);
+        assertThat(tombstoneCountBeforeCleanup).isEqualTo(ITERATIONS);
+        verify(degradedWriteTracker, never()).recordAuthoritativeDegradedWrite(any(), any(), any());
+        verify(repairService, never()).scheduleImmediateRepairByNodesAsync(any(), any(), any());
+
+        cleanupRun(inputs);
+        long receiptCountAfterCleanup = countReceiptKeys();
+        Long tombstoneCountAfterCleanup = redisTemplate.opsForZSet().zCard(EXPIRY_SET_KEY);
+        ResourceSnapshot resource = sampler.snapshot();
+        LoadSmokeReport report = buildReport(
+                results,
+                wallNanos,
+                resource,
+                receiptCountBeforeCleanup,
+                tombstoneCountBeforeCleanup,
+                receiptCountAfterCleanup,
+                tombstoneCountAfterCleanup
+        );
+        writeReport(report);
+
+        assertThat(report.failures()).isZero();
+        assertThat(report.cleanupSuccess()).isTrue();
+        assertThat(report.p99Millis()).isLessThan(30_000D);
+        assertThat(report.resource().heapPeakDeltaBytes()).isLessThan(96L * 1024 * 1024);
+        assertThat(report.resource().directBufferAvailable()).isTrue();
+        assertThat(report.resource().directBufferPeakDeltaBytes()).isLessThan(64L * 1024 * 1024);
+        assertThat(report.resource().threadPeakDelta()).isLessThan(64);
+    }
+
+    /**
+     * 创建每次迭代唯一的 staging 内容、hash 和描述。
+     */
+    private List<LoadInput> prepareInputs() throws Exception {
+        List<LoadInput> inputs = new ArrayList<>();
+        for (int index = 0; index < ITERATIONS; index++) {
+            byte[] content = deterministicBytes(index);
+            String hash = hash(content);
+            String sessionId = "load-smoke-" + index;
+            String stagingKey = stagingKey(sessionId);
+            String etag = minioClient.putObject(
+                    PutObjectRequest.builder().bucket(SOURCE_BUCKET).key(stagingKey).build(),
+                    RequestBody.fromBytes(content)
+            ).eTag();
+            DirectUploadPartDescriptor part = new DirectUploadPartDescriptor(
+                    7L,
+                    sessionId,
+                    0,
+                    SOURCE_BUCKET,
+                    stagingKey,
+                    "tenant/7/" + hash,
+                    content.length,
+                    etag,
+                    hash,
+                    hash,
+                    "SHA-256",
+                    List.of(TARGET_BUCKET),
+                    1
+            );
+            inputs.add(new LoadInput(part, content));
+        }
+        return inputs;
+    }
+
+    /**
+     * 构建一个等待统一起跑信号的提升任务。
+     */
+    private Callable<LoadResult> promotionTask(LoadInput input, CountDownLatch start) {
+        return () -> {
+            start.await(5, TimeUnit.SECONDS);
+            long startedAt = System.nanoTime();
+            try {
+                DirectUploadDigestAccumulator digest = DirectUploadDigestAccumulator.sha256();
+                DirectUploadPromotionResult result = promotionService.promote(input.part(), digest);
+                return new LoadResult(
+                        true,
+                        Duration.ofNanos(System.nanoTime() - startedAt).toMillis(),
+                        result.size(),
+                        digest.finishHash(),
+                        null
+                );
+            } catch (RuntimeException e) {
+                return new LoadResult(
+                        false,
+                        Duration.ofNanos(System.nanoTime() - startedAt).toMillis(),
+                        0L,
+                        null,
+                        e.getClass().getSimpleName()
+                );
+            }
+        };
+    }
+
+    /**
+     * 断言每次迭代完成真实对象提升、hash 校验和 staging 删除。
+     */
+    private void assertSuccessfulResults(List<LoadInput> inputs, List<LoadResult> results) {
+        assertThat(results).hasSize(ITERATIONS).allMatch(LoadResult::success);
+        for (int index = 0; index < ITERATIONS; index++) {
+            LoadInput input = inputs.get(index);
+            LoadResult result = results.get(index);
+            assertThat(result.bytes()).isEqualTo(PART_BYTES);
+            assertThat(result.hash()).isEqualTo(input.part().plainHash());
+            assertThat(readObject(TARGET_BUCKET, input.part().finalObjectName()))
+                    .containsExactly(input.content());
+            assertThat(objectExists(SOURCE_BUCKET, input.part().stagingObjectName())).isFalse();
+            assertThat(objectExists(
+                    SOURCE_BUCKET,
+                    input.part().stagingDescriptor().sealedObjectName()
+            )).isFalse();
+        }
+    }
+
+    /**
+     * 删除本次 smoke 创建的 final 对象和 run 级 Redis lifecycle 数据。
+     */
+    private void cleanupRun(List<LoadInput> inputs) {
+        for (LoadInput input : inputs) {
+            minioClient.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(TARGET_BUCKET)
+                    .key(input.part().finalObjectName())
+                    .build());
+        }
+        flushRedis();
+        assertThat(listObjectCount(SOURCE_BUCKET)).isZero();
+        assertThat(listObjectCount(TARGET_BUCKET)).isZero();
+        assertThat(redisDatabaseSize()).isZero();
+    }
+
+    /**
+     * 汇总固定 PR smoke 的分位数、吞吐、资源和 lifecycle 证据。
+     */
+    private LoadSmokeReport buildReport(
+            List<LoadResult> results,
+            long wallNanos,
+            ResourceSnapshot resource,
+            long receiptCount,
+            long tombstoneCount,
+            long receiptCountAfterCleanup,
+            Long tombstoneCountAfterCleanup
+    ) {
+        List<Long> latencies = results.stream()
+                .map(LoadResult::latencyMillis)
+                .sorted()
+                .toList();
+        long totalBytes = results.stream().mapToLong(LoadResult::bytes).sum();
+        long wallMillis = Duration.ofNanos(wallNanos).toMillis();
+        double seconds = Math.max(0.001D, wallNanos / 1_000_000_000D);
+        return new LoadSmokeReport(
+                "direct-upload-load-smoke-v1",
+                Instant.now().toString(),
+                environmentSnapshot(),
+                ITERATIONS,
+                CONCURRENCY,
+                PART_BYTES,
+                results.stream().filter(LoadResult::success).count(),
+                results.stream().filter(result -> !result.success()).count(),
+                wallMillis,
+                percentile(latencies, 0.50D),
+                percentile(latencies, 0.95D),
+                percentile(latencies, 0.99D),
+                totalBytes / seconds,
+                resource,
+                new LifecycleSnapshot(
+                        receiptCount,
+                        tombstoneCount,
+                        receiptCountAfterCleanup,
+                        requireAvailableCount(tombstoneCountAfterCleanup, "staging tombstone after cleanup"),
+                        "unavailable:not-exercised",
+                        null,
+                        "unavailable:not-exercised",
+                        null
+                ),
+                true
+        );
+    }
+
+    /**
+     * 将机器可读 JSON 与人读 Markdown 报告写入 Failsafe target。
+     */
+    private void writeReport(LoadSmokeReport report) throws Exception {
+        Path reportDirectory = Path.of("target", "direct-upload-load-smoke");
+        Files.createDirectories(reportDirectory);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writerWithDefaultPrettyPrinter()
+                .writeValue(reportDirectory.resolve("report.json").toFile(), report);
+        String markdown = """
+                # Direct Upload Load Smoke
+
+                - environment fingerprint: %s
+                - OS/arch/Java: %s / %s / %s
+                - processors/max heap bytes: %d / %d
+                - iterations: %d
+                - concurrency: %d
+                - part bytes: %d
+                - success/failure: %d/%d
+                - latency p50/p95/p99 ms: %.2f / %.2f / %.2f
+                - throughput bytes/sec: %.2f
+                - heap peak delta bytes: %d
+                - direct-buffer available/peak delta bytes: %s / %d
+                - GC count/time delta: %d / %d ms
+                - thread peak delta: %d
+                - receipt/tombstone before cleanup: %d / %d
+                - receipt/tombstone after cleanup: %d / %d
+                - degraded backlog: %s
+                - repair backlog: %s
+                - object and Redis residual after cleanup: 0
+                """.formatted(
+                report.environment().fingerprint(),
+                report.environment().osName(),
+                report.environment().osArchitecture(),
+                report.environment().javaVersion(),
+                report.environment().availableProcessors(),
+                report.environment().maxHeapBytes(),
+                report.iterations(),
+                report.concurrency(),
+                report.partBytes(),
+                report.successes(),
+                report.failures(),
+                report.p50Millis(),
+                report.p95Millis(),
+                report.p99Millis(),
+                report.bytesPerSecond(),
+                report.resource().heapPeakDeltaBytes(),
+                report.resource().directBufferAvailable(),
+                report.resource().directBufferPeakDeltaBytes(),
+                report.resource().gcCollectionCountDelta(),
+                report.resource().gcCollectionTimeMillisDelta(),
+                report.resource().threadPeakDelta(),
+                report.lifecycle().receiptCountBeforeCleanup(),
+                report.lifecycle().stagingTombstoneCountBeforeCleanup(),
+                report.lifecycle().receiptCountAfterCleanup(),
+                report.lifecycle().stagingTombstoneCountAfterCleanup(),
+                report.lifecycle().degradedBacklogStatus(),
+                report.lifecycle().repairBacklogStatus()
+        );
+        Files.writeString(reportDirectory.resolve("report.md"), markdown, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 生成不含凭据的 JVM/主机环境指纹，防止跨环境误比较报告。
+     */
+    private EnvironmentSnapshot environmentSnapshot() {
+        String osName = System.getProperty("os.name", "unavailable");
+        String osArchitecture = System.getProperty("os.arch", "unavailable");
+        String javaVersion = System.getProperty("java.version", "unavailable");
+        int processors = Runtime.getRuntime().availableProcessors();
+        long maxHeapBytes = Runtime.getRuntime().maxMemory();
+        String source = String.join("|",
+                osName,
+                osArchitecture,
+                javaVersion,
+                Integer.toString(processors),
+                Long.toString(maxHeapBytes));
+        try {
+            String fingerprint = HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(source.getBytes(StandardCharsets.UTF_8)));
+            return new EnvironmentSnapshot(
+                    fingerprint, osName, osArchitecture, javaVersion, processors, maxHeapBytes);
+        } catch (Exception e) {
+            throw new IllegalStateException("无法生成 load smoke 环境指纹", e);
+        }
+    }
+
+    /**
+     * 计算已排序样本的 nearest-rank 分位数。
+     */
+    private double percentile(List<Long> sortedValues, double percentile) {
+        int rank = (int) Math.ceil(percentile * sortedValues.size());
+        return sortedValues.get(Math.max(0, rank - 1));
+    }
+
+    /**
+     * 将 Redis 计数解包为真实值；驱动未返回数据时失败而不是伪造零。
+     */
+    private long requireAvailableCount(Long value, String name) {
+        if (value == null) {
+            throw new IllegalStateException(name + " unavailable");
+        }
+        return value;
+    }
+
+    /**
+     * 建立逻辑节点到真实 MinIO endpoint 和物理身份的映射。
+     */
+    private void configureNode(String node, String physicalStorageId) {
+        when(clientManager.getClient(node)).thenReturn(minioClient);
+        NodeConfig nodeConfig = new NodeConfig();
+        nodeConfig.setName(node);
+        nodeConfig.setEndpoint(endpoint(MINIO));
+        nodeConfig.setPhysicalStorageId(physicalStorageId);
+        when(clientManager.getNodeConfig(node)).thenReturn(nodeConfig);
+        when(s3Monitor.isNodeOnline(node)).thenReturn(true);
+    }
+
+    /**
+     * 创建固定名称的 smoke 测试桶。
+     */
+    private void createBucket(String bucket) {
+        minioClient.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+    }
+
+    /**
+     * 删除测试桶中的全部对象并删除桶。
+     */
+    private void deleteBucket(String bucket) {
+        minioClient.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).build())
+                .contents()
+                .forEach(object -> minioClient.deleteObject(DeleteObjectRequest.builder()
+                        .bucket(bucket).key(object.key()).build()));
+        minioClient.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+    }
+
+    /**
+     * 返回测试桶中的对象数量。
+     */
+    private long listObjectCount(String bucket) {
+        return minioClient.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).build())
+                .keyCount();
+    }
+
+    /**
+     * 读取小型 final 对象用于内容断言。
+     */
+    private byte[] readObject(String bucket, String key) {
+        return minioClient.getObjectAsBytes(
+                GetObjectRequest.builder().bucket(bucket).key(key).build()).asByteArray();
+    }
+
+    /**
+     * 判断真实 MinIO 中对象是否存在。
+     */
+    private boolean objectExists(String bucket, String key) {
+        try {
+            minioClient.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+            return true;
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * 清空隔离 Redis database 中的 run 级测试状态。
+     */
+    private static void flushRedis() {
+        try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+            connection.serverCommands().flushDb();
+        }
+    }
+
+    /**
+     * 统计真实 Redis 中的 promotion receipt 数量。
+     */
+    private long countReceiptKeys() {
+        var keys = redisTemplate.keys(RECEIPT_KEY_PATTERN);
+        return keys == null ? 0L : keys.size();
+    }
+
+    /**
+     * 返回隔离 Redis database 的 key 总数。
+     */
+    private long redisDatabaseSize() {
+        try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+            Long size = connection.serverCommands().dbSize();
+            return size == null ? 0L : size;
+        }
+    }
+
+    /**
+     * 生成不会跨迭代重复的固定大小内容。
+     */
+    private byte[] deterministicBytes(int iteration) {
+        byte[] seed = ("direct-load-smoke-" + iteration + "-").getBytes(StandardCharsets.UTF_8);
+        byte[] content = new byte[PART_BYTES];
+        for (int index = 0; index < content.length; index++) {
+            content[index] = seed[index % seed.length];
+        }
+        return content;
+    }
+
+    /**
+     * 返回规范 staging object key。
+     */
+    private String stagingKey(String sessionId) {
+        return "tenant/7/staging/direct-upload/" + sessionId + "/part-0";
+    }
+
+    /**
+     * 计算 direct-upload 合同使用的 SHA-256 内容地址。
+     */
+    private String hash(byte[] content) throws Exception {
+        return "sha256:" + HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(content));
+    }
+
+    /**
+     * 返回容器映射到宿主机的 endpoint。
+     */
+    private static String endpoint(GenericContainer<?> container) {
+        return "http://" + container.getHost() + ":" + container.getMappedPort(MINIO_PORT);
+    }
+
+    /**
+     * 创建 path-style MinIO 客户端。
+     */
+    private static S3Client s3Client(String endpoint) {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+                .httpClientBuilder(ApacheHttpClient.builder()
+                        .connectionTimeout(Duration.ofSeconds(2))
+                        .socketTimeout(Duration.ofSeconds(15)))
+                .build();
+    }
+
+    /**
+     * 周期采集 JVM heap、GC、线程和 direct buffer 峰值。
+     */
+    private static final class ResourceSampler implements AutoCloseable {
+        private final MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
+        private final ThreadMXBean threads = ManagementFactory.getThreadMXBean();
+        private final List<GarbageCollectorMXBean> collectors = ManagementFactory.getGarbageCollectorMXBeans();
+        private final BufferPoolMXBean directBuffer = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
+                .stream()
+                .filter(pool -> "direct".equals(pool.getName()))
+                .findFirst()
+                .orElse(null);
+        private final long heapStart = memory.getHeapMemoryUsage().getUsed();
+        private final long gcCountStart = gcCount();
+        private final long gcTimeStart = gcTime();
+        private final int threadStart = threads.getThreadCount();
+        private final long directStart = directMemory();
+        private final AtomicLong heapPeak = new AtomicLong(heapStart);
+        private final AtomicLong directPeak = new AtomicLong(directStart);
+        private final AtomicLong threadPeak = new AtomicLong(threadStart);
+        private final AtomicBoolean running = new AtomicBoolean();
+        private ExecutorService samplerExecutor;
+
+        /**
+         * 启动单线程有界资源采样循环。
+         */
+        void start() {
+            running.set(true);
+            samplerExecutor = Executors.newSingleThreadExecutor();
+            samplerExecutor.submit(() -> {
+                while (running.get()) {
+                    sample();
+                    try {
+                        Thread.sleep(20L);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            });
+        }
+
+        /**
+         * 更新当前资源峰值。
+         */
+        private void sample() {
+            heapPeak.accumulateAndGet(memory.getHeapMemoryUsage().getUsed(), Math::max);
+            directPeak.accumulateAndGet(directMemory(), Math::max);
+            threadPeak.accumulateAndGet(threads.getThreadCount(), Math::max);
+        }
+
+        /**
+         * 生成包含峰值与增量的不可变资源快照。
+         */
+        ResourceSnapshot snapshot() {
+            sample();
+            return new ResourceSnapshot(
+                    heapStart,
+                    heapPeak.get(),
+                    Math.max(0L, heapPeak.get() - heapStart),
+                    gcCountStart,
+                    gcCount(),
+                    Math.max(0L, gcCount() - gcCountStart),
+                    gcTimeStart,
+                    gcTime(),
+                    Math.max(0L, gcTime() - gcTimeStart),
+                    threadStart,
+                    (int) threadPeak.get(),
+                    (int) Math.max(0L, threadPeak.get() - threadStart),
+                    directBuffer != null,
+                    directStart,
+                    directPeak.get(),
+                    directBuffer == null ? -1L : Math.max(0L, directPeak.get() - directStart)
+            );
+        }
+
+        /**
+         * 停止采样线程并等待其退出。
+         */
+        @Override
+        public void close() {
+            running.set(false);
+            if (samplerExecutor != null) {
+                samplerExecutor.shutdownNow();
+                try {
+                    if (!samplerExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("资源采样线程未在期限内退出");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("等待资源采样线程退出时被中断", e);
+                }
+            }
+        }
+
+        /**
+         * 汇总所有 GC bean 的 collection count。
+         */
+        private long gcCount() {
+            return collectors.stream().mapToLong(GarbageCollectorMXBean::getCollectionCount)
+                    .filter(value -> value >= 0L).sum();
+        }
+
+        /**
+         * 汇总所有 GC bean 的 collection time。
+         */
+        private long gcTime() {
+            return collectors.stream().mapToLong(GarbageCollectorMXBean::getCollectionTime)
+                    .filter(value -> value >= 0L).sum();
+        }
+
+        /**
+         * 返回当前 direct buffer 占用，平台不可用时显式返回 -1。
+         */
+        private long directMemory() {
+            return directBuffer == null ? -1L : directBuffer.getMemoryUsed();
+        }
+    }
+
+    /**
+     * 保存单次 smoke 输入。
+     */
+    private record LoadInput(DirectUploadPartDescriptor part, byte[] content) {
+    }
+
+    /**
+     * 保存单次 smoke 结果。
+     */
+    private record LoadResult(boolean success, long latencyMillis, long bytes, String hash, String error) {
+    }
+
+    /**
+     * 保存 JVM 资源起点、峰值和增量。
+     */
+    private record ResourceSnapshot(
+            long heapStartBytes,
+            long heapPeakBytes,
+            long heapPeakDeltaBytes,
+            long gcCollectionCountStart,
+            long gcCollectionCountEnd,
+            long gcCollectionCountDelta,
+            long gcCollectionTimeMillisStart,
+            long gcCollectionTimeMillisEnd,
+            long gcCollectionTimeMillisDelta,
+            int threadStart,
+            int threadPeak,
+            int threadPeakDelta,
+            boolean directBufferAvailable,
+            long directBufferStartBytes,
+            long directBufferPeakBytes,
+            long directBufferPeakDeltaBytes
+    ) {
+    }
+
+    /**
+     * 保存清理前后 lifecycle 与 backlog 计数。
+     */
+    private record LifecycleSnapshot(
+            long receiptCountBeforeCleanup,
+            long stagingTombstoneCountBeforeCleanup,
+            long receiptCountAfterCleanup,
+            long stagingTombstoneCountAfterCleanup,
+            String degradedBacklogStatus,
+            Long degradedBacklogAfterCleanup,
+            String repairBacklogStatus,
+            Long repairBacklogAfterCleanup
+    ) {
+    }
+
+    /**
+     * 保存不含凭据的 JVM/主机环境事实。
+     */
+    private record EnvironmentSnapshot(
+            String fingerprint,
+            String osName,
+            String osArchitecture,
+            String javaVersion,
+            int availableProcessors,
+            long maxHeapBytes
+    ) {
+    }
+
+    /**
+     * 保存机器可读的 direct-upload PR smoke 报告。
+     */
+    private record LoadSmokeReport(
+            String schema,
+            String generatedAt,
+            EnvironmentSnapshot environment,
+            int iterations,
+            int concurrency,
+            int partBytes,
+            long successes,
+            long failures,
+            long wallMillis,
+            double p50Millis,
+            double p95Millis,
+            double p99Millis,
+            double bytesPerSecond,
+            ResourceSnapshot resource,
+            LifecycleSnapshot lifecycle,
+            boolean cleanupSuccess
+    ) {
+    }
+}

--- a/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadLoadSmokeIT.java
+++ b/platform-storage/src/test/java/cn/flying/storage/service/DirectUploadLoadSmokeIT.java
@@ -68,10 +68,13 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -272,7 +275,11 @@ class DirectUploadLoadSmokeIT {
         Long tombstoneCountBeforeCleanup = redisTemplate.opsForZSet().zCard(EXPIRY_SET_KEY);
         assertThat(receiptCountBeforeCleanup).isEqualTo(ITERATIONS);
         assertThat(tombstoneCountBeforeCleanup).isEqualTo(ITERATIONS);
-        verify(degradedWriteTracker, never()).recordAuthoritativeDegradedWrite(any(), any(), any());
+        verify(degradedWriteTracker, times(ITERATIONS)).recordAuthoritativeDegradedWrite(
+                any(),
+                argThat(nodes -> nodes.size() == 1 && nodes.contains(TARGET_BUCKET)),
+                eq(7L)
+        );
         verify(repairService, never()).scheduleImmediateRepairByNodesAsync(any(), any(), any());
 
         cleanupRun(inputs);

--- a/tools/k6/README.md
+++ b/tools/k6/README.md
@@ -3,6 +3,7 @@
 本目录提供可复用、可门禁、可归档的 K6 压测框架，覆盖：
 - 读路径：`/files`（`basic/keyword/combo`）与 `/files/stats`
 - 写路径：`/upload-sessions`、`/upload-sessions/{clientId}/chunks/{chunkNumber}`、`/upload-sessions/{clientId}/complete`、`/upload-sessions/{clientId}/progress`
+- 直传闭环：direct create → 原始预签名 PUT → direct complete → manifest metadata → 原始预签名 GET → size/hash 校验 → 清理
 - 混合路径：70% 查询 + 30% 上传
 
 ## 目录结构
@@ -24,8 +25,10 @@ tools/k6/
 │   ├── local-load.js
 │   └── local-smoke.js
 ├── scripts/
+│   ├── compare-direct-baseline.mjs
 │   └── render-query-baseline.mjs
 ├── chunk-upload.js
+├── direct-path.js
 ├── file-query.js
 ├── run-ci.sh
 └── run-local.sh
@@ -54,19 +57,30 @@ brew install k6
 
 框架变量：
 - `K6_PROFILE=smoke|load`
-- `K6_SCENARIO=all|file-query|chunk-upload|core-mixed`
+- `K6_SCENARIO=all|file-query|chunk-upload|core-mixed|direct-path`
 - `K6_ENGINE=auto|local|docker`（默认 `auto`；`auto` 仅自动使用本地 k6）
 - `K6_DOCKER_IMAGE`（Docker 引擎必填，必须是 digest 固定镜像）
-- `RUN_ID`（默认当前时间戳）
+- `RUN_ID`（默认当前时间戳；只允许 1～64 位安全字符，首位字母/数字，其余字母、数字、点、下划线或连字符；非法值会在执行前失败关闭）
 - `RESULT_DIR`（默认 `tools/k6/results/<RUN_ID>`）
+- `ENVIRONMENT_FINGERPRINT`（同环境 baseline 比较键；脚本默认按脱敏目标、引擎、OS/架构生成）
 
 上传变量：
 - `TOTAL_CHUNKS`（默认 `5`）
 - `CHUNK_SIZE`（默认 `1024` 字节）
 
+直传变量：
+- `DIRECT_TOTAL_CHUNKS`（默认 `2`，未设置时可继承 `TOTAL_CHUNKS`）
+- `DIRECT_CHUNK_SIZE`（默认 `65536` 字节，未设置时可继承 `CHUNK_SIZE`）
+- `DIRECT_P99_BUDGET_MS`（默认 `60000`，作为测试级总预算，不等同生产 SLA）
+- `DIRECT_RESOURCE_SNAPSHOT_PATH`（可选，同源资源快照相对路径；分别在运行开始和清理完成后探测，未配置时两阶段均报告为 `unavailable/not_configured`）
+- `DIRECT_LIFECYCLE_SNAPSHOT_PATH`（可选，同源 staging/receipt/degraded/repair 快照相对路径；分别记录开始/结束可用性，未配置时不伪造 `0`）
+
+direct-path 套件禁用 k6 的 `url`/`name` 系统标签并关闭运行日志输出，避免预签名查询参数进入指标、日志或 artifact；平台鉴权头也不会发送到原始预签名 PUT/GET。
+
 可选变量：
 - `CLEANUP=true|false`（默认 `true`）
 - `CI_INCLUDE_CHUNK=true|false`（默认 `false`）
+- `CI_INCLUDE_DIRECT=true|false`（默认 `false`；显式选择 `direct-path` 时自动启用）
 
 ## 本地运行
 
@@ -80,7 +94,7 @@ bash tools/k6/run-local.sh --profile smoke --scenario all --engine auto
 
 ### 2) load 档位（查询/上传控速）
 
-默认 `K6_SCENARIO=all` 时跑 `file-query + chunk-upload`。
+默认 `K6_SCENARIO=all` 时跑 `file-query + chunk-upload + direct-path`。
 
 ```bash
 bash tools/k6/run-local.sh --profile load --scenario all --engine auto
@@ -92,7 +106,9 @@ bash tools/k6/run-local.sh --profile load --scenario all --engine auto
 bash tools/k6/run-local.sh --profile smoke --scenario file-query --engine auto
 bash tools/k6/run-local.sh --profile smoke --scenario core-mixed --engine auto
 bash tools/k6/run-local.sh --profile smoke --scenario chunk-upload --engine auto
+bash tools/k6/run-local.sh --profile smoke --scenario direct-path --engine auto
 bash tools/k6/run-local.sh --profile load --scenario chunk-upload --engine auto
+bash tools/k6/run-local.sh --profile load --scenario direct-path --engine auto
 ```
 
 ## 固定门禁阈值
@@ -113,14 +129,25 @@ bash tools/k6/run-local.sh --profile load --scenario chunk-upload --engine auto
 - `upload_complete p95 < 1500ms`
 - `upload_e2e_ms p95 < 6000ms`
 
+直传链路：
+- `direct_flow_failure_rate == 0`
+- `direct_cleanup_failure_rate == 0`
+- upload/download/end-to-end `p99 < DIRECT_P99_BUDGET_MS`
+
+直传 PUT/GET 直接请求预签名 URL，不携带 `Authorization`、`X-Tenant-ID` 或 JSON 头。ETag 只作为对象版本条件；内容身份始终使用 `sha256:<lowercase hex>` 复核。
+
+包含 `direct-path` 时，运行脚本强制使用 `k6 --log-output none`，避免网络错误把含签名查询参数的预签名 URL 写入控制台日志。结果、失败样本和阈值仍通过 `summary.*`、`metrics.json` 与退出码交付。
+
 ## 报告产物
 
 每次运行会在 `RESULT_DIR` 输出：
-- `summary.txt`：可读摘要（含 endpoint 的 p50/p90/p95、错误率、请求量、阈值结果、失败样本）
+- `summary.txt`：可读摘要（含 endpoint 的 p50/p90/p95/p99、错误率、请求量、阈值结果、失败样本）
 - `summary.json`：完整 k6 summary
 - `metrics.json`：精简指标快照
 - `query-baseline.json`：检索基线结构化快照（endpoint 指标 + 阈值结果，便于文档回填）
-- `run-meta.json`：运行元数据（`runId/profile/scenario/engine/timestamp/baseUrlMask`）
+- `direct-path-baseline.json`：直传 upload/download/e2e p50/p95/p99、吞吐、失败率和观测可用性
+- `direct-path-report.md`：直传报告；未配置的 heap/GC/thread/direct-buffer 或生命周期采集会显式显示 `unavailable`，绝不填 0
+- `run-meta.json`：运行元数据（目标掩码、环境指纹、OS/架构、CPU/内存、k6 版本等）
 
 ## 基线回填自动汇总
 
@@ -136,6 +163,19 @@ node tools/k6/scripts/render-query-baseline.mjs \
 脚本会读取两个目录下的 `query-baseline.json`，输出：
 - “结果回填模板”表格（RUN_ID / 阈值结论）
 - “指标摘录”表格（endpoint 的 p50/p90/p95/errorRate/requests）
+
+## 直传基线比较
+
+只比较 `environment.fingerprint` 完全一致的两份基线。默认规则为：p95/p99 变差超过 20%、上传/下载吞吐下降超过 20%，或 flow/cleanup 从 0 变为非 0 时返回失败。环境不同时输出 `NOT_COMPARABLE`，不制造虚假回归结论。
+
+比较前还会要求 `evidence.valid=true`：至少存在一条 flow 样本、一条 cleanup 样本和一个完成文件。仅加载脚本、setup 失败或没有执行迭代生成的零值不能成为性能基线。
+
+```bash
+node tools/k6/scripts/compare-direct-baseline.mjs \
+  --baseline tools/k6/results/<BASE>/direct-path-baseline.json \
+  --candidate tools/k6/results/<CANDIDATE>/direct-path-baseline.json \
+  --output tools/k6/results/<CANDIDATE>/direct-path-comparison.md
+```
 
 ## CI 说明
 
@@ -158,7 +198,7 @@ GitHub Actions Secrets（与统一变量同名）：
 - `USERNAME`
 - `PASSWORD`
 
-手工触发时可选择是否包含 `chunk-upload` 场景。
+手工工作流默认执行 `direct-path/smoke`，也可选择 load 和其他场景。镜像固定为 `grafana/k6:0.49.0` 对应的 multi-arch digest；报告 artifact 使用 `if: always()` 上传。外部环境 secret 只服务手工工作流，不属于 PR 强制门禁；PR 内真实 MinIO/Redis/Toxiproxy 门禁由 `platform-storage -Pit` 提供。
 
 ## 常见问题
 
@@ -166,3 +206,5 @@ GitHub Actions Secrets（与统一变量同名）：
 - `400 缺少租户标识`：检查是否携带 `X-Tenant-ID`。
 - `429 Too Many Requests`：触发全局限流，建议降低 `VUS` 或 arrival `rate`。
 - 上传失败：确认 `chunk` 请求为 `PUT multipart/form-data`，路径包含 `clientId` 和 `chunkNumber`。
+- 直传 PUT/GET 失败：确认 MinIO CORS 暴露 `ETag`，并确认压测脚本未向预签名 URL 添加平台鉴权头。
+- cleanup 阈值失败：按 `RUN_ID` 搜索残留文件；不要关闭 `CLEANUP` 后把运行视为通过。

--- a/tools/k6/direct-path.js
+++ b/tools/k6/direct-path.js
@@ -1,0 +1,480 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { randomBytes, sha256 } from 'k6/crypto';
+import {
+  buildRequestTags,
+  createConstantVusOptions,
+  ensureRequiredConfig,
+  getBaseConfig,
+  getDirectPathConfig,
+  getDirectPathThresholds,
+  getGlobalThresholds,
+  mergeThresholds,
+  parseBooleanEnv,
+  parseIntEnv,
+} from './lib/config.js';
+import { loginOrFail } from './lib/auth.js';
+import { checkApiSuccess, checkFieldPresent } from './lib/assertions.js';
+import { cleanupRunFiles } from './lib/cleanup.js';
+import {
+  directCleanupFailureRate,
+  directFlowFailureRate,
+  recordDirectPathResult,
+  recordDirectSnapshotAvailability,
+  recordEndpointResult,
+  recordHttpStatus,
+} from './lib/metrics.js';
+import { buildAuthHeaders, del, get, post, safeJsonPath } from './lib/http.js';
+import { createSummaryHandler } from './lib/summary.js';
+
+const baseConfig = getBaseConfig();
+ensureRequiredConfig(baseConfig);
+const directConfig = getDirectPathConfig();
+const cleanupEnabled = parseBooleanEnv('CLEANUP', true);
+const visibleEtagPattern = /^[\x21-\x7e]{1,255}$/;
+const standaloneSummaryConfig = {
+  ...baseConfig,
+  directExecution: {
+    executor: 'constant-vus',
+    concurrency: parseIntEnv('VUS', 1, 1),
+    duration: __ENV.DURATION || '30s',
+    preAllocatedVUs: null,
+    maxVUs: null,
+  },
+};
+
+export const options = createConstantVusOptions(
+  1,
+  '30s',
+  mergeThresholds(getGlobalThresholds(), getDirectPathThresholds()),
+);
+
+/**
+ * 生成符合后端格式约束且长度有界的 clientId。
+ *
+ * @param {string} runId 运行 ID
+ * @returns {string} 客户端会话 ID
+ */
+function buildClientId(runId) {
+  const safeRunId = String(runId).replace(/[^A-Za-z0-9-]/g, '-').slice(0, 40);
+  return `direct-${safeRunId}-${__VU}-${__ITER}`.slice(0, 64);
+}
+
+/**
+ * 为一次迭代生成直传分片及可信哈希计划。
+ *
+ * @returns {{index:number, bytes:ArrayBuffer, size:number, hash:string}[]} 分片计划
+ */
+function buildPartPlan() {
+  const parts = [];
+  for (let index = 0; index < directConfig.totalChunks; index += 1) {
+    const bytes = randomBytes(directConfig.chunkSize);
+    parts.push({
+      index,
+      bytes,
+      size: bytes.byteLength,
+      hash: `sha256:${sha256(bytes, 'hex')}`,
+    });
+  }
+  return parts;
+}
+
+/**
+ * 记录对象存储原始请求结果；预签名请求不得携带平台鉴权头。
+ *
+ * @param {import('k6/http').RefinedResponse<'text'|'binary'>} response HTTP 响应
+ * @param {Record<string,string>} tags 指标标签
+ * @param {boolean} success 是否成功
+ */
+function recordRawStorageResult(response, tags, success) {
+  recordEndpointResult(success, tags);
+  recordHttpStatus(response?.status, tags);
+  directFlowFailureRate.add(!success, Object.assign({}, tags, { phase: tags.endpoint }));
+}
+
+/**
+ * 中止失败会话并验证后端已接受清理请求。
+ *
+ * @param {{config:{baseUrl:string,tenantId:string},token:string}} context 压测上下文
+ * @param {string|undefined} clientId 客户端会话 ID
+ * @param {string} scenarioName 场景名
+ * @returns {boolean} 中止是否成功
+ */
+function abortDirectSession(context, clientId, scenarioName) {
+  if (!clientId) {
+    return true;
+  }
+  const tags = buildRequestTags(scenarioName, 'direct_abort', 'DELETE');
+  const response = del(`${context.config.baseUrl}/upload-sessions/${clientId}/direct`, {
+    headers: buildAuthHeaders(context.config.tenantId, context.token),
+    tags,
+  });
+  return checkApiSuccess(response, 'direct/abort', tags);
+}
+
+/**
+ * 记录失败迭代的有界指标并执行会话回收。
+ *
+ * @param {{config:{baseUrl:string,tenantId:string},token:string}} context 压测上下文
+ * @param {string} scenarioName 场景名
+ * @param {number} startedAt 开始时间
+ * @param {number} uploadStartedAt 上传开始时间
+ * @param {number} uploadedBytes 已上传字节数
+ * @param {number} downloadedBytes 已下载字节数
+ * @param {string|undefined} clientId 客户端会话 ID
+ * @returns {{ok:false,clientId:string|undefined}} 失败结果
+ */
+function failIteration(
+  context,
+  scenarioName,
+  startedAt,
+  uploadStartedAt,
+  uploadedBytes,
+  downloadedBytes,
+  clientId,
+) {
+  if (clientId) {
+    const abortOk = abortDirectSession(context, clientId, scenarioName);
+    directCleanupFailureRate.add(!abortOk, { reason: abortOk ? 'none' : 'abort_failed' });
+  }
+  const now = Date.now();
+  recordDirectPathResult(
+    {
+      uploadMs: Math.max(0, now - uploadStartedAt),
+      downloadMs: 0,
+      totalMs: Math.max(0, now - startedAt),
+      uploadedBytes,
+      downloadedBytes,
+      ok: false,
+    },
+    buildRequestTags(scenarioName, 'direct_path', 'CUSTOM'),
+  );
+  return { ok: false, clientId };
+}
+
+/**
+ * 调用可选的同源观测快照端点，只记录可用性而不落盘敏感响应。
+ *
+ * @param {{config:{baseUrl:string,tenantId:string},token:string}} context 压测上下文
+ * @param {string} relativePath 同源相对路径
+ * @param {string} endpoint 指标端点名
+ * @param {string} scenarioName 场景名
+ * @returns {boolean} 快照是否可用
+ */
+function probeOptionalSnapshot(context, relativePath, endpoint, scenarioName) {
+  if (!relativePath || !relativePath.startsWith('/') || relativePath.startsWith('//')) {
+    return false;
+  }
+  const tags = buildRequestTags(scenarioName, endpoint, 'GET');
+  const response = get(`${context.config.baseUrl}${relativePath}`, {
+    headers: buildAuthHeaders(context.config.tenantId, context.token),
+    tags,
+  });
+  return response.status === 200 && safeJsonPath(response, 'code') === 200;
+}
+
+/**
+ * 在运行起点或清理后终点采集可选观测端点的可用性证据。
+ *
+ * @param {{config:{baseUrl:string,tenantId:string,resourceSnapshotPath:string,lifecycleSnapshotPath:string},token:string}} context 压测上下文
+ * @param {string} scenarioName 场景名
+ * @param {'start'|'end'} stage 快照阶段
+ * @returns {{resourceAvailable:boolean,lifecycleAvailable:boolean}} 快照可用性
+ */
+export function captureDirectSnapshotAvailability(context, scenarioName, stage) {
+  const resourceAvailable = probeOptionalSnapshot(
+    context,
+    context.config.resourceSnapshotPath,
+    `direct_resource_snapshot_${stage}`,
+    scenarioName,
+  );
+  const lifecycleAvailable = probeOptionalSnapshot(
+    context,
+    context.config.lifecycleSnapshotPath,
+    `direct_lifecycle_snapshot_${stage}`,
+    scenarioName,
+  );
+  recordDirectSnapshotAvailability(
+    resourceAvailable,
+    lifecycleAvailable,
+    stage,
+    buildRequestTags(scenarioName, `direct_snapshot_${stage}`, 'CUSTOM'),
+  );
+  return { resourceAvailable, lifecycleAvailable };
+}
+
+/**
+ * 执行 create -> raw PUT -> complete -> metadata -> raw GET 的直传闭环。
+ *
+ * @param {{config:{baseUrl:string,tenantId:string,runId:string,resourceSnapshotPath:string,lifecycleSnapshotPath:string},token:string}} context 压测上下文
+ * @param {string} scenarioName 场景名
+ * @returns {{ok:boolean,clientId:string|undefined,fileHash?:string}} 流程结果
+ */
+export function runDirectPathFlow(context, scenarioName = 'direct-path') {
+  const startedAt = Date.now();
+  const uploadStartedAt = Date.now();
+  const headers = buildAuthHeaders(context.config.tenantId, context.token, {
+    'Content-Type': 'application/json',
+  });
+  const clientId = buildClientId(context.config.runId);
+  const fileName = `k6-${context.config.runId}-${__VU}-${__ITER}-direct.bin`;
+  const partPlan = buildPartPlan();
+  const fileSize = partPlan.reduce((total, part) => total + part.size, 0);
+  let uploadedBytes = 0;
+  let downloadedBytes = 0;
+
+  const createTags = buildRequestTags(scenarioName, 'direct_create', 'POST');
+  const createResponse = post(
+    `${context.config.baseUrl}/upload-sessions/direct`,
+    JSON.stringify({
+      clientId,
+      fileName,
+      fileSize,
+      contentType: 'application/octet-stream',
+      chunkSize: directConfig.chunkSize,
+      totalChunks: partPlan.length,
+      parts: partPlan.map((part) => ({
+        index: part.index,
+        size: part.size,
+        plainHash: part.hash,
+        cipherHash: part.hash,
+        checksumAlgorithm: 'SHA-256',
+      })),
+    }),
+    { headers, tags: createTags },
+  );
+  const createOk = checkApiSuccess(createResponse, 'direct/create', createTags);
+  const issuedClientId = checkFieldPresent(
+    createResponse,
+    'data.clientId',
+    'direct/create clientId present',
+    createTags,
+  );
+  const issuedParts = safeJsonPath(createResponse, 'data.parts');
+  const issuedPartsOk = check(createResponse, {
+    'direct/create preserves clientId and trusted part plan': () =>
+      String(issuedClientId || '') === clientId &&
+      Array.isArray(issuedParts) &&
+      issuedParts.length === partPlan.length &&
+      issuedParts.every((part, index) =>
+        Number(part.index) === index &&
+        Number(part.size) === partPlan[index].size &&
+        String(part.plainHash) === partPlan[index].hash &&
+        String(part.cipherHash) === partPlan[index].hash &&
+        typeof part.uploadUrl === 'string' &&
+        part.uploadUrl.length > 0),
+  });
+  if (!createOk || !issuedClientId || !issuedPartsOk) {
+    return failIteration(
+      context,
+      scenarioName,
+      startedAt,
+      uploadStartedAt,
+      uploadedBytes,
+      downloadedBytes,
+      issuedClientId || undefined,
+    );
+  }
+
+  const completedParts = [];
+  for (const plannedPart of partPlan) {
+    const issuedPart = issuedParts.find((candidate) => Number(candidate.index) === plannedPart.index);
+    if (!issuedPart || !issuedPart.uploadUrl) {
+      return failIteration(
+        context,
+        scenarioName,
+        startedAt,
+        uploadStartedAt,
+        uploadedBytes,
+        downloadedBytes,
+        String(issuedClientId),
+      );
+    }
+
+    const putTags = buildRequestTags(scenarioName, 'direct_presigned_put', 'PUT');
+    const putResponse = http.put(issuedPart.uploadUrl, plannedPart.bytes, { tags: putTags });
+    const eTag = putResponse.headers.ETag || putResponse.headers.Etag || putResponse.headers.etag;
+    const putOk = check(putResponse, {
+      'direct/presigned PUT http 2xx': (response) => response.status >= 200 && response.status < 300,
+      'direct/presigned PUT exposes valid ETag': () => visibleEtagPattern.test(String(eTag || '')),
+    });
+    recordRawStorageResult(putResponse, putTags, putOk);
+    if (!putOk) {
+      return failIteration(
+        context,
+        scenarioName,
+        startedAt,
+        uploadStartedAt,
+        uploadedBytes,
+        downloadedBytes,
+        String(issuedClientId),
+      );
+    }
+    uploadedBytes += plannedPart.size;
+    completedParts.push({ index: plannedPart.index, eTag: String(eTag) });
+  }
+
+  const completeTags = buildRequestTags(scenarioName, 'direct_complete', 'POST');
+  const completeResponse = post(
+    `${context.config.baseUrl}/upload-sessions/${issuedClientId}/direct/complete`,
+    JSON.stringify({ parts: completedParts }),
+    { headers, tags: completeTags },
+  );
+  const completeOk = checkApiSuccess(completeResponse, 'direct/complete', completeTags);
+  const fileHash = checkFieldPresent(
+    completeResponse,
+    'data.fileHash',
+    'direct/complete fileHash present',
+    completeTags,
+  );
+  const completedManifestHash = safeJsonPath(completeResponse, 'data.manifestHash');
+  const completeEvidenceOk = check(completeResponse, {
+    'direct/complete returns file and manifest evidence': () =>
+      Boolean(safeJsonPath(completeResponse, 'data.fileId')) &&
+      typeof completedManifestHash === 'string' &&
+      completedManifestHash.startsWith('sha256:'),
+  });
+  if (!completeOk || !fileHash || !completeEvidenceOk) {
+    return failIteration(
+      context,
+      scenarioName,
+      startedAt,
+      uploadStartedAt,
+      uploadedBytes,
+      downloadedBytes,
+      String(issuedClientId),
+    );
+  }
+  const uploadCompletedAt = Date.now();
+
+  const metadataTags = buildRequestTags(scenarioName, 'direct_download_metadata', 'GET');
+  const metadataResponse = get(
+    `${context.config.baseUrl}/files/hash/${encodeURIComponent(String(fileHash))}/download-metadata`,
+    { headers: buildAuthHeaders(context.config.tenantId, context.token), tags: metadataTags },
+  );
+  const metadataOk = checkApiSuccess(metadataResponse, 'direct/download-metadata', metadataTags);
+  const downloadParts = safeJsonPath(metadataResponse, 'data.parts');
+  const metadataPartsOk = check(metadataResponse, {
+    'direct/download-metadata binds manifest and ordered parts': () =>
+      safeJsonPath(metadataResponse, 'data.manifestHash') === completedManifestHash &&
+      Number(safeJsonPath(metadataResponse, 'data.fileSize')) === fileSize &&
+      Number(safeJsonPath(metadataResponse, 'data.totalChunks')) === partPlan.length &&
+      Array.isArray(downloadParts) &&
+      downloadParts.length === partPlan.length &&
+      downloadParts.every((part, index) =>
+        Number(part.index) === index &&
+        Number(part.size) === partPlan[index].size &&
+        typeof part.downloadUrl === 'string' &&
+        part.downloadUrl.length > 0 &&
+        String(part.cipherHash) === partPlan[index].hash),
+  });
+  if (!metadataOk || !metadataPartsOk) {
+    return failIteration(
+      context,
+      scenarioName,
+      startedAt,
+      uploadStartedAt,
+      uploadedBytes,
+      downloadedBytes,
+      undefined,
+    );
+  }
+
+  const downloadStartedAt = Date.now();
+  for (const downloadPart of downloadParts) {
+    const plannedPart = partPlan[Number(downloadPart.index)];
+    const getTags = buildRequestTags(scenarioName, 'direct_presigned_get', 'GET');
+    const getResponse = http.get(downloadPart.downloadUrl, {
+      tags: getTags,
+      responseType: 'binary',
+    });
+    const bodyLength = getResponse.body && getResponse.body.byteLength !== undefined
+      ? getResponse.body.byteLength
+      : -1;
+    const actualHash = getResponse.status === 200 && bodyLength >= 0
+      ? `sha256:${sha256(getResponse.body, 'hex')}`
+      : '';
+    const getOk = check(getResponse, {
+      'direct/presigned GET http 200': (response) => response.status === 200,
+      'direct/presigned GET size matches manifest': () =>
+        bodyLength === Number(downloadPart.size) && bodyLength === plannedPart.size,
+      'direct/presigned GET hash matches manifest and source': () =>
+        actualHash === String(downloadPart.cipherHash) && actualHash === plannedPart.hash,
+    });
+    recordRawStorageResult(getResponse, getTags, getOk);
+    if (!getOk) {
+      return failIteration(
+        context,
+        scenarioName,
+        startedAt,
+        uploadStartedAt,
+        uploadedBytes,
+        downloadedBytes,
+        undefined,
+      );
+    }
+    downloadedBytes += bodyLength;
+  }
+
+  const completedAt = Date.now();
+  recordDirectPathResult(
+    {
+      uploadMs: uploadCompletedAt - uploadStartedAt,
+      downloadMs: completedAt - downloadStartedAt,
+      totalMs: completedAt - startedAt,
+      uploadedBytes,
+      downloadedBytes,
+      ok: true,
+    },
+    buildRequestTags(scenarioName, 'direct_path', 'CUSTOM'),
+  );
+  return { ok: true, clientId: String(issuedClientId), fileHash: String(fileHash) };
+}
+
+/**
+ * 初始化直传压测上下文。
+ *
+ * @returns {{token:string,config:Record<string,string>}} 压测上下文
+ */
+export function setup() {
+  const token = loginOrFail(baseConfig, 'direct_path_setup', 1);
+  const context = { token, config: baseConfig };
+  captureDirectSnapshotAvailability(context, 'direct-path', 'start');
+  return context;
+}
+
+/**
+ * 运行一次直传上传/下载闭环。
+ *
+ * @param {{token:string,config:Record<string,string>}} data setup 返回上下文
+ */
+export default function (data) {
+  runDirectPathFlow(data, 'direct-path');
+  sleep(1);
+}
+
+/**
+ * 强制清理本 run 文件；失败会计入阈值并终止运行。
+ *
+ * @param {{token:string,config:Record<string,string>}} data setup 返回上下文
+ */
+export function teardown(data) {
+  try {
+    if (!cleanupEnabled) {
+      directCleanupFailureRate.add(true, { reason: 'disabled' });
+      throw new Error('direct-path 要求启用 CLEANUP 以证明无残留');
+    }
+
+    const cleanupResult = cleanupRunFiles(data);
+    directCleanupFailureRate.add(!cleanupResult.ok, {
+      reason: cleanupResult.reason || 'none',
+    });
+    if (!cleanupResult.ok) {
+      throw new Error(`direct-path 清理失败: ${cleanupResult.reason}`);
+    }
+  } finally {
+    captureDirectSnapshotAvailability(data, 'direct-path', 'end');
+  }
+}
+
+export const handleSummary = createSummaryHandler(standaloneSummaryConfig, 'direct-path');

--- a/tools/k6/lib/cleanup.js
+++ b/tools/k6/lib/cleanup.js
@@ -81,13 +81,21 @@ function deleteFiles(config, token, identifiers) {
 }
 
 /**
- * 根据 runId 兜底清理压测文件，失败时只告警不抛错。
+ * 根据 runId 兜底清理压测文件并返回可审计结果。
  *
  * @param {{config:{baseUrl:string, tenantId:string, runId:string}, token:string}} context 上下文
+ * @returns {{ok:boolean, queried:boolean, found:number, deleted:number, remaining:number|null, reason:string|null}} 清理结果
  */
 export function cleanupRunFiles(context) {
   if (!context || !context.config || !context.token) {
-    return;
+    return {
+      ok: false,
+      queried: false,
+      found: 0,
+      deleted: 0,
+      remaining: null,
+      reason: 'invalid_context',
+    };
   }
 
   const keyword = `k6-${context.config.runId}`;
@@ -101,7 +109,14 @@ export function cleanupRunFiles(context) {
     const result = queryFilesByKeyword(context.config, context.token, keyword, pageNum);
     if (!result.ok) {
       console.warn(`[k6-cleanup] 查询待删文件失败，keyword=${keyword}, pageNum=${pageNum}`);
-      break;
+      return {
+        ok: false,
+        queried: true,
+        found: allIdentifiers.length,
+        deleted: 0,
+        remaining: null,
+        reason: 'query_failed',
+      };
     }
 
     const identifiers = extractIdentifiers(result.records);
@@ -111,16 +126,72 @@ export function cleanupRunFiles(context) {
     pageNum += 1;
   }
 
+  if (totalPages > maxPages) {
+    return {
+      ok: false,
+      queried: true,
+      found: allIdentifiers.length,
+      deleted: 0,
+      remaining: null,
+      reason: 'page_limit_exceeded',
+    };
+  }
+
   const deduplicated = Array.from(new Set(allIdentifiers));
   if (deduplicated.length === 0) {
-    return;
+    return {
+      ok: true,
+      queried: true,
+      found: 0,
+      deleted: 0,
+      remaining: 0,
+      reason: null,
+    };
   }
 
   const success = deleteFiles(context.config, context.token, deduplicated);
   if (!success) {
     console.warn(`[k6-cleanup] 批量删除失败，count=${deduplicated.length}`);
-    return;
+    return {
+      ok: false,
+      queried: true,
+      found: deduplicated.length,
+      deleted: 0,
+      remaining: deduplicated.length,
+      reason: 'delete_failed',
+    };
   }
 
-  console.log(`[k6-cleanup] 批量删除成功，count=${deduplicated.length}`);
+  const verification = queryFilesByKeyword(context.config, context.token, keyword, 1);
+  if (!verification.ok) {
+    return {
+      ok: false,
+      queried: true,
+      found: deduplicated.length,
+      deleted: deduplicated.length,
+      remaining: null,
+      reason: 'verification_query_failed',
+    };
+  }
+  const remaining = extractIdentifiers(verification.records).length;
+  if (remaining > 0) {
+    return {
+      ok: false,
+      queried: true,
+      found: deduplicated.length,
+      deleted: deduplicated.length,
+      remaining,
+      reason: 'residual_files',
+    };
+  }
+
+  console.log(`[k6-cleanup] 批量删除并复核成功，count=${deduplicated.length}`);
+  return {
+    ok: true,
+    queried: true,
+    found: deduplicated.length,
+    deleted: deduplicated.length,
+    remaining: 0,
+    reason: null,
+  };
 }

--- a/tools/k6/lib/config.js
+++ b/tools/k6/lib/config.js
@@ -48,10 +48,13 @@ export function generateDefaultRunId() {
 /**
  * 构建基础配置（认证、地址、运行标识、报告路径）。
  *
- * @returns {{baseUrl:string, tenantId:string, username:string, password:string, runId:string, resultDir:string, profile:string, scenario:string}} 基础配置
+ * @returns {{baseUrl:string, tenantId:string, username:string, password:string, runId:string, resultDir:string, profile:string, scenario:string, suite:string, directExecution:Record<string, any>}} 基础配置
  */
 export function getBaseConfig() {
   const runId = __ENV.RUN_ID || generateDefaultRunId();
+  const directPath = getDirectPathConfig();
+  const profile = __ENV.K6_PROFILE || 'smoke';
+  const suite = __ENV.K6_SUITE || 'local';
 
   return {
     baseUrl: __ENV.BASE_URL || 'http://localhost:8000/record-platform/api/v1',
@@ -60,8 +63,51 @@ export function getBaseConfig() {
     password: __ENV.PASSWORD || '',
     runId,
     resultDir: __ENV.RESULT_DIR || 'tools/k6/results',
-    profile: __ENV.K6_PROFILE || 'smoke',
+    profile,
     scenario: __ENV.K6_SCENARIO || 'all',
+    suite,
+    engine: __ENV.K6_ENGINE || 'unknown',
+    engineArtifact: __ENV.K6_ENGINE_ARTIFACT || 'unavailable:not-configured',
+    environmentFingerprint: __ENV.ENVIRONMENT_FINGERPRINT || 'unavailable:not-configured',
+    resourceSnapshotPath: __ENV.DIRECT_RESOURCE_SNAPSHOT_PATH || '',
+    lifecycleSnapshotPath: __ENV.DIRECT_LIFECYCLE_SNAPSHOT_PATH || '',
+    directPath,
+    directExecution: getDirectExecutionConfig(profile, suite),
+  };
+}
+
+/**
+ * 构建可审计的 direct-path 执行模型，防止不同并发或时长被误当成同一基线。
+ *
+ * @param {string} profile 运行档位
+ * @param {string} suite 套件来源（local|ci）
+ * @returns {{executor:string,concurrency:number,duration:string,preAllocatedVUs:number|null,maxVUs:number|null}} 执行参数
+ */
+function getDirectExecutionConfig(profile, suite) {
+  if (suite === 'ci') {
+    return {
+      executor: 'constant-vus',
+      concurrency: parseIntEnv('CI_DIRECT_PATH_VUS', 1, 1),
+      duration: __ENV.CI_DIRECT_PATH_DURATION || '60s',
+      preAllocatedVUs: null,
+      maxVUs: null,
+    };
+  }
+  if (profile === 'load') {
+    return {
+      executor: 'constant-arrival-rate',
+      concurrency: parseIntEnv('DIRECT_PATH_RATE', 1, 1),
+      duration: __ENV.DIRECT_PATH_DURATION || '3m',
+      preAllocatedVUs: parseIntEnv('DIRECT_PATH_PRE_ALLOCATED_VUS', 5, 1),
+      maxVUs: parseIntEnv('DIRECT_PATH_MAX_VUS', 20, 1),
+    };
+  }
+  return {
+    executor: 'constant-vus',
+    concurrency: parseIntEnv('SMOKE_DIRECT_PATH_VUS', parseIntEnv('VUS', 1, 1), 1),
+    duration: __ENV.SMOKE_DIRECT_PATH_DURATION || __ENV.DURATION || '90s',
+    preAllocatedVUs: null,
+    maxVUs: null,
   };
 }
 
@@ -91,6 +137,19 @@ export function getUploadConfig() {
   return {
     totalChunks: parseIntEnv('TOTAL_CHUNKS', 5, 1),
     chunkSize: parseIntEnv('CHUNK_SIZE', 1024, 1),
+  };
+}
+
+/**
+ * 构建直传上传/下载压测配置。
+ *
+ * @returns {{totalChunks:number, chunkSize:number, p99BudgetMs:number}} 直传配置
+ */
+export function getDirectPathConfig() {
+  return {
+    totalChunks: parseIntEnv('DIRECT_TOTAL_CHUNKS', parseIntEnv('TOTAL_CHUNKS', 2, 1), 1),
+    chunkSize: parseIntEnv('DIRECT_CHUNK_SIZE', parseIntEnv('CHUNK_SIZE', 64 * 1024, 1), 1),
+    p99BudgetMs: parseIntEnv('DIRECT_P99_BUDGET_MS', 60_000, 1),
   };
 }
 
@@ -151,6 +210,22 @@ export function getUploadThresholds() {
 }
 
 /**
+ * 获取直传全链路阈值，确保失败、哈希漂移和清理残留都能使运行失败。
+ *
+ * @returns {Record<string, string[]>} 直传阈值映射
+ */
+export function getDirectPathThresholds() {
+  const budget = getDirectPathConfig().p99BudgetMs;
+  return {
+    direct_flow_failure_rate: ['rate==0'],
+    direct_cleanup_failure_rate: ['rate==0'],
+    direct_upload_e2e_ms: [`p(99)<${budget}`],
+    direct_download_e2e_ms: [`p(99)<${budget}`],
+    direct_path_e2e_ms: [`p(99)<${budget}`],
+  };
+}
+
+/**
  * 合并多组阈值配置。
  *
  * @param {...Record<string, string[]>} thresholdGroups 阈值组
@@ -158,6 +233,34 @@ export function getUploadThresholds() {
  */
 export function mergeThresholds(...thresholdGroups) {
   return Object.assign({}, ...thresholdGroups);
+}
+
+/**
+ * 返回报告必须保留的 Trend 统计项，确保 p50/p95/p99 可进入 handleSummary。
+ *
+ * @returns {string[]} Trend 统计项
+ */
+export function getSummaryTrendStats() {
+  return ['avg', 'med', 'p(50)', 'p(90)', 'p(95)', 'p(99)', 'max'];
+}
+
+/**
+ * 返回不会记录请求 URL/name 的系统标签，防止预签名查询参数进入输出或 artifact。
+ *
+ * @returns {string[]} 允许的 k6 系统标签
+ */
+export function getSafeSystemTags() {
+  return [
+    'status',
+    'method',
+    'group',
+    'check',
+    'error',
+    'error_code',
+    'scenario',
+    'service',
+    'expected_response',
+  ];
 }
 
 /**
@@ -173,6 +276,8 @@ export function createConstantVusOptions(defaultVus, defaultDuration, thresholds
     vus: parseIntEnv('VUS', defaultVus, 1),
     duration: __ENV.DURATION || defaultDuration,
     thresholds,
+    summaryTrendStats: getSummaryTrendStats(),
+    systemTags: getSafeSystemTags(),
   };
 }
 

--- a/tools/k6/lib/metrics.js
+++ b/tools/k6/lib/metrics.js
@@ -16,6 +16,74 @@ export const businessErrorRate = new Rate('business_error_rate');
 export const uploadFileCount = new Counter('upload_file_count');
 
 /**
+ * 直传上传阶段耗时（毫秒）。
+ */
+export const directUploadE2eMs = new Trend('direct_upload_e2e_ms', true);
+
+/**
+ * 直传下载校验阶段耗时（毫秒）。
+ */
+export const directDownloadE2eMs = new Trend('direct_download_e2e_ms', true);
+
+/**
+ * 直传创建到下载校验完成的全链路耗时（毫秒）。
+ */
+export const directPathE2eMs = new Trend('direct_path_e2e_ms', true);
+
+/**
+ * 直传流程失败率。
+ */
+export const directFlowFailureRate = new Rate('direct_flow_failure_rate');
+
+/**
+ * 直传清理失败率。
+ */
+export const directCleanupFailureRate = new Rate('direct_cleanup_failure_rate');
+
+/**
+ * 直传上传字节数。
+ */
+export const directUploadedBytes = new Counter('direct_uploaded_bytes');
+
+/**
+ * 直传下载并校验通过的字节数。
+ */
+export const directDownloadedBytes = new Counter('direct_downloaded_bytes');
+
+/**
+ * 完成直传上传并下载校验的文件数。
+ */
+export const directFileCount = new Counter('direct_file_count');
+
+/**
+ * 目标资源快照可用率。
+ */
+export const directResourceSnapshotStartAvailability = new Rate(
+  'direct_resource_snapshot_start_availability',
+);
+
+/**
+ * 目标资源结束快照可用率。
+ */
+export const directResourceSnapshotEndAvailability = new Rate(
+  'direct_resource_snapshot_end_availability',
+);
+
+/**
+ * 存储生命周期快照可用率。
+ */
+export const directLifecycleSnapshotStartAvailability = new Rate(
+  'direct_lifecycle_snapshot_start_availability',
+);
+
+/**
+ * 存储生命周期结束快照可用率。
+ */
+export const directLifecycleSnapshotEndAvailability = new Rate(
+  'direct_lifecycle_snapshot_end_availability',
+);
+
+/**
  * 接口请求总量（按 endpoint tag 聚合）。
  */
 export const endpointRequestCount = new Counter('endpoint_request_count');
@@ -52,6 +120,47 @@ export function recordUploadE2e(durationMs, tags = {}) {
  */
 export function recordUploadFile(tags = {}) {
   uploadFileCount.add(1, tags);
+}
+
+/**
+ * 记录一次直传上传、下载和端到端结果。
+ *
+ * @param {{uploadMs:number, downloadMs:number, totalMs:number, uploadedBytes:number, downloadedBytes:number, ok:boolean}} result 直传结果
+ * @param {Record<string, string>} tags 指标标签
+ */
+export function recordDirectPathResult(result, tags = {}) {
+  directUploadE2eMs.add(result.uploadMs, tags);
+  directDownloadE2eMs.add(result.downloadMs, tags);
+  directPathE2eMs.add(result.totalMs, tags);
+  directUploadedBytes.add(result.uploadedBytes, tags);
+  directDownloadedBytes.add(result.downloadedBytes, tags);
+  directFlowFailureRate.add(!result.ok, tags);
+  if (result.ok) {
+    directFileCount.add(1, tags);
+  }
+}
+
+/**
+ * 记录目标资源与存储生命周期快照是否可用。
+ *
+ * @param {boolean} resourceAvailable 资源快照是否可用
+ * @param {boolean} lifecycleAvailable 生命周期快照是否可用
+ * @param {'start'|'end'} stage 快照阶段
+ * @param {Record<string, string>} tags 指标标签
+ */
+export function recordDirectSnapshotAvailability(
+  resourceAvailable,
+  lifecycleAvailable,
+  stage,
+  tags = {},
+) {
+  if (stage === 'start') {
+    directResourceSnapshotStartAvailability.add(resourceAvailable, tags);
+    directLifecycleSnapshotStartAvailability.add(lifecycleAvailable, tags);
+    return;
+  }
+  directResourceSnapshotEndAvailability.add(resourceAvailable, tags);
+  directLifecycleSnapshotEndAvailability.add(lifecycleAvailable, tags);
 }
 
 /**

--- a/tools/k6/lib/summary.js
+++ b/tools/k6/lib/summary.js
@@ -162,7 +162,7 @@ function buildEndpointMetricLines(endpointStats) {
     const durationValues = stat.durationValues || {};
     const errorRate = stat.requests > 0 ? stat.failures / stat.requests : undefined;
 
-    return `${endpoint} -> p50=${formatMs(durationValues['p(50)'])}, p90=${formatMs(durationValues['p(90)'])}, p95=${formatMs(durationValues['p(95)'])}, error=${formatRate(errorRate)}, requests=${formatCount(stat.requests)}`;
+    return `${endpoint} -> p50=${formatMs(durationValues['p(50)'])}, p90=${formatMs(durationValues['p(90)'])}, p95=${formatMs(durationValues['p(95)'])}, p99=${formatMs(durationValues['p(99)'])}, error=${formatRate(errorRate)}, requests=${formatCount(stat.requests)}`;
   });
 }
 
@@ -170,7 +170,7 @@ function buildEndpointMetricLines(endpointStats) {
  * 构建 endpoint 维度结构化快照，供报告自动回填使用。
  *
  * @param {Record<string, {durationValues:Record<string,number>, requests:number, failures:number}>} endpointStats 端点聚合结果
- * @returns {Record<string, {p50:number|null, p90:number|null, p95:number|null, errorRate:number|null, requests:number, failures:number}>} endpoint 快照
+ * @returns {Record<string, {p50:number|null, p90:number|null, p95:number|null, p99:number|null, errorRate:number|null, requests:number, failures:number}>} endpoint 快照
  */
 function buildEndpointMetricSnapshot(endpointStats) {
   const snapshot = {};
@@ -183,6 +183,7 @@ function buildEndpointMetricSnapshot(endpointStats) {
       p50: durationValues['p(50)'] ?? null,
       p90: durationValues['p(90)'] ?? null,
       p95: durationValues['p(95)'] ?? null,
+      p99: durationValues['p(99)'] ?? null,
       errorRate,
       requests: stat.requests,
       failures: stat.failures,
@@ -278,6 +279,220 @@ function buildMetricsSnapshot(metrics) {
 }
 
 /**
+ * 提取 Trend 指标的分位值，缺失时保留 null。
+ *
+ * @param {Record<string, any>} metrics 指标对象
+ * @param {string} metricName 指标名
+ * @returns {{p50:number|null,p95:number|null,p99:number|null,avg:number|null}} 分位值
+ */
+function readTrend(metrics, metricName) {
+  const values = metrics?.[metricName]?.values || {};
+  return {
+    p50: values['p(50)'] ?? null,
+    p95: values['p(95)'] ?? null,
+    p99: values['p(99)'] ?? null,
+    avg: values.avg ?? null,
+  };
+}
+
+/**
+ * 提取 Rate 指标并显式标识未采集状态。
+ *
+ * @param {Record<string, any>} metrics 指标对象
+ * @param {string} metricName 指标名
+ * @param {boolean} configured 是否配置了采集端点
+ * @returns {{status:string,rate:number|null,reason:string|null}} 可用性状态
+ */
+function readAvailability(metrics, metricName, configured) {
+  if (!configured) {
+    return {
+      status: 'unavailable',
+      rate: null,
+      reason: 'not_configured',
+    };
+  }
+  const values = metrics?.[metricName]?.values;
+  if (!values || values.rate === undefined || values.rate === null) {
+    return {
+      status: 'unavailable',
+      rate: null,
+      reason: 'no_samples',
+    };
+  }
+  return {
+    status: Number(values.rate) > 0 ? 'available' : 'unavailable',
+    rate: Number(values.rate),
+    reason: Number(values.rate) > 0 ? null : 'probe_failed',
+  };
+}
+
+/**
+ * 构建开始/结束两阶段快照可用性，禁止用单次探测冒充前后对照。
+ *
+ * @param {Record<string, any>} metrics 指标对象
+ * @param {string} prefix 指标前缀
+ * @param {boolean} configured 是否配置了快照端点
+ * @returns {{start:Record<string,any>,end:Record<string,any>}} 两阶段状态
+ */
+function readSnapshotPair(metrics, prefix, configured) {
+  return {
+    start: readAvailability(metrics, `${prefix}_start_availability`, configured),
+    end: readAvailability(metrics, `${prefix}_end_availability`, configured),
+  };
+}
+
+/**
+ * 读取 Counter 数值；指标缺失时返回 null，禁止把未执行伪装成零。
+ *
+ * @param {Record<string, any>} values Counter values
+ * @param {string} name 字段名
+ * @returns {number|null} 真实数值或不可用
+ */
+function readFiniteValue(values, name) {
+  const value = values?.[name];
+  return Number.isFinite(value) ? Number(value) : null;
+}
+
+/**
+ * 构建直传全链路基线，环境不一致时由比较器拒绝比较。
+ *
+ * @param {any} data k6 summary 数据
+ * @param {string} suiteName 套件名
+ * @param {{runId:string,profile:string,scenario:string,engine:string,environmentFingerprint:string,resourceSnapshotPath:string,lifecycleSnapshotPath:string,directExecution:Record<string,any>}} config 配置
+ * @returns {Record<string, any>} 直传基线
+ */
+function buildDirectPathBaseline(data, suiteName, config) {
+  const metrics = data.metrics || {};
+  const uploaded = metrics.direct_uploaded_bytes?.values || {};
+  const downloaded = metrics.direct_downloaded_bytes?.values || {};
+  const files = metrics.direct_file_count?.values || {};
+  const flowFailure = metrics.direct_flow_failure_rate?.values || {};
+  const cleanupFailure = metrics.direct_cleanup_failure_rate?.values || {};
+  const flowSamples = Number(flowFailure.passes || 0) + Number(flowFailure.fails || 0);
+  const cleanupSamples = Number(cleanupFailure.passes || 0) + Number(cleanupFailure.fails || 0);
+  const completedFiles = Number(files.count || 0);
+  const latency = {
+    upload: readTrend(metrics, 'direct_upload_e2e_ms'),
+    download: readTrend(metrics, 'direct_download_e2e_ms'),
+    endToEnd: readTrend(metrics, 'direct_path_e2e_ms'),
+  };
+  const throughput = {
+    uploadedBytes: readFiniteValue(uploaded, 'count'),
+    uploadedBytesPerSecond: readFiniteValue(uploaded, 'rate'),
+    downloadedBytes: readFiniteValue(downloaded, 'count'),
+    downloadedBytesPerSecond: readFiniteValue(downloaded, 'rate'),
+    completedFiles: readFiniteValue(files, 'count'),
+    completedFilesPerSecond: readFiniteValue(files, 'rate'),
+  };
+  const requiredNumbers = [
+    latency.upload.p95,
+    latency.upload.p99,
+    latency.download.p95,
+    latency.download.p99,
+    latency.endToEnd.p95,
+    latency.endToEnd.p99,
+    throughput.uploadedBytesPerSecond,
+    throughput.downloadedBytesPerSecond,
+    flowFailure.rate,
+    cleanupFailure.rate,
+  ];
+  const metricsComplete = requiredNumbers.every((value) => Number.isFinite(value));
+  const compatibilityComplete = Boolean(
+    config.environmentFingerprint &&
+    !String(config.environmentFingerprint).startsWith('unavailable:') &&
+    config.engine &&
+    config.engineArtifact &&
+    !String(config.engineArtifact).startsWith('unavailable:') &&
+    config.directPath &&
+    Number.isFinite(config.directPath.totalChunks) &&
+    Number.isFinite(config.directPath.chunkSize) &&
+    config.directExecution?.executor &&
+    Number.isFinite(config.directExecution?.concurrency) &&
+    config.directExecution?.duration,
+  );
+  return {
+    schemaVersion: 2,
+    runId: config.runId,
+    profile: config.profile,
+    scenario: config.scenario,
+    suite: suiteName,
+    generatedAt: new Date().toISOString(),
+    environment: {
+      fingerprint: config.environmentFingerprint || 'unavailable:not-configured',
+      engine: config.engine || 'unknown',
+      engineArtifact: config.engineArtifact || 'unavailable:not-configured',
+    },
+    workload: config.directPath || null,
+    execution: config.directExecution || null,
+    latencyMs: latency,
+    throughput,
+    failure: {
+      flowRate: flowFailure.rate ?? null,
+      cleanupRate: cleanupFailure.rate ?? null,
+    },
+    evidence: {
+      flowSamples,
+      cleanupSamples,
+      completedFiles,
+      metricsComplete,
+      compatibilityComplete,
+      valid: flowSamples > 0 && cleanupSamples > 0 && completedFiles > 0 &&
+        metricsComplete && compatibilityComplete,
+    },
+    resourceSnapshot: readSnapshotPair(
+      metrics,
+      'direct_resource_snapshot',
+      Boolean(config.resourceSnapshotPath),
+    ),
+    lifecycleSnapshot: readSnapshotPair(
+      metrics,
+      'direct_lifecycle_snapshot',
+      Boolean(config.lifecycleSnapshotPath),
+    ),
+  };
+}
+
+/**
+ * 渲染直传基线的人类可读 Markdown 报告。
+ *
+ * @param {Record<string, any>} baseline 直传基线
+ * @returns {string} Markdown 报告
+ */
+function buildDirectPathReport(baseline) {
+  const upload = baseline.latencyMs.upload;
+  const download = baseline.latencyMs.download;
+  const endToEnd = baseline.latencyMs.endToEnd;
+  const lines = [
+    '# Direct path load report',
+    '',
+    `- Run: \`${baseline.runId}\``,
+    `- Profile/scenario: \`${baseline.profile}/${baseline.scenario}\``,
+    `- Environment fingerprint: \`${baseline.environment.fingerprint}\``,
+    `- Engine: \`${baseline.environment.engine}\` (${baseline.environment.engineArtifact})`,
+    `- Workload: ${baseline.workload ? `${baseline.workload.totalChunks} chunks x ${baseline.workload.chunkSize} bytes` : 'unavailable'}`,
+    `- Execution: ${baseline.execution ? `${baseline.execution.executor}, concurrency=${baseline.execution.concurrency}, duration=${baseline.execution.duration}` : 'unavailable'}`,
+    '',
+    '| Metric | p50 | p95 | p99 |',
+    '|---|---:|---:|---:|',
+    `| Upload | ${formatMs(upload.p50)} | ${formatMs(upload.p95)} | ${formatMs(upload.p99)} |`,
+    `| Download | ${formatMs(download.p50)} | ${formatMs(download.p95)} | ${formatMs(download.p99)} |`,
+    `| End-to-end | ${formatMs(endToEnd.p50)} | ${formatMs(endToEnd.p95)} | ${formatMs(endToEnd.p99)} |`,
+    '',
+    `- Upload throughput: ${baseline.throughput.uploadedBytesPerSecond === null ? 'N/A' : `${Number(baseline.throughput.uploadedBytesPerSecond).toFixed(2)} bytes/s`}`,
+    `- Download throughput: ${baseline.throughput.downloadedBytesPerSecond === null ? 'N/A' : `${Number(baseline.throughput.downloadedBytesPerSecond).toFixed(2)} bytes/s`}`,
+    `- Flow failure rate: ${formatRate(baseline.failure.flowRate)}`,
+    `- Cleanup failure rate: ${formatRate(baseline.failure.cleanupRate)}`,
+    `- Evidence valid: ${baseline.evidence.valid} (flows=${baseline.evidence.flowSamples}, cleanup=${baseline.evidence.cleanupSamples}, files=${baseline.evidence.completedFiles})`,
+    `- Resource snapshot start/end: ${baseline.resourceSnapshot.start.status} / ${baseline.resourceSnapshot.end.status}`,
+    `- Lifecycle snapshot start/end: ${baseline.lifecycleSnapshot.start.status} / ${baseline.lifecycleSnapshot.end.status}`,
+    '',
+    '> unavailable 表示目标环境未配置或未成功返回观测快照，不会伪装成 0。',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+/**
  * 生成人类可读文本报告。
  *
  * @param {any} data k6 summary 数据
@@ -292,6 +507,9 @@ function buildTextSummary(data, suiteName, config) {
   const failedValues = metrics.http_req_failed?.values || {};
   const checksValues = metrics.checks?.values || {};
   const uploadValues = metrics.upload_e2e_ms?.values || {};
+  const directUploadValues = metrics.direct_upload_e2e_ms?.values || {};
+  const directDownloadValues = metrics.direct_download_e2e_ms?.values || {};
+  const directPathValues = metrics.direct_path_e2e_ms?.values || {};
 
   const thresholdStatus = collectThresholdStatus(metrics);
   const endpointStats = collectEndpointStats(metrics);
@@ -304,10 +522,13 @@ function buildTextSummary(data, suiteName, config) {
   lines.push('');
   lines.push('== Global Metrics ==');
   lines.push(`http_reqs: count=${formatCount(requestValues.count)}`);
-  lines.push(`http_req_duration: avg=${formatMs(durationValues.avg)}, p90=${formatMs(durationValues['p(90)'])}, p95=${formatMs(durationValues['p(95)'])}`);
+  lines.push(`http_req_duration: avg=${formatMs(durationValues.avg)}, p90=${formatMs(durationValues['p(90)'])}, p95=${formatMs(durationValues['p(95)'])}, p99=${formatMs(durationValues['p(99)'])}`);
   lines.push(`http_req_failed: rate=${failedValues.rate !== undefined ? Number(failedValues.rate).toFixed(4) : 'N/A'}`);
   lines.push(`checks: rate=${checksValues.rate !== undefined ? Number(checksValues.rate).toFixed(4) : 'N/A'}`);
   lines.push(`upload_e2e_ms: p95=${formatMs(uploadValues['p(95)'])}`);
+  lines.push(`direct_upload_e2e_ms: p95=${formatMs(directUploadValues['p(95)'])}, p99=${formatMs(directUploadValues['p(99)'])}`);
+  lines.push(`direct_download_e2e_ms: p95=${formatMs(directDownloadValues['p(95)'])}, p99=${formatMs(directDownloadValues['p(99)'])}`);
+  lines.push(`direct_path_e2e_ms: p95=${formatMs(directPathValues['p(95)'])}, p99=${formatMs(directPathValues['p(99)'])}`);
   lines.push('');
 
   lines.push('== Endpoint Metrics ==');
@@ -351,7 +572,7 @@ function buildTextSummary(data, suiteName, config) {
  * @param {any} data k6 summary 数据
  * @param {string} suiteName 套件名
  * @param {{runId:string, profile:string, scenario:string}} config 配置
- * @returns {{runId:string, profile:string, scenario:string, suite:string, generatedAt:string, thresholdFailedCount:number, thresholds:Array<{metric:string, threshold:string, ok:boolean}>, endpoints:Record<string, {p50:number|null, p90:number|null, p95:number|null, errorRate:number|null, requests:number, failures:number}>}} 基线快照
+ * @returns {{runId:string, profile:string, scenario:string, suite:string, generatedAt:string, thresholdFailedCount:number, thresholds:Array<{metric:string, threshold:string, ok:boolean}>, endpoints:Record<string, {p50:number|null, p90:number|null, p95:number|null, p99:number|null, errorRate:number|null, requests:number, failures:number}>}} 基线快照
  */
 function buildQueryBaselineSnapshot(data, suiteName, config) {
   const metrics = data.metrics || {};
@@ -383,12 +604,16 @@ export function createSummaryHandler(config, suiteName) {
     const textSummary = buildTextSummary(data, suiteName, config);
     const metricsSnapshot = buildMetricsSnapshot(data.metrics || {});
     const queryBaselineSnapshot = buildQueryBaselineSnapshot(data, suiteName, config);
+    const directPathBaseline = buildDirectPathBaseline(data, suiteName, config);
+    const directPathReport = buildDirectPathReport(directPathBaseline);
 
     return {
       [buildResultPath(outputDir, 'summary.txt')]: textSummary,
       [buildResultPath(outputDir, 'summary.json')]: JSON.stringify(data, null, 2),
       [buildResultPath(outputDir, 'metrics.json')]: JSON.stringify(metricsSnapshot, null, 2),
       [buildResultPath(outputDir, 'query-baseline.json')]: JSON.stringify(queryBaselineSnapshot, null, 2),
+      [buildResultPath(outputDir, 'direct-path-baseline.json')]: JSON.stringify(directPathBaseline, null, 2),
+      [buildResultPath(outputDir, 'direct-path-report.md')]: directPathReport,
       stdout: textSummary,
     };
   };

--- a/tools/k6/run-ci.sh
+++ b/tools/k6/run-ci.sh
@@ -8,6 +8,9 @@ Usage: tools/k6/run-ci.sh [options]
 
 Options:
   --include-chunk               在 CI smoke 中追加 chunk-upload 场景
+  --include-direct              在 CI smoke 中追加 direct-path 场景
+  --scenario <all|file-query|core-mixed|chunk-upload|direct-path>
+                                 场景过滤（默认：all）
   --engine <auto|local|docker>  执行引擎（默认：auto；auto 仅自动使用本地 k6）
   --run-id <id>                 自定义运行 ID（默认：ci-当前时间）
   --result-dir <dir>            自定义结果目录（默认：tools/k6/results/<run-id>）
@@ -19,6 +22,7 @@ Environment (required):
   USERNAME
   PASSWORD
   K6_DOCKER_IMAGE               Docker 引擎必填，且必须使用 digest 固定镜像
+  ENVIRONMENT_FINGERPRINT       同环境 baseline 比较标识（默认按目标掩码/引擎/OS 生成）
 USAGE
 }
 
@@ -29,6 +33,17 @@ USAGE
 has_command() {
   local cmd="$1"
   command -v "$cmd" >/dev/null 2>&1
+}
+
+# 校验运行标识可安全用于文件名、会话名和精确清理关键字。
+#
+# @param $1 运行 ID
+validate_run_id() {
+  local run_id="$1"
+  if [[ ! "$run_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]]; then
+    echo "[ERROR] run-id 必须为 1-64 位，首位为字母或数字，其余仅允许字母、数字、点、下划线或连字符。" >&2
+    exit 1
+  fi
 }
 
 # 根据输入参数解析最终执行引擎。
@@ -170,6 +185,22 @@ mask_base_url() {
   printf '%s' "$masked"
 }
 
+# 生成不包含凭证的环境指纹，供 baseline 比较前置校验。
+#
+# @param $1 脱敏目标地址
+# @param $2 engine
+# @returns 环境指纹
+build_environment_fingerprint() {
+  local target_mask="$1"
+  local engine="$2"
+  local source="target=${target_mask};engine=${engine};artifact=${K6_ENGINE_ARTIFACT:-unavailable};os=$(uname -s);arch=$(uname -m)"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$source" | shasum -a 256 | awk '{print $1}'
+    return
+  fi
+  printf '%s' "$source" | sha256sum | awk '{print $1}'
+}
+
 # 写入运行元数据，供审计与报告回填使用。
 #
 # @param $1 结果目录
@@ -186,10 +217,20 @@ write_run_meta() {
   local timestamp
   local base_url
   local base_url_mask
+  local cpu_count
+  local memory_bytes
+  local os_name
+  local architecture
+  local k6_version
 
   timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   base_url="${BASE_URL:-http://localhost:8000/record-platform/api/v1}"
   base_url_mask="$(mask_base_url "$base_url")"
+  os_name="$(uname -s)"
+  architecture="$(uname -m)"
+  cpu_count="$(sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo unavailable)"
+  memory_bytes="$(sysctl -n hw.memsize 2>/dev/null || awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || echo unavailable)"
+  k6_version="${K6_ENGINE_ARTIFACT:-unavailable:not-configured}"
 
   cat >"${result_dir}/run-meta.json" <<EOF
 {
@@ -197,10 +238,31 @@ write_run_meta() {
   "profile": "${profile}",
   "scenario": "${scenario}",
   "engine": "${engine}",
+  "engineArtifact": "${K6_ENGINE_ARTIFACT:-unavailable:not-configured}",
+  "logOutput": "${K6_EFFECTIVE_LOG_OUTPUT:-stderr}",
   "timestamp": "${timestamp}",
-  "baseUrlMask": "${base_url_mask}"
+  "baseUrlMask": "${base_url_mask}",
+  "environmentFingerprint": "${ENVIRONMENT_FINGERPRINT}",
+  "host": {
+    "os": "${os_name}",
+    "architecture": "${architecture}",
+    "cpuCount": "${cpu_count}",
+    "memoryBytes": "${memory_bytes}",
+    "k6Version": "${k6_version}"
+  }
 }
 EOF
+}
+
+# 判断当前 CI 套件是否会访问带签名查询参数的对象存储 URL。
+#
+# @param $1 scenario
+# @param $2 include_direct
+# @returns 0=包含 direct-path，1=不包含
+includes_direct_path() {
+  local scenario="$1"
+  local include_direct="$2"
+  [[ "$scenario" == "direct-path" || ("$scenario" == "all" && "$include_direct" == "true") ]]
 }
 
 # 通过本地 k6 二进制执行压测。
@@ -208,7 +270,7 @@ EOF
 # @param $1 suite 脚本路径
 run_with_local_k6() {
   local suite_script="$1"
-  k6 run "$suite_script"
+  k6 run --log-output "${K6_EFFECTIVE_LOG_OUTPUT:-stderr}" "$suite_script"
 }
 
 # 通过 Docker 中的 grafana/k6 执行压测。
@@ -243,14 +305,38 @@ run_with_docker_k6() {
     -e PASSWORD \
     -e K6_PROFILE \
     -e K6_SCENARIO \
+    -e K6_SUITE \
+    -e K6_ENGINE \
+    -e K6_ENGINE_ARTIFACT \
     -e RUN_ID \
     -e RESULT_DIR \
     -e CLEANUP \
     -e CI_INCLUDE_CHUNK \
+    -e CI_INCLUDE_DIRECT \
     -e TOTAL_CHUNKS \
     -e CHUNK_SIZE \
+    -e DIRECT_TOTAL_CHUNKS \
+    -e DIRECT_CHUNK_SIZE \
+    -e DIRECT_P99_BUDGET_MS \
+    -e DIRECT_RESOURCE_SNAPSHOT_PATH \
+    -e DIRECT_LIFECYCLE_SNAPSHOT_PATH \
+    -e ENVIRONMENT_FINGERPRINT \
+    -e VUS \
+    -e DURATION \
+    -e MIX_QUERY_WEIGHT \
+    -e CI_FILE_QUERY_VUS \
+    -e CI_FILE_QUERY_DURATION \
+    -e CI_CORE_MIXED_VUS \
+    -e CI_CORE_MIXED_DURATION \
+    -e CI_CORE_MIXED_START_TIME \
+    -e CI_CHUNK_UPLOAD_VUS \
+    -e CI_CHUNK_UPLOAD_DURATION \
+    -e CI_CHUNK_START_TIME \
+    -e CI_DIRECT_PATH_VUS \
+    -e CI_DIRECT_PATH_DURATION \
+    -e CI_DIRECT_PATH_START_TIME \
     "$docker_image" \
-    run "$suite_script"
+    run --log-output "${K6_EFFECTIVE_LOG_OUTPUT:-stderr}" "$suite_script"
 }
 
 # 根据执行引擎分发到对应的运行入口。
@@ -288,6 +374,8 @@ validate_required_env() {
 # 主流程：解析参数并运行 CI smoke。
 main() {
   local include_chunk="${CI_INCLUDE_CHUNK:-false}"
+  local include_direct="${CI_INCLUDE_DIRECT:-false}"
+  local scenario="${K6_SCENARIO:-all}"
   local engine="${K6_ENGINE:-auto}"
   local default_base_url="http://localhost:8000/record-platform/api/v1"
   local original_base_url="${BASE_URL:-$default_base_url}"
@@ -299,6 +387,14 @@ main() {
       --include-chunk)
         include_chunk="true"
         shift
+        ;;
+      --include-direct)
+        include_direct="true"
+        shift
+        ;;
+      --scenario)
+        scenario="$2"
+        shift 2
         ;;
       --engine)
         engine="$2"
@@ -324,6 +420,8 @@ main() {
     esac
   done
 
+  validate_run_id "$run_id"
+
   local resolved_engine
   resolved_engine="$(resolve_engine "$engine")"
   validate_required_env
@@ -338,12 +436,29 @@ main() {
   result_dir="$(resolve_existing_dir_absolute_path "$result_dir")"
 
   export K6_PROFILE="smoke"
-  export K6_SCENARIO="${K6_SCENARIO:-all}"
+  export K6_SCENARIO="$scenario"
+  export K6_SUITE="ci"
   export K6_ENGINE="$resolved_engine"
+  if [[ "$resolved_engine" == "docker" ]]; then
+    export K6_ENGINE_ARTIFACT="$K6_DOCKER_IMAGE"
+  else
+    export K6_ENGINE_ARTIFACT="$(k6 version 2>/dev/null | head -1 | tr '"' "'")"
+  fi
   export BASE_URL="$runtime_base_url"
   export CI_INCLUDE_CHUNK="$include_chunk"
+  export CI_INCLUDE_DIRECT="$include_direct"
   export RUN_ID="$run_id"
   export RESULT_DIR="$result_dir"
+  export ENVIRONMENT_FINGERPRINT="${ENVIRONMENT_FINGERPRINT:-$(build_environment_fingerprint "$(mask_base_url "$runtime_base_url")" "$resolved_engine")}"
+  if [[ ! "$ENVIRONMENT_FINGERPRINT" =~ ^[A-Za-z0-9._:-]{1,128}$ ]]; then
+    echo "[ERROR] ENVIRONMENT_FINGERPRINT 仅允许 1-128 位字母、数字、点、下划线、冒号或连字符。" >&2
+    exit 1
+  fi
+  if includes_direct_path "$scenario" "$include_direct"; then
+    export K6_EFFECTIVE_LOG_OUTPUT="none"
+  else
+    export K6_EFFECTIVE_LOG_OUTPUT="${K6_LOG_OUTPUT:-stderr}"
+  fi
 
   if [[ "$resolved_engine" == "docker" && "$runtime_base_url" != "$original_base_url" ]]; then
     echo "[INFO] docker engine 检测到 loopback BASE_URL，已改写为: $(mask_base_url "$runtime_base_url")"
@@ -352,9 +467,8 @@ main() {
   write_run_meta "$result_dir" "$run_id" "$K6_PROFILE" "$K6_SCENARIO" "$resolved_engine"
 
   echo "[INFO] BASE_URL=$(mask_base_url "$BASE_URL")"
-  echo "[INFO] TENANT_ID=$TENANT_ID"
-  echo "[INFO] USERNAME=$USERNAME"
-  echo "[INFO] run_id=$RUN_ID result_dir=$RESULT_DIR include_chunk=$CI_INCLUDE_CHUNK engine=$K6_ENGINE"
+  echo "[INFO] run_id=$RUN_ID result_dir=$RESULT_DIR include_chunk=$CI_INCLUDE_CHUNK include_direct=$CI_INCLUDE_DIRECT engine=$K6_ENGINE"
+  echo "[INFO] k6_log_output=$K6_EFFECTIVE_LOG_OUTPUT"
 
   run_k6_suite "$resolved_engine" "tools/k6/suites/ci-smoke.js"
 }

--- a/tools/k6/run-local.sh
+++ b/tools/k6/run-local.sh
@@ -8,7 +8,7 @@ Usage: tools/k6/run-local.sh [options]
 
 Options:
   --profile <smoke|load>        运行档位（默认：smoke）
-  --scenario <all|file-query|chunk-upload|core-mixed>
+  --scenario <all|file-query|chunk-upload|core-mixed|direct-path>
                                  场景过滤（默认：all）
   --engine <auto|local|docker>  执行引擎（默认：auto；auto 仅自动使用本地 k6）
   --run-id <id>                 自定义运行 ID（默认：当前时间）
@@ -17,6 +17,9 @@ Options:
 
 Environment:
   K6_DOCKER_IMAGE               Docker 引擎必填，且必须使用 digest 固定镜像
+  ENVIRONMENT_FINGERPRINT       同环境 baseline 比较标识（默认按目标掩码/引擎/OS 生成）
+  DIRECT_RESOURCE_SNAPSHOT_PATH 可选的同源资源快照相对路径
+  DIRECT_LIFECYCLE_SNAPSHOT_PATH 可选的同源存储生命周期快照相对路径
 USAGE
 }
 
@@ -27,6 +30,17 @@ USAGE
 has_command() {
   local cmd="$1"
   command -v "$cmd" >/dev/null 2>&1
+}
+
+# 校验运行标识可安全用于文件名、会话名和精确清理关键字。
+#
+# @param $1 运行 ID
+validate_run_id() {
+  local run_id="$1"
+  if [[ ! "$run_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]]; then
+    echo "[ERROR] run-id 必须为 1-64 位，首位为字母或数字，其余仅允许字母、数字、点、下划线或连字符。" >&2
+    exit 1
+  fi
 }
 
 # 根据输入参数解析最终执行引擎。
@@ -168,6 +182,22 @@ mask_base_url() {
   printf '%s' "$masked"
 }
 
+# 生成不包含凭证的环境指纹，供 baseline 比较前置校验。
+#
+# @param $1 脱敏目标地址
+# @param $2 engine
+# @returns 环境指纹
+build_environment_fingerprint() {
+  local target_mask="$1"
+  local engine="$2"
+  local source="target=${target_mask};engine=${engine};artifact=${K6_ENGINE_ARTIFACT:-unavailable};os=$(uname -s);arch=$(uname -m)"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$source" | shasum -a 256 | awk '{print $1}'
+    return
+  fi
+  printf '%s' "$source" | sha256sum | awk '{print $1}'
+}
+
 # 写入运行元数据，供审计与报告回填使用。
 #
 # @param $1 结果目录
@@ -184,10 +214,20 @@ write_run_meta() {
   local timestamp
   local base_url
   local base_url_mask
+  local cpu_count
+  local memory_bytes
+  local os_name
+  local architecture
+  local k6_version
 
   timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   base_url="${BASE_URL:-http://localhost:8000/record-platform/api/v1}"
   base_url_mask="$(mask_base_url "$base_url")"
+  os_name="$(uname -s)"
+  architecture="$(uname -m)"
+  cpu_count="$(sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo unavailable)"
+  memory_bytes="$(sysctl -n hw.memsize 2>/dev/null || awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || echo unavailable)"
+  k6_version="${K6_ENGINE_ARTIFACT:-unavailable:not-configured}"
 
   cat >"${result_dir}/run-meta.json" <<EOF
 {
@@ -195,10 +235,31 @@ write_run_meta() {
   "profile": "${profile}",
   "scenario": "${scenario}",
   "engine": "${engine}",
+  "engineArtifact": "${K6_ENGINE_ARTIFACT:-unavailable:not-configured}",
+  "logOutput": "${K6_EFFECTIVE_LOG_OUTPUT:-stderr}",
   "timestamp": "${timestamp}",
-  "baseUrlMask": "${base_url_mask}"
+  "baseUrlMask": "${base_url_mask}",
+  "environmentFingerprint": "${ENVIRONMENT_FINGERPRINT}",
+  "host": {
+    "os": "${os_name}",
+    "architecture": "${architecture}",
+    "cpuCount": "${cpu_count}",
+    "memoryBytes": "${memory_bytes}",
+    "k6Version": "${k6_version}"
+  }
 }
 EOF
+}
+
+# 判断当前套件是否会访问带签名查询参数的对象存储 URL。
+#
+# @param $1 profile
+# @param $2 scenario
+# @returns 0=包含 direct-path，1=不包含
+includes_direct_path() {
+  local profile="$1"
+  local scenario="$2"
+  [[ "$scenario" == "direct-path" || ("$scenario" == "all" && "$profile" == "load") ]]
 }
 
 # 通过本地 k6 二进制执行压测。
@@ -206,7 +267,7 @@ EOF
 # @param $1 suite 脚本路径
 run_with_local_k6() {
   local suite_script="$1"
-  k6 run "$suite_script"
+  k6 run --log-output "${K6_EFFECTIVE_LOG_OUTPUT:-stderr}" "$suite_script"
 }
 
 # 通过 Docker 中的 grafana/k6 执行压测。
@@ -241,14 +302,51 @@ run_with_docker_k6() {
     -e PASSWORD \
     -e K6_PROFILE \
     -e K6_SCENARIO \
+    -e K6_SUITE \
+    -e K6_ENGINE \
+    -e K6_ENGINE_ARTIFACT \
     -e RUN_ID \
     -e RESULT_DIR \
     -e CLEANUP \
     -e CI_INCLUDE_CHUNK \
     -e TOTAL_CHUNKS \
     -e CHUNK_SIZE \
+    -e DIRECT_TOTAL_CHUNKS \
+    -e DIRECT_CHUNK_SIZE \
+    -e DIRECT_P99_BUDGET_MS \
+    -e DIRECT_RESOURCE_SNAPSHOT_PATH \
+    -e DIRECT_LIFECYCLE_SNAPSHOT_PATH \
+    -e ENVIRONMENT_FINGERPRINT \
+    -e VUS \
+    -e DURATION \
+    -e MIX_QUERY_WEIGHT \
+    -e SMOKE_FILE_QUERY_VUS \
+    -e SMOKE_FILE_QUERY_DURATION \
+    -e SMOKE_CORE_MIXED_VUS \
+    -e SMOKE_CORE_MIXED_DURATION \
+    -e SMOKE_CORE_MIXED_START_TIME \
+    -e SMOKE_CHUNK_UPLOAD_VUS \
+    -e SMOKE_CHUNK_UPLOAD_DURATION \
+    -e SMOKE_CHUNK_START_TIME \
+    -e SMOKE_DIRECT_PATH_VUS \
+    -e SMOKE_DIRECT_PATH_DURATION \
+    -e SMOKE_DIRECT_PATH_START_TIME \
+    -e QUERY_RATE \
+    -e QUERY_DURATION \
+    -e QUERY_PRE_ALLOCATED_VUS \
+    -e QUERY_MAX_VUS \
+    -e UPLOAD_RATE \
+    -e UPLOAD_DURATION \
+    -e UPLOAD_PRE_ALLOCATED_VUS \
+    -e UPLOAD_MAX_VUS \
+    -e LOAD_CHUNK_START_TIME \
+    -e DIRECT_PATH_RATE \
+    -e DIRECT_PATH_DURATION \
+    -e DIRECT_PATH_PRE_ALLOCATED_VUS \
+    -e DIRECT_PATH_MAX_VUS \
+    -e LOAD_DIRECT_START_TIME \
     "$docker_image" \
-    run "$suite_script"
+    run --log-output "${K6_EFFECTIVE_LOG_OUTPUT:-stderr}" "$suite_script"
 }
 
 # 根据执行引擎分发到对应的运行入口。
@@ -327,6 +425,8 @@ main() {
     esac
   done
 
+  validate_run_id "$run_id"
+
   local resolved_engine
   resolved_engine="$(resolve_engine "$engine")"
   local runtime_base_url
@@ -348,10 +448,26 @@ main() {
 
   export K6_PROFILE="$profile"
   export K6_SCENARIO="$scenario"
+  export K6_SUITE="local"
   export K6_ENGINE="$resolved_engine"
+  if [[ "$resolved_engine" == "docker" ]]; then
+    export K6_ENGINE_ARTIFACT="$K6_DOCKER_IMAGE"
+  else
+    export K6_ENGINE_ARTIFACT="$(k6 version 2>/dev/null | head -1 | tr '"' "'")"
+  fi
   export BASE_URL="$runtime_base_url"
   export RUN_ID="$run_id"
   export RESULT_DIR="$result_dir"
+  export ENVIRONMENT_FINGERPRINT="${ENVIRONMENT_FINGERPRINT:-$(build_environment_fingerprint "$(mask_base_url "$runtime_base_url")" "$resolved_engine")}"
+  if [[ ! "$ENVIRONMENT_FINGERPRINT" =~ ^[A-Za-z0-9._:-]{1,128}$ ]]; then
+    echo "[ERROR] ENVIRONMENT_FINGERPRINT 仅允许 1-128 位字母、数字、点、下划线、冒号或连字符。" >&2
+    exit 1
+  fi
+  if includes_direct_path "$profile" "$scenario"; then
+    export K6_EFFECTIVE_LOG_OUTPUT="none"
+  else
+    export K6_EFFECTIVE_LOG_OUTPUT="${K6_LOG_OUTPUT:-stderr}"
+  fi
 
   if [[ "$resolved_engine" == "docker" && "$runtime_base_url" != "$original_base_url" ]]; then
     echo "[INFO] docker engine 检测到 loopback BASE_URL，已改写为: $(mask_base_url "$runtime_base_url")"
@@ -362,6 +478,7 @@ main() {
   echo "[INFO] profile=$K6_PROFILE scenario=$K6_SCENARIO run_id=$RUN_ID"
   echo "[INFO] engine=$K6_ENGINE"
   echo "[INFO] result_dir=$RESULT_DIR"
+  echo "[INFO] k6_log_output=$K6_EFFECTIVE_LOG_OUTPUT"
   echo "[INFO] suite=$suite_script"
 
   run_k6_suite "$resolved_engine" "$suite_script"

--- a/tools/k6/scripts/compare-direct-baseline.mjs
+++ b/tools/k6/scripts/compare-direct-baseline.mjs
@@ -1,0 +1,289 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * 读取并解析直传基线 JSON。
+ *
+ * @param {string} filePath 文件路径
+ * @returns {Record<string, any>} 基线对象
+ */
+function readBaseline(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * 解析命令行参数。
+ *
+ * @returns {{baseline:string,candidate:string,output:string|null,threshold:number}} 参数
+ */
+function parseArgs() {
+  const result = {
+    baseline: '',
+    candidate: '',
+    output: null,
+    threshold: 20,
+  };
+  for (let index = 2; index < process.argv.length; index += 1) {
+    const name = process.argv[index];
+    const value = process.argv[index + 1];
+    if (name === '--baseline') {
+      result.baseline = value;
+      index += 1;
+    } else if (name === '--candidate') {
+      result.candidate = value;
+      index += 1;
+    } else if (name === '--output') {
+      result.output = value;
+      index += 1;
+    } else if (name === '--threshold-percent') {
+      result.threshold = Number(value);
+      index += 1;
+    } else {
+      throw new Error(`未知参数: ${name}`);
+    }
+  }
+  if (!result.baseline || !result.candidate) {
+    throw new Error('必须提供 --baseline 和 --candidate');
+  }
+  if (!Number.isFinite(result.threshold) || result.threshold < 0) {
+    throw new Error('--threshold-percent 必须是非负数');
+  }
+  return result;
+}
+
+/**
+ * 计算候选值相对基线的百分比变化。
+ *
+ * @param {number|null|undefined} baseline 基线值
+ * @param {number|null|undefined} candidate 候选值
+ * @returns {number|null} 百分比变化
+ */
+function percentChange(baseline, candidate) {
+  if (!Number.isFinite(baseline) || !Number.isFinite(candidate) || baseline <= 0) {
+    return null;
+  }
+  return ((candidate - baseline) / baseline) * 100;
+}
+
+/**
+ * 提取嵌套数值。
+ *
+ * @param {Record<string, any>} source 对象
+ * @param {string[]} keys 路径
+ * @returns {number|null} 数值
+ */
+function readNumber(source, keys) {
+  let value = source;
+  for (const key of keys) {
+    value = value?.[key];
+  }
+  return Number.isFinite(value) ? Number(value) : null;
+}
+
+/**
+ * 提取决定性能可比性的环境与负载合同。
+ *
+ * @param {Record<string, any>} source 基线对象
+ * @returns {Record<string, any>} 可比性合同
+ */
+function readCompatibilityContract(source) {
+  return {
+    schemaVersion: source.schemaVersion ?? null,
+    profile: source.profile ?? null,
+    scenario: source.scenario ?? null,
+    engine: source.environment?.engine ?? null,
+    engineArtifact: source.environment?.engineArtifact ?? null,
+    workload: {
+      totalChunks: readNumber(source, ['workload', 'totalChunks']),
+      chunkSize: readNumber(source, ['workload', 'chunkSize']),
+    },
+    execution: {
+      executor: source.execution?.executor ?? null,
+      concurrency: readNumber(source, ['execution', 'concurrency']),
+      duration: source.execution?.duration ?? null,
+      preAllocatedVUs: source.execution?.preAllocatedVUs ?? null,
+      maxVUs: source.execution?.maxVUs ?? null,
+    },
+  };
+}
+
+/**
+ * 独立复核基线的必需样本与指标，禁止信任可被手工篡改的 evidence.valid 标记。
+ *
+ * @param {Record<string, any>} source 基线对象
+ * @returns {boolean} 证据是否完整
+ */
+function hasCompleteEvidence(source) {
+  const requiredNumbers = [];
+  for (const phase of ['upload', 'download', 'endToEnd']) {
+    for (const percentile of ['p95', 'p99']) {
+      requiredNumbers.push(readNumber(source, ['latencyMs', phase, percentile]));
+    }
+  }
+  requiredNumbers.push(
+    readNumber(source, ['throughput', 'uploadedBytesPerSecond']),
+    readNumber(source, ['throughput', 'downloadedBytesPerSecond']),
+    readNumber(source, ['failure', 'flowRate']),
+    readNumber(source, ['failure', 'cleanupRate']),
+  );
+  return source.evidence?.valid === true &&
+    source.evidence?.metricsComplete === true &&
+    source.evidence?.compatibilityComplete === true &&
+    Number(source.evidence?.flowSamples) > 0 &&
+    Number(source.evidence?.cleanupSamples) > 0 &&
+    Number(source.evidence?.completedFiles) > 0 &&
+    requiredNumbers.every((value) => Number.isFinite(value));
+}
+
+/**
+ * 比较一项“越小越好”的时延指标。
+ *
+ * @param {string} label 指标名
+ * @param {number|null} baseline 基线值
+ * @param {number|null} candidate 候选值
+ * @param {number} threshold 阈值百分比
+ * @returns {{line:string,regression:boolean}} 比较结果
+ */
+function compareLatency(label, baseline, candidate, threshold) {
+  const delta = percentChange(baseline, candidate);
+  const regression = delta !== null && delta > threshold;
+  return {
+    line: `| ${label} | ${baseline ?? 'N/A'} | ${candidate ?? 'N/A'} | ${delta === null ? 'N/A' : `${delta.toFixed(2)}%`} | ${regression ? 'REGRESSION' : 'OK'} |`,
+    regression,
+  };
+}
+
+/**
+ * 比较一项“越大越好”的吞吐指标。
+ *
+ * @param {string} label 指标名
+ * @param {number|null} baseline 基线值
+ * @param {number|null} candidate 候选值
+ * @param {number} threshold 阈值百分比
+ * @returns {{line:string,regression:boolean}} 比较结果
+ */
+function compareThroughput(label, baseline, candidate, threshold) {
+  const delta = percentChange(baseline, candidate);
+  const regression = delta !== null && delta < -threshold;
+  return {
+    line: `| ${label} | ${baseline ?? 'N/A'} | ${candidate ?? 'N/A'} | ${delta === null ? 'N/A' : `${delta.toFixed(2)}%`} | ${regression ? 'REGRESSION' : 'OK'} |`,
+    regression,
+  };
+}
+
+/**
+ * 比较同环境直传基线并返回 Markdown 与退出码。
+ *
+ * @param {Record<string, any>} baseline 基线
+ * @param {Record<string, any>} candidate 候选
+ * @param {number} threshold 阈值百分比
+ * @returns {{report:string,exitCode:number}} 比较结果
+ */
+function compareBaselines(baseline, candidate, threshold) {
+  const baselineEvidenceValid = hasCompleteEvidence(baseline);
+  const candidateEvidenceValid = hasCompleteEvidence(candidate);
+  if (!baselineEvidenceValid || !candidateEvidenceValid) {
+    return {
+      report: [
+        '# Direct path baseline comparison',
+        '',
+        'Result: INVALID_EVIDENCE',
+        '',
+        `- Baseline evidence valid: ${baselineEvidenceValid}`,
+        `- Candidate evidence valid: ${candidateEvidenceValid}`,
+        '',
+      ].join('\n'),
+      exitCode: 1,
+    };
+  }
+  const baselineFingerprint = baseline.environment?.fingerprint;
+  const candidateFingerprint = candidate.environment?.fingerprint;
+  const baselineContract = readCompatibilityContract(baseline);
+  const candidateContract = readCompatibilityContract(candidate);
+  const contractMatches = JSON.stringify(baselineContract) === JSON.stringify(candidateContract);
+  if (!baselineFingerprint || baselineFingerprint !== candidateFingerprint || !contractMatches) {
+    return {
+      report: [
+        '# Direct path baseline comparison',
+        '',
+        'Result: NOT_COMPARABLE',
+        '',
+        `- Baseline fingerprint: \`${baselineFingerprint || 'unavailable'}\``,
+        `- Candidate fingerprint: \`${candidateFingerprint || 'unavailable'}\``,
+        `- Environment fingerprint match: ${baselineFingerprint === candidateFingerprint}`,
+        `- Workload/execution contract match: ${contractMatches}`,
+        `- Baseline contract: \`${JSON.stringify(baselineContract)}\``,
+        `- Candidate contract: \`${JSON.stringify(candidateContract)}\``,
+        '- 不同环境、运行引擎、并发、时长或分片负载不会给出虚假性能回归结论。',
+        '',
+      ].join('\n'),
+      exitCode: 0,
+    };
+  }
+
+  const comparisons = [];
+  for (const phase of ['upload', 'download', 'endToEnd']) {
+    for (const percentile of ['p95', 'p99']) {
+      comparisons.push(compareLatency(
+        `${phase}.${percentile}`,
+        readNumber(baseline, ['latencyMs', phase, percentile]),
+        readNumber(candidate, ['latencyMs', phase, percentile]),
+        threshold,
+      ));
+    }
+  }
+  comparisons.push(compareThroughput(
+    'uploadedBytesPerSecond',
+    readNumber(baseline, ['throughput', 'uploadedBytesPerSecond']),
+    readNumber(candidate, ['throughput', 'uploadedBytesPerSecond']),
+    threshold,
+  ));
+  comparisons.push(compareThroughput(
+    'downloadedBytesPerSecond',
+    readNumber(baseline, ['throughput', 'downloadedBytesPerSecond']),
+    readNumber(candidate, ['throughput', 'downloadedBytesPerSecond']),
+    threshold,
+  ));
+
+  const baselineFlow = readNumber(baseline, ['failure', 'flowRate']);
+  const candidateFlow = readNumber(candidate, ['failure', 'flowRate']);
+  const baselineCleanup = readNumber(baseline, ['failure', 'cleanupRate']);
+  const candidateCleanup = readNumber(candidate, ['failure', 'cleanupRate']);
+  const flowRegression = baselineFlow === 0 && candidateFlow !== null && candidateFlow > 0;
+  const cleanupRegression = baselineCleanup === 0 && candidateCleanup !== null && candidateCleanup > 0;
+  comparisons.push({
+    line: `| flowFailureRate | ${baselineFlow ?? 'N/A'} | ${candidateFlow ?? 'N/A'} | N/A | ${flowRegression ? 'REGRESSION' : 'OK'} |`,
+    regression: flowRegression,
+  });
+  comparisons.push({
+    line: `| cleanupFailureRate | ${baselineCleanup ?? 'N/A'} | ${candidateCleanup ?? 'N/A'} | N/A | ${cleanupRegression ? 'REGRESSION' : 'OK'} |`,
+    regression: cleanupRegression,
+  });
+
+  const regressions = comparisons.filter((item) => item.regression).length;
+  return {
+    report: [
+      '# Direct path baseline comparison',
+      '',
+      `Result: ${regressions === 0 ? 'PASS' : 'FAIL'}`,
+      '',
+      `- Environment fingerprint: \`${baselineFingerprint}\``,
+      `- Regression threshold: ${threshold}%`,
+      '',
+      '| Metric | Baseline | Candidate | Change | Result |',
+      '|---|---:|---:|---:|---|',
+      ...comparisons.map((item) => item.line),
+      '',
+    ].join('\n'),
+    exitCode: regressions === 0 ? 0 : 1,
+  };
+}
+
+const args = parseArgs();
+const result = compareBaselines(readBaseline(args.baseline), readBaseline(args.candidate), args.threshold);
+if (args.output) {
+  fs.mkdirSync(path.dirname(args.output), { recursive: true });
+  fs.writeFileSync(args.output, result.report, 'utf8');
+}
+process.stdout.write(result.report);
+process.exitCode = result.exitCode;

--- a/tools/k6/suites/ci-smoke.js
+++ b/tools/k6/suites/ci-smoke.js
@@ -2,8 +2,11 @@ import { sleep } from 'k6';
 import {
   ensureRequiredConfig,
   getBaseConfig,
+  getDirectPathThresholds,
   getGlobalThresholds,
   getQueryThresholds,
+  getSafeSystemTags,
+  getSummaryTrendStats,
   getUploadThresholds,
   mergeThresholds,
   parseBooleanEnv,
@@ -13,13 +16,16 @@ import { loginOrFail } from '../lib/auth.js';
 import { cleanupRunFiles } from '../lib/cleanup.js';
 import { createSummaryHandler } from '../lib/summary.js';
 import { runChunkUploadFlow } from '../chunk-upload.js';
+import { captureDirectSnapshotAvailability, runDirectPathFlow } from '../direct-path.js';
 import { runFileQueryFlow } from '../file-query.js';
 import { runCoreMixedIteration } from '../scenarios/core-mixed.js';
+import { directCleanupFailureRate } from '../lib/metrics.js';
 
 const baseConfig = getBaseConfig();
 ensureRequiredConfig(baseConfig);
 const cleanupEnabled = parseBooleanEnv('CLEANUP', true);
 const includeChunkInCi = parseBooleanEnv('CI_INCLUDE_CHUNK', false);
+const includeDirectInCi = parseBooleanEnv('CI_INCLUDE_DIRECT', false);
 
 /**
  * 判断是否启用某个场景。
@@ -34,7 +40,7 @@ function shouldEnableScenario(scenarioName) {
 /**
  * 构建 CI smoke 套件计划（场景 + 阈值开关）。
  *
- * @returns {{scenarios:Record<string, any>, includeQueryThreshold:boolean, includeUploadThreshold:boolean}} 套件计划
+ * @returns {{scenarios:Record<string, any>, includeQueryThreshold:boolean, includeUploadThreshold:boolean, includeDirectThreshold:boolean}} 套件计划
  */
 function buildCiPlan() {
   const scenarios = {};
@@ -42,6 +48,8 @@ function buildCiPlan() {
   const enableFileQuery = shouldEnableScenario('file-query');
   const enableCoreMixed = shouldEnableScenario('core-mixed');
   const enableChunkUpload = includeChunkInCi && shouldEnableScenario('chunk-upload');
+  const enableDirectPath = (includeDirectInCi || baseConfig.scenario === 'direct-path')
+    && shouldEnableScenario('direct-path');
 
   if (enableFileQuery) {
     scenarios.fileQueryCiSmoke = {
@@ -73,14 +81,25 @@ function buildCiPlan() {
     };
   }
 
+  if (enableDirectPath) {
+    scenarios.directPathCiSmoke = {
+      executor: 'constant-vus',
+      exec: 'runDirectPathCiSmoke',
+      vus: parseIntEnv('CI_DIRECT_PATH_VUS', 1, 1),
+      duration: __ENV.CI_DIRECT_PATH_DURATION || '60s',
+      startTime: Object.keys(scenarios).length > 0 ? __ENV.CI_DIRECT_PATH_START_TIME || '230s' : '0s',
+    };
+  }
+
   if (Object.keys(scenarios).length === 0) {
-    throw new Error(`K6_SCENARIO=${baseConfig.scenario} 无有效场景，可选值: all|file-query|core-mixed|chunk-upload`);
+    throw new Error(`K6_SCENARIO=${baseConfig.scenario} 无有效场景，可选值: all|file-query|core-mixed|chunk-upload|direct-path`);
   }
 
   return {
     scenarios,
     includeQueryThreshold: enableFileQuery || enableCoreMixed,
     includeUploadThreshold: enableChunkUpload || enableCoreMixed,
+    includeDirectThreshold: enableDirectPath,
   };
 }
 
@@ -88,10 +107,13 @@ const ciPlan = buildCiPlan();
 
 export const options = {
   scenarios: ciPlan.scenarios,
+  summaryTrendStats: getSummaryTrendStats(),
+  systemTags: getSafeSystemTags(),
   thresholds: mergeThresholds(
     getGlobalThresholds(),
     ciPlan.includeQueryThreshold ? getQueryThresholds() : {},
     ciPlan.includeUploadThreshold ? getUploadThresholds() : {},
+    ciPlan.includeDirectThreshold ? getDirectPathThresholds() : {},
   ),
 };
 
@@ -102,10 +124,14 @@ export const options = {
  */
 export function setup() {
   const token = loginOrFail(baseConfig, 'ci_smoke_setup', 1);
-  return {
+  const context = {
     token,
     config: baseConfig,
   };
+  if (ciPlan.includeDirectThreshold) {
+    captureDirectSnapshotAvailability(context, 'ci_direct_path', 'start');
+  }
+  return context;
 }
 
 /**
@@ -139,19 +165,48 @@ export function runChunkUploadCiSmoke(data) {
 }
 
 /**
+ * 运行 direct-path CI smoke 场景。
+ *
+ * @param {{token:string, config:{baseUrl:string, tenantId:string, runId:string}}} data setup 返回上下文
+ */
+export function runDirectPathCiSmoke(data) {
+  runDirectPathFlow(data, 'ci_direct_path');
+  sleep(1);
+}
+
+/**
  * 执行收尾清理，失败仅告警不抛错。
  *
  * @param {{token:string, config:{baseUrl:string, tenantId:string, runId:string}}} data setup 返回上下文
  */
 export function teardown(data) {
-  if (!cleanupEnabled) {
-    return;
-  }
-
   try {
-    cleanupRunFiles(data);
-  } catch (error) {
-    console.warn(`[k6-cleanup] ci-smoke teardown 清理异常: ${error && error.message ? error.message : error}`);
+    if (!cleanupEnabled) {
+      if (ciPlan.includeDirectThreshold) {
+        directCleanupFailureRate.add(true, { reason: 'disabled' });
+        throw new Error('direct-path CI smoke 要求启用 CLEANUP');
+      }
+      return;
+    }
+
+    try {
+      const result = cleanupRunFiles(data);
+      if (ciPlan.includeDirectThreshold) {
+        directCleanupFailureRate.add(!result.ok, { reason: result.reason || 'none' });
+        if (!result.ok) {
+          throw new Error(`direct-path CI smoke 清理失败: ${result.reason}`);
+        }
+      }
+    } catch (error) {
+      if (ciPlan.includeDirectThreshold) {
+        throw error;
+      }
+      console.warn(`[k6-cleanup] ci-smoke teardown 清理异常: ${error && error.message ? error.message : error}`);
+    }
+  } finally {
+    if (ciPlan.includeDirectThreshold) {
+      captureDirectSnapshotAvailability(data, 'ci_direct_path', 'end');
+    }
   }
 }
 

--- a/tools/k6/suites/local-load.js
+++ b/tools/k6/suites/local-load.js
@@ -1,8 +1,11 @@
 import {
   ensureRequiredConfig,
   getBaseConfig,
+  getDirectPathThresholds,
   getGlobalThresholds,
   getQueryThresholds,
+  getSafeSystemTags,
+  getSummaryTrendStats,
   getUploadThresholds,
   mergeThresholds,
   parseBooleanEnv,
@@ -12,7 +15,9 @@ import { loginOrFail } from '../lib/auth.js';
 import { cleanupRunFiles } from '../lib/cleanup.js';
 import { createSummaryHandler } from '../lib/summary.js';
 import { runChunkUploadFlow } from '../chunk-upload.js';
+import { captureDirectSnapshotAvailability, runDirectPathFlow } from '../direct-path.js';
 import { runFileQueryFlow } from '../file-query.js';
+import { directCleanupFailureRate } from '../lib/metrics.js';
 
 const baseConfig = getBaseConfig();
 ensureRequiredConfig(baseConfig);
@@ -31,13 +36,14 @@ function shouldEnableScenario(scenarioName) {
 /**
  * 构建本地 load 套件计划（场景 + 阈值开关）。
  *
- * @returns {{scenarios:Record<string, any>, includeQueryThreshold:boolean, includeUploadThreshold:boolean}} 套件计划
+ * @returns {{scenarios:Record<string, any>, includeQueryThreshold:boolean, includeUploadThreshold:boolean, includeDirectThreshold:boolean}} 套件计划
  */
 function buildLoadPlan() {
   const scenarios = {};
 
   const enableQuery = shouldEnableScenario('file-query');
   const enableUpload = shouldEnableScenario('chunk-upload');
+  const enableDirectPath = shouldEnableScenario('direct-path');
 
   if (enableQuery) {
     scenarios.fileQueryLoad = {
@@ -65,14 +71,28 @@ function buildLoadPlan() {
     };
   }
 
+  if (enableDirectPath) {
+    scenarios.directPathLoad = {
+      executor: 'constant-arrival-rate',
+      exec: 'runDirectPathLoad',
+      rate: parseIntEnv('DIRECT_PATH_RATE', 1, 1),
+      timeUnit: '1s',
+      duration: __ENV.DIRECT_PATH_DURATION || '3m',
+      preAllocatedVUs: parseIntEnv('DIRECT_PATH_PRE_ALLOCATED_VUS', 5, 1),
+      maxVUs: parseIntEnv('DIRECT_PATH_MAX_VUS', 20, 1),
+      startTime: enableQuery || enableUpload ? __ENV.LOAD_DIRECT_START_TIME || '6m20s' : '0s',
+    };
+  }
+
   if (Object.keys(scenarios).length === 0) {
-    throw new Error(`K6_SCENARIO=${baseConfig.scenario} 无有效场景，可选值: all|file-query|chunk-upload`);
+    throw new Error(`K6_SCENARIO=${baseConfig.scenario} 无有效场景，可选值: all|file-query|chunk-upload|direct-path`);
   }
 
   return {
     scenarios,
     includeQueryThreshold: enableQuery,
     includeUploadThreshold: enableUpload,
+    includeDirectThreshold: enableDirectPath,
   };
 }
 
@@ -80,10 +100,13 @@ const loadPlan = buildLoadPlan();
 
 export const options = {
   scenarios: loadPlan.scenarios,
+  summaryTrendStats: getSummaryTrendStats(),
+  systemTags: getSafeSystemTags(),
   thresholds: mergeThresholds(
     getGlobalThresholds(),
     loadPlan.includeQueryThreshold ? getQueryThresholds() : {},
     loadPlan.includeUploadThreshold ? getUploadThresholds() : {},
+    loadPlan.includeDirectThreshold ? getDirectPathThresholds() : {},
   ),
 };
 
@@ -94,10 +117,14 @@ export const options = {
  */
 export function setup() {
   const token = loginOrFail(baseConfig, 'local_load_setup', 1);
-  return {
+  const context = {
     token,
     config: baseConfig,
   };
+  if (loadPlan.includeDirectThreshold) {
+    captureDirectSnapshotAvailability(context, 'load_direct_path', 'start');
+  }
+  return context;
 }
 
 /**
@@ -119,19 +146,47 @@ export function runChunkUploadLoad(data) {
 }
 
 /**
+ * 运行 direct-path load 场景。
+ *
+ * @param {{token:string, config:{baseUrl:string, tenantId:string, runId:string}}} data setup 返回上下文
+ */
+export function runDirectPathLoad(data) {
+  runDirectPathFlow(data, 'load_direct_path');
+}
+
+/**
  * 执行收尾清理，失败仅告警不抛错。
  *
  * @param {{token:string, config:{baseUrl:string, tenantId:string, runId:string}}} data setup 返回上下文
  */
 export function teardown(data) {
-  if (!cleanupEnabled) {
-    return;
-  }
-
   try {
-    cleanupRunFiles(data);
-  } catch (error) {
-    console.warn(`[k6-cleanup] local-load teardown 清理异常: ${error && error.message ? error.message : error}`);
+    if (!cleanupEnabled) {
+      if (loadPlan.includeDirectThreshold) {
+        directCleanupFailureRate.add(true, { reason: 'disabled' });
+        throw new Error('direct-path load 要求启用 CLEANUP');
+      }
+      return;
+    }
+
+    try {
+      const result = cleanupRunFiles(data);
+      if (loadPlan.includeDirectThreshold) {
+        directCleanupFailureRate.add(!result.ok, { reason: result.reason || 'none' });
+        if (!result.ok) {
+          throw new Error(`direct-path load 清理失败: ${result.reason}`);
+        }
+      }
+    } catch (error) {
+      if (loadPlan.includeDirectThreshold) {
+        throw error;
+      }
+      console.warn(`[k6-cleanup] local-load teardown 清理异常: ${error && error.message ? error.message : error}`);
+    }
+  } finally {
+    if (loadPlan.includeDirectThreshold) {
+      captureDirectSnapshotAvailability(data, 'load_direct_path', 'end');
+    }
   }
 }
 

--- a/tools/k6/suites/local-smoke.js
+++ b/tools/k6/suites/local-smoke.js
@@ -2,8 +2,11 @@ import { sleep } from 'k6';
 import {
   ensureRequiredConfig,
   getBaseConfig,
+  getDirectPathThresholds,
   getGlobalThresholds,
   getQueryThresholds,
+  getSafeSystemTags,
+  getSummaryTrendStats,
   getUploadThresholds,
   mergeThresholds,
   parseBooleanEnv,
@@ -13,8 +16,10 @@ import { loginOrFail } from '../lib/auth.js';
 import { cleanupRunFiles } from '../lib/cleanup.js';
 import { createSummaryHandler } from '../lib/summary.js';
 import { runChunkUploadFlow } from '../chunk-upload.js';
+import { captureDirectSnapshotAvailability, runDirectPathFlow } from '../direct-path.js';
 import { runFileQueryFlow } from '../file-query.js';
 import { runCoreMixedIteration } from '../scenarios/core-mixed.js';
+import { directCleanupFailureRate } from '../lib/metrics.js';
 
 const baseConfig = getBaseConfig();
 ensureRequiredConfig(baseConfig);
@@ -33,7 +38,7 @@ function shouldEnableScenario(scenarioName) {
 /**
  * 构建本地 smoke 套件计划（默认 file-query + core-mixed）。
  *
- * @returns {{scenarios:Record<string, any>, includeQueryThreshold:boolean, includeUploadThreshold:boolean}} 套件计划
+ * @returns {{scenarios:Record<string, any>, includeQueryThreshold:boolean, includeUploadThreshold:boolean, includeDirectThreshold:boolean}} 套件计划
  */
 function buildSmokePlan() {
   const scenarios = {};
@@ -41,6 +46,7 @@ function buildSmokePlan() {
   const enableFileQuery = shouldEnableScenario('file-query');
   const enableCoreMixed = shouldEnableScenario('core-mixed');
   const enableChunkUpload = baseConfig.scenario === 'chunk-upload';
+  const enableDirectPath = baseConfig.scenario === 'direct-path';
 
   if (enableFileQuery) {
     scenarios.fileQuerySmoke = {
@@ -72,14 +78,25 @@ function buildSmokePlan() {
     };
   }
 
+  if (enableDirectPath) {
+    scenarios.directPathSmoke = {
+      executor: 'constant-vus',
+      exec: 'runDirectPathSmoke',
+      vus: parseIntEnv('SMOKE_DIRECT_PATH_VUS', 1, 1),
+      duration: __ENV.SMOKE_DIRECT_PATH_DURATION || '90s',
+      startTime: Object.keys(scenarios).length > 0 ? __ENV.SMOKE_DIRECT_PATH_START_TIME || '320s' : '0s',
+    };
+  }
+
   if (Object.keys(scenarios).length === 0) {
-    throw new Error(`K6_SCENARIO=${baseConfig.scenario} 无有效场景，可选值: all|file-query|core-mixed|chunk-upload`);
+    throw new Error(`K6_SCENARIO=${baseConfig.scenario} 无有效场景，可选值: all|file-query|core-mixed|chunk-upload|direct-path`);
   }
 
   return {
     scenarios,
     includeQueryThreshold: enableFileQuery || enableCoreMixed,
     includeUploadThreshold: enableChunkUpload || enableCoreMixed,
+    includeDirectThreshold: enableDirectPath,
   };
 }
 
@@ -87,10 +104,13 @@ const smokePlan = buildSmokePlan();
 
 export const options = {
   scenarios: smokePlan.scenarios,
+  summaryTrendStats: getSummaryTrendStats(),
+  systemTags: getSafeSystemTags(),
   thresholds: mergeThresholds(
     getGlobalThresholds(),
     smokePlan.includeQueryThreshold ? getQueryThresholds() : {},
     smokePlan.includeUploadThreshold ? getUploadThresholds() : {},
+    smokePlan.includeDirectThreshold ? getDirectPathThresholds() : {},
   ),
 };
 
@@ -101,10 +121,14 @@ export const options = {
  */
 export function setup() {
   const token = loginOrFail(baseConfig, 'local_smoke_setup', 1);
-  return {
+  const context = {
     token,
     config: baseConfig,
   };
+  if (smokePlan.includeDirectThreshold) {
+    captureDirectSnapshotAvailability(context, 'smoke_direct_path', 'start');
+  }
+  return context;
 }
 
 /**
@@ -138,19 +162,48 @@ export function runChunkUploadSmoke(data) {
 }
 
 /**
+ * 运行 direct-path smoke 场景。
+ *
+ * @param {{token:string, config:{baseUrl:string, tenantId:string, runId:string}}} data setup 返回上下文
+ */
+export function runDirectPathSmoke(data) {
+  runDirectPathFlow(data, 'smoke_direct_path');
+  sleep(1);
+}
+
+/**
  * 执行收尾清理，失败仅告警不抛错。
  *
  * @param {{token:string, config:{baseUrl:string, tenantId:string, runId:string}}} data setup 返回上下文
  */
 export function teardown(data) {
-  if (!cleanupEnabled) {
-    return;
-  }
-
   try {
-    cleanupRunFiles(data);
-  } catch (error) {
-    console.warn(`[k6-cleanup] local-smoke teardown 清理异常: ${error && error.message ? error.message : error}`);
+    if (!cleanupEnabled) {
+      if (smokePlan.includeDirectThreshold) {
+        directCleanupFailureRate.add(true, { reason: 'disabled' });
+        throw new Error('direct-path smoke 要求启用 CLEANUP');
+      }
+      return;
+    }
+
+    try {
+      const result = cleanupRunFiles(data);
+      if (smokePlan.includeDirectThreshold) {
+        directCleanupFailureRate.add(!result.ok, { reason: result.reason || 'none' });
+        if (!result.ok) {
+          throw new Error(`direct-path smoke 清理失败: ${result.reason}`);
+        }
+      }
+    } catch (error) {
+      if (smokePlan.includeDirectThreshold) {
+        throw error;
+      }
+      console.warn(`[k6-cleanup] local-smoke teardown 清理异常: ${error && error.message ? error.message : error}`);
+    }
+  } finally {
+    if (smokePlan.includeDirectThreshold) {
+      captureDirectSnapshotAvailability(data, 'smoke_direct_path', 'end');
+    }
   }
 }
 


### PR DESCRIPTION
## Scope

- add a nine-case direct-upload MinIO/Toxiproxy fault matrix across three independent provider containers
- add a bounded concurrent MinIO/Redis load smoke with latency, throughput, JVM resource, lifecycle, and cleanup artifacts
- add the public direct upload/complete/manifest/download k6 path, safe run-scoped cleanup, comparable baseline evidence, and a 20% regression comparator
- harden manual performance workflow inputs, pin the k6 image by digest, and require exact Failsafe reports in CI
- refresh TESTING.md and k6 operator guidance

## Local verification

- `mvn -q -f platform-storage/pom.xml -DskipTests test` — passed on Java 21
- `mvn test` in platform-storage — 383 tests passed
- frontend check — 0 errors and 0 warnings
- frontend coverage — 40 files / 560 tests passed; statements and lines 91.43%, branches 85%, functions 94.92%
- frontend production build — passed
- docs consistency routes/env/roadmap/versions — passed with generated OpenAPI
- `actionlint`, YAML parse, `bash -n`, Node syntax checks, `git diff --check`, and all four `k6 inspect` entries — passed
- fake-server direct-path E2E and baseline comparator PASS/FAIL/INVALID_EVIDENCE/NOT_COMPARABLE fixtures — passed

## Container verification boundary

Docker is not available on the local macOS host. The new fixed-image MinIO/Toxiproxy/Redis integration tests therefore require the PR Linux Docker CI as the authoritative execution result. The broader backend `-Pit` attempt reached 1,237 backend-service tests and 414 backend-web unit tests, then stopped at the existing Testcontainers Docker discovery boundary.

## Security review

Manual read-only review found no production credentials in artifacts, excludes raw URL/name system tags from k6 output, masks target metadata, rejects unsafe run IDs before requests, and scopes cleanup to the run prefix.