### PR TITLE
fix: own runtime dependencies and patch Maven advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Verify the installation at:
 
 | Category      | Technology                                              | Version               |
 | ------------- | ------------------------------------------------------- | --------------------- |
-| Backend       | Java + Spring Boot + Virtual Threads                    | 21, 3.5.14            |
+| Backend       | Java + Spring Boot + Virtual Threads                    | 21, 3.5.16            |
 | Microservices | Apache Dubbo (Triple protocol), Nacos                   | 3.3.6                 |
 | Blockchain    | FISCO BCOS, Solidity                                    | 3.8.0, ^0.8.11        |
 | Storage       | S3-compatible (AWS SDK v2), MySQL, Redis (Redisson)     | 2.x, 8.0+, 7.0+       |

--- a/README_CN.md
+++ b/README_CN.md
@@ -190,7 +190,7 @@ cd platform-frontend && pnpm install && pnpm dev
 
 | 分类     | 技术                                                    | 版本               |
 | -------- | ------------------------------------------------------- | ------------------ |
-| 后端     | Java + Spring Boot + Virtual Threads                    | 21, 3.5.14         |
+| 后端     | Java + Spring Boot + Virtual Threads                    | 21, 3.5.16         |
 | 微服务   | Apache Dubbo (Triple 协议), Nacos                       | 3.3.6              |
 | 区块链   | FISCO BCOS, Solidity                                    | 3.8.0, ^0.8.11     |
 | 存储     | S3 兼容存储 (AWS SDK v2), MySQL, Redis (Redisson)        | 2.x, 8.0+, 7.0+    |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@
 | 组件 | 当前基线 | 演进原则 |
 | --- | --- | --- |
 | Java | 21 LTS | 新 LTS 先验证构建、容器和依赖兼容性 |
-| Spring Boot | 3.5.14 | 4.x 迁移单独立项，不在依赖更新中顺带升级 |
+| Spring Boot | 3.5.16 | 4.x 迁移单独立项，不在依赖更新中顺带升级 |
 | Dubbo | 3.3.6 Triple | 保持 consumer/provider 契约兼容 |
 | Svelte | 5.55+ | 使用稳定 Runes API |
 | SvelteKit | 2.59+ | 与前端 lockfile 同步验证 |

--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/platform-backend/pom.xml
+++ b/platform-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>cn.flying</groupId>

--- a/platform-storage/pom.xml
+++ b/platform-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>cn.flying</groupId>
@@ -34,6 +34,24 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <!--
+            Storage production code imports Jackson 2 directly. Keep all imported modules as
+            direct dependencies so JSON persistence does not rely on Nacos/Dubbo transitives.
+            Versions remain owned by the existing Jackson BOM override.
+        -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Logstash Logback Encoder for JSON logging -->

