### PR TITLE
docs: close P3 enterprise key governance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,7 +76,7 @@
 | P0 | 建立不可绕过的质量与依赖自动化基线 | 已完成 | required checks、Dependabot、覆盖率和 Trivy 子集 |
 | P1 | 建立可追溯证明、发布、故障恢复与观测能力 | 已完成 | signed proof、public verifier、环境/合约工具、OTel/SLO、完整性治理 |
 | P2 | 收口大文件直传/下载、历史 manifest、真实故障与在线文档 | 功能已完成；在线状态由发布门禁判定 | P2-1–P2-Q3 已通过 exact-main；P2-5 以合并提交的 Docs/Pages 证据为最终判据 |
-| P3 | 企业密钥治理：外部 KMS、自动轮换、运行时密码敏捷与密钥暴露收敛 | 进行中 | P3-1、P3-2、P3-3 已验收；P3-4 独立 leaf 正在实现/验收 |
+| P3 | 企业密钥治理：外部 KMS、自动轮换、运行时密码敏捷与密钥暴露收敛 | 已完成 | P3-1–P3-4 均通过独立 PR、exact-main 全量门禁与 Pages 验收 |
 | P4 | 内容寻址、隐私证明、跨链、DID/VC 与后量子探索 | 条件触发 | 仅方向性评估，不承诺日期 |
 | P6 | 统一安全策略与剩余 advisory 治理 | 预留 | 不在 P2 以局部零漏洞替代 |
 
@@ -205,9 +205,9 @@ Signed ZIP 的 `VALID` 要求：本地合同全部通过、显式信任的 Ed255
 
 在第 2–3 步完成前，本 leaf 只能表述为“文档实现完成/待发布验收”，不能表述为“已在线验证”。
 
-## 7. P3：企业密钥治理（进行中）
+## 7. P3：企业密钥治理（已完成）
 
-P3 将本地 AES-GCM envelope 演进为可替换、可接外部 KMS、可自动轮换、可按 provider/suite 治理且减少明文 DEK 暴露的企业密钥生命周期。四个 leaf 严格串行；每个 leaf 都必须从上一个已验收的 exact `main` 创建独立分支和 PR，合并、精确主线验收并归档后才可启动下一个。
+P3 已将本地 AES-GCM envelope 演进为可替换、可接外部 KMS、可自动轮换、可按 provider/suite 治理且减少明文 DEK 暴露的企业密钥生命周期。四个 leaf 严格串行完成；每个 leaf 都从上一个已验收的 exact `main` 创建独立分支和 PR，并在合并、精确主线验收与归档后才启动下一个。
 
 ### P3-1 Wrapping Provider 与外部 KMS（已完成）
 
@@ -231,15 +231,16 @@ P3 将本地 AES-GCM envelope 演进为可替换、可接外部 KMS、可自动�
 - local/Vault wrapping 与 local Ed25519 proof provider 提供真实运行时 dispatch；ML-DSA/ML-KEM 仅为 experimental/unimplemented 目录项，生产写入永久拒绝；
 - 管理 API、指纹审计、低基数指标、V1.20 backfill/constraint/concurrency 迁移门禁和运维文档已验收；PR #319 已合并，exact `main@c0bd8076994ce0cb3bf98a3ff0f722c60ea84a4c` 全部门禁和 Pages 通过，Trellis 已归档。
 
-### P3-4 密钥暴露收敛（本 leaf）
+### P3-4 密钥暴露收敛（已完成）
 
 - owner、friend-share、认证分享和公开分享的 metadata/decrypt-info 默认只返回 60 秒、会话/actor/tenant/file/version/suite/精确信封绑定的 `grant-v1` 引用，不返回 plaintext `initialKey`；
 - Redis 仅保存引用摘要和非秘密绑定，Lua 原子消费只允许首次与一次短窗同会话重试；rotation、分享撤销、信封 supersede/revoke、文件版本变化和跨 actor/session/tenant/client 均失败关闭；
 - grant 只经 POST body 消费，相关响应 `no-store`，常规/操作日志跳过请求与响应体；独立用户/可信客户端 IP 限流、稳定审计和低基数指标不记录引用、会话、IP 或密钥；
 - 前端不把 grant/DEK 写入下载任务或浏览器持久存储，解密前即时消费；framed v2 把 DEK 导入 non-extractable HKDF `CryptoKey` 并清理可变字节，legacy AES 同样导入 non-extractable key；
-- `plaintext-v0` 仅允许客户端显式协商、服务端显式开关且未超过硬截止时间，生产默认关闭；真实 Redis 并发、前端生命周期、OpenAPI 和全量门禁随本 leaf 验收。
+- `plaintext-v0` 仅允许客户端显式协商、服务端显式开关且未超过硬截止时间，生产默认关闭；真实 Redis 并发、前端生命周期、OpenAPI 和全量门禁均已验收；
+- PR #320 已合并；exact `main@7f9d639f3395269735e9efeb3dbea4e9e025d412` 的 Test Suite `30267453969`、Deploy Documentation `30267454033`、CodeQL、依赖提交与 Pages deployment `5622671802` 均成功，关键线上路由返回 HTTP 200，Trellis 已归档。
 
-四个 leaf 全部完成后执行 validation-only P3 阶段回归；backend/frontend/config/docs/security 全量门禁、最新 main review、exact-main 和父任务归档缺一不可。
+P3 validation-only 阶段回归已完成：P3-1～P3-4 分别以 PR #317～#320 串行合入 `cfe9b9e5`、`a4ba5acf`、`c0bd8076`、`7f9d639f`；最终 exact-main backend/frontend/config/docs/security 门禁、OpenAPI 幂等生成、依赖审计、真实浏览器下载 E2E 4/4、Pages 关键路由和最新主线 review 全部通过，未发现已知高置信问题。
 
 ## 8. P4：远期探索（条件触发）
 


### PR DESCRIPTION
## 范围

- 将 canonical ROADMAP 的 P3 阶段状态更新为已完成
- 记录 P3-1 至 P3-4 串行 PR、exact-main 与 Pages 验收证据
- 记录 P3 validation-only 全量回归和最新主线 review 结论

## 验证

- OpenApiContractExportTest：3 项通过，0 失败/跳过
- docs consistency：routes/env/roadmap/versions 全部通过
- VitePress production build 通过
- git diff --check 通过
- P3-4 exact-main Test Suite 30267453969 全部成功
- Pages deployment 5622671802 成功，关键路由 HTTP 200

## 边界

本 PR 只修改 ROADMAP.md，不修改已验收的产品代码。