### PR TITLE
fix: patch docs dependency advisories

### DIFF
--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   esbuild@0.21.5: 0.25.0
   lodash-es: '>=4.18.0'
-  postcss: 8.5.16
+  postcss: 8.5.18
   preact: 10.28.4
   rollup: 4.59.0
   vite: '>=6.4.3 <7'
@@ -43,10 +43,10 @@ importers:
         version: 5.9.3
       vitepress:
         specifier: ^1.5.0
-        version: 1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3)(typescript@5.9.3)
       vitepress-plugin-mermaid:
         specifier: ^2.0.17
-        version: 2.0.17(mermaid@11.15.0)(vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3))
+        version: 2.0.17(mermaid@11.15.0)(vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3)(typescript@5.9.3))
       vue:
         specifier: 3.5.29
         version: 3.5.29(typescript@5.9.3)
@@ -970,8 +970,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -1205,8 +1205,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.28.4:
@@ -1373,7 +1373,7 @@ packages:
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
-      postcss: 8.5.16
+      postcss: 8.5.18
     peerDependenciesMeta:
       markdown-it-mathjax3:
         optional: true
@@ -1959,7 +1959,7 @@ snapshots:
       '@vue/shared': 3.5.29
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.16
+      postcss: 8.5.18
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.29':
@@ -2286,7 +2286,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -2470,7 +2470,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -2531,7 +2531,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.16:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -2684,7 +2684,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.18
       rollup: 4.59.0
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -2692,14 +2692,14 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitepress-plugin-mermaid@2.0.17(mermaid@11.15.0)(vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3)):
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.15.0)(vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3)(typescript@5.9.3)):
     dependencies:
       mermaid: 11.15.0
-      vitepress: 1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3)
+      vitepress: 1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3)(typescript@5.9.3)
     optionalDependencies:
       '@mermaid-js/mermaid-mindmap': 9.3.0
 
-  vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.16)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.3.3)(lightningcss@1.32.0)(postcss@8.5.18)(search-insights@2.17.3)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.46.2)(search-insights@2.17.3)
@@ -2720,7 +2720,7 @@ snapshots:
       vite: 6.4.3(@types/node@25.3.3)(lightningcss@1.32.0)
       vue: 3.5.29(typescript@5.9.3)
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.18
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/node'

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -9,10 +9,10 @@ minimumReleaseAge: 10080
 trustPolicy: no-downgrade
 
 overrides:
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   esbuild@0.21.5: 0.25.0
   lodash-es: '>=4.18.0'
-  postcss: 8.5.16
+  postcss: 8.5.18
   preact: 10.28.4
   rollup: 4.59.0
   vite: '>=6.4.3 <7'


### PR DESCRIPTION
## Scope

- pin the docs workspace DOMPurify override to 3.4.12
- pin the docs workspace PostCSS override to 8.5.18
- regenerate only the necessary pnpm 10.26.1 lockfile snapshots
- keep the seven-day minimum release age policy unchanged, with no exclusions

## Validation

- `npx --yes pnpm@10.26.1 -C docs install --frozen-lockfile` twice; lockfile SHA-256 remained `a93c069302dbce3a17d4b9d5a3df011a78cd43123d3e58465cf1fd38d73dba98`
- `npx --yes pnpm@10.26.1 -C docs audit --audit-level low`
- `npx --yes pnpm@10.26.1 -C docs audit --audit-level high`
- `npx --yes pnpm@10.26.1 -C docs docs:build`
- `python3 tools/docs/check_consistency.py --check-routes --check-env --check-roadmap --check-versions`
- `git diff --check`

## Advisory boundary

This change targets Dependabot alerts 590 and 588 without dismissing or downgrading them. Existing P6 Medium/Low advisories remain out of scope, so this PR does not claim the repository is globally advisory-free.