--- a/platform-storage/src/test/java/cn/flying/storage/architecture/RuntimeDependencyOwnershipTest.java
+++ b/platform-storage/src/test/java/cn/flying/storage/architecture/RuntimeDependencyOwnershipTest.java
@@ -1,0 +1,148 @@
+package cn.flying.storage.architecture;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guards production dependency ownership that cannot be delegated to unrelated starter transitives.
+ */
+class RuntimeDependencyOwnershipTest {
+
+    private static final String JACKSON_GROUP = "com.fasterxml.jackson.core";
+    private static final Set<String> REQUIRED_JACKSON_ARTIFACTS = Set.of(
+            "jackson-annotations",
+            "jackson-core",
+            "jackson-databind"
+    );
+
+    /**
+     * Verifies every Jackson 2 module imported by storage production code is direct and BOM-managed.
+     */
+    @Test
+    void shouldDeclareJackson2ProductionDependenciesDirectly() throws Exception {
+        Map<String, DependencyDeclaration> directJacksonDependencies = readDirectJacksonDependencies(locateStoragePom());
+
+        assertEquals(REQUIRED_JACKSON_ARTIFACTS, directJacksonDependencies.keySet(),
+                "Storage must own every Jackson 2 module imported by production code");
+        directJacksonDependencies.forEach((artifactId, declaration) -> {
+            assertTrue(declaration.scope().isBlank() || "compile".equals(declaration.scope()),
+                    () -> artifactId + " must be a production dependency");
+            assertTrue(declaration.version().isBlank(),
+                    () -> artifactId + " must inherit its version from the managed Jackson BOM");
+        });
+    }
+
+    /**
+     * Locates the storage POM when Maven is launched from either the repository root or module root.
+     */
+    private Path locateStoragePom() {
+        List<Path> candidates = List.of(Path.of("platform-storage", "pom.xml"), Path.of("pom.xml"));
+        for (Path candidate : candidates) {
+            if (Files.isRegularFile(candidate) && isStoragePom(candidate)) {
+                return candidate;
+            }
+        }
+        return fail("Unable to locate platform-storage/pom.xml from " + Path.of("").toAbsolutePath());
+    }
+
+    /**
+     * Confirms that a candidate POM belongs to the storage module.
+     */
+    private boolean isStoragePom(Path candidate) {
+        try {
+            return "platform-storage".equals(directChildText(parsePom(candidate).getDocumentElement(), "artifactId"));
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Reads Jackson declarations only from project/dependencies, excluding dependencyManagement and transitives.
+     */
+    private Map<String, DependencyDeclaration> readDirectJacksonDependencies(Path pomPath) throws Exception {
+        Element project = parsePom(pomPath).getDocumentElement();
+        Element dependencies = directChild(project, "dependencies");
+        assertNotNull(dependencies, "Storage POM must declare project dependencies");
+
+        Map<String, DependencyDeclaration> declarations = new LinkedHashMap<>();
+        for (Element dependency : directChildren(dependencies, "dependency")) {
+            if (!JACKSON_GROUP.equals(directChildText(dependency, "groupId"))) {
+                continue;
+            }
+            String artifactId = directChildText(dependency, "artifactId");
+            DependencyDeclaration previous = declarations.put(artifactId, new DependencyDeclaration(
+                    directChildText(dependency, "scope"),
+                    directChildText(dependency, "version")
+            ));
+            assertTrue(previous == null, () -> "Duplicate direct dependency: " + JACKSON_GROUP + ":" + artifactId);
+        }
+        return declarations;
+    }
+
+    /**
+     * Parses a Maven POM with external entity expansion disabled.
+     */
+    private Document parsePom(Path pomPath) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder().parse(pomPath.toFile());
+    }
+
+    /**
+     * Returns a named direct child element without traversing nested Maven sections.
+     */
+    private Element directChild(Element parent, String name) {
+        for (Element child : directChildren(parent, name)) {
+            return child;
+        }
+        return null;
+    }
+
+    /**
+     * Returns all direct child elements with the requested local node name.
+     */
+    private List<Element> directChildren(Element parent, String name) {
+        NodeList nodes = parent.getChildNodes();
+        List<Element> matches = new ArrayList<>();
+        for (int index = 0; index < nodes.getLength(); index++) {
+            Node node = nodes.item(index);
+            if (node instanceof Element element && name.equals(element.getNodeName())) {
+                matches.add(element);
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * Returns trimmed text from a named direct child, or an empty string when absent.
+     */
+    private String directChildText(Element parent, String name) {
+        Element child = directChild(parent, name);
+        return child == null ? "" : child.getTextContent().trim();
+    }
+
+    /**
+     * Captures the ownership-relevant fields of one direct dependency declaration.
+     */
+    private record DependencyDeclaration(String scope, String version) {
+    }
+}

--- a/platform-verifier/pom.xml
+++ b/platform-verifier/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version>
+        <version>3.5.16</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary

- declare the Jackson 2 modules imported by `platform-storage` as direct, BOM-managed production dependencies
- add an architecture test that fails if those dependencies become transitive-only, non-production scoped, duplicated, or locally version-pinned
- move all five Maven roots from Spring Boot 3.5.14 to the compatible 3.5.16 patch and synchronize the roadmap/readme baseline

## Root cause and impact

Storage JSON persistence imported Jackson 2 directly but obtained it accidentally through the Dubbo/Nacos dependency graph. Removing or narrowing that transitive would break compilation or runtime behavior outside the consuming module's control.

The default branch also reported 41 duplicated High Maven alert occurrences across six advisories. They reduce to three patched dependency families: Spring Framework 6.2.19, Spring Data 3.5.12+, and Micrometer 1.15.12. Spring Boot 3.5.16 manages Framework 6.2.19, Spring Data 3.5.13, and Micrometer 1.15.12 without crossing the repository's 3.5.x compatibility boundary.

References: [Spring Boot 3.5.16 release](https://spring.io/blog/2026/06/25/spring-boot-3-5-16-available-now), [Spring Boot 3.5 managed coordinates](https://docs.spring.io/spring-boot/3.5/appendix/dependency-versions/coordinates.html).

## Validation

- `mvn -f platform-api/pom.xml clean install` — 7 tests passed
- `mvn -f platform-verifier/pom.xml clean install` — 157 tests passed
- `mvn -f platform-storage/pom.xml clean test` — 384 tests passed
- `mvn -f platform-fisco/pom.xml clean test` — 158 tests passed
- `mvn -f platform-backend/pom.xml clean test -pl backend-common,backend-service,backend-web -am` — 450 tests passed, 21 existing conditional skips
- `mvn -f platform-storage/pom.xml -Dtest=RuntimeDependencyOwnershipTest test` — 1 test passed
- `python3 tools/docs/check_consistency.py` — routes/env/roadmap/versions passed
- `trivy fs --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 --format table .` — 0 findings across all scanned Maven manifests
- `git diff --check` — passed

Local Docker is unavailable, so no local Testcontainers result is claimed. The required PR workflow must run canonical `clean verify -Pit` suites without skips before merge.

## Compatibility and rollback

- no REST/Dubbo payload, database migration, or runtime configuration contract changes
- remains on Spring Boot 3.5.x; Boot 4.x is explicitly out of scope
- rollback is a single commit revert
