### PR TITLE
fix: make required CI gates fail closed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,10 @@ coverage:
     patch:
       default:
         target: 80%
-        threshold: 5%
+        threshold: 0%
+        informational: false
+        if_not_found: failure
+        if_ci_failed: error
 
 comment:
   layout: "condensed_header, diff, flags, components"

--- a/.github/workflows/docs-consistency.yml
+++ b/.github/workflows/docs-consistency.yml
@@ -1,35 +1,7 @@
 name: Docs Consistency
 
 on:
-  pull_request:
-    paths:
-      - 'ROADMAP*.md'
-      - 'README.md'
-      - 'README_CN.md'
-      - 'API_DOCUMENTATION.md'
-      - 'CONTRIBUTING.md'
-      - 'TESTING.md'
-      - 'docs/**'
-      - 'scripts/*.md'
-      - 'tools/k6/README.md'
-      - 'tools/docs/**'
-      - 'platform-api/pom.xml'
-      - 'platform-verifier/**'
-      - 'platform-backend/pom.xml'
-      - 'platform-fisco/pom.xml'
-      - 'platform-storage/pom.xml'
-      - 'platform-frontend/package.json'
-      - 'platform-frontend/pnpm-lock.yaml'
-      - '.env.example'
-      - 'platform-frontend/.env.example'
-      - 'scripts/env.sh'
-      - 'platform-backend/backend-web/src/main/java/cn/flying/controller/**'
-      - 'platform-backend/backend-web/src/main/java/cn/flying/config/**'
-      - 'platform-backend/backend-web/src/main/resources/application*.yml'
-      - 'platform-backend/backend-web/src/main/resources/db/migration/**'
-      - 'platform-backend/backend-service/src/main/java/**'
-      - 'platform-backend/**/src/test/java/**'
-      - '.github/workflows/*.yml'
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -41,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
@@ -66,9 +38,9 @@ jobs:
           test
 
       - name: Upload OpenAPI artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: backend-openapi
+          name: docs-backend-openapi
           path: platform-backend/backend-web/target/openapi/openapi.json
           if-no-files-found: error
 
@@ -78,16 +50,16 @@ jobs:
     needs: export-openapi
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download OpenAPI artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: backend-openapi
+          name: docs-backend-openapi
           path: platform-backend/backend-web/target/openapi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -100,15 +72,15 @@ jobs:
     needs: docs-consistency
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -116,6 +88,9 @@ jobs:
 
       - name: Install docs dependencies
         run: pnpm -C docs install --frozen-lockfile
+
+      - name: Audit docs production and development dependencies
+        run: corepack pnpm@10.26.1 -C docs audit --audit-level high
 
       - name: Build docs
         run: pnpm -C docs docs:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -754,10 +754,7 @@ jobs:
         if: always()
         with:
           use_oidc: true
-          files: |
-            platform-backend/backend-common/target/site/jacoco/jacoco.xml
-            platform-backend/backend-service/target/site/jacoco/jacoco.xml
-            platform-backend/backend-web/target/site/jacoco/jacoco.xml
+          files: platform-backend/backend-common/target/site/jacoco/jacoco.xml,platform-backend/backend-service/target/site/jacoco/jacoco.xml,platform-backend/backend-web/target/site/jacoco/jacoco.xml
           flags: backend
           disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,9 @@ jobs:
       pull-requests: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      automation: ${{ steps.filter.outputs.automation }}
+      contract: ${{ steps.filter.outputs.contract }}
+      docs: ${{ steps.filter.outputs.docs }}
+      build: ${{ steps.filter.outputs.build }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
@@ -40,18 +41,63 @@ jobs:
               - 'docs/public/nacos-config-template.yaml'
               - 'pom.xml'
               - '.github/workflows/**'
-            frontend:
+            contract:
+              - 'platform-api/**'
+              - 'platform-verifier/**'
+              - 'platform-backend/**'
+              - 'platform-fisco/src/main/resources/contract-registry/**'
+              - 'platform-frontend/src/lib/api/**'
+              - 'platform-frontend/scripts/generate-api-types.mjs'
+              - 'platform-frontend/package.json'
+              - 'platform-frontend/pnpm-lock.yaml'
+              - 'platform-frontend/pnpm-workspace.yaml'
+              - 'tools/contracts/**'
+              - 'pom.xml'
+              - '.github/workflows/**'
+            docs:
+              - 'ROADMAP*.md'
+              - 'README.md'
+              - 'README_CN.md'
+              - 'API_DOCUMENTATION.md'
+              - 'CONTRIBUTING.md'
+              - 'TESTING.md'
+              - 'docs/**'
+              - 'scripts/*.md'
+              - 'tools/k6/README.md'
+              - 'tools/docs/**'
+              - 'platform-api/pom.xml'
+              - 'platform-verifier/**'
+              - 'platform-backend/pom.xml'
+              - 'platform-fisco/pom.xml'
+              - 'platform-storage/pom.xml'
+              - 'platform-frontend/package.json'
+              - 'platform-frontend/pnpm-lock.yaml'
+              - '.env.example'
+              - 'platform-frontend/.env.example'
+              - 'scripts/env.sh'
+              - 'platform-backend/backend-web/src/main/java/cn/flying/controller/**'
+              - 'platform-backend/backend-web/src/main/java/cn/flying/config/**'
+              - 'platform-backend/backend-web/src/main/resources/application*.yml'
+              - 'platform-backend/backend-web/src/main/resources/db/migration/**'
+              - 'platform-backend/backend-service/src/main/java/**'
+              - 'platform-backend/**/src/test/java/**'
+              - '.github/workflows/docs-consistency.yml'
+              - '.github/workflows/test.yml'
+            build:
+              - 'platform-api/**'
+              - 'platform-verifier/**'
+              - 'platform-backend/**'
+              - 'platform-fisco/**'
+              - 'platform-storage/**'
               - 'platform-frontend/**'
-              - '.github/workflows/**'
-            automation:
-              - '.github/workflows/**'
+              - 'pom.xml'
               - 'config/**'
               - 'scripts/**'
               - 'tools/**'
               - 'docker-compose.infra.yml'
               - '.env.example'
               - 'docs/public/nacos-config-template.yaml'
-              - 'platform-frontend/.env.example'
+              - '.github/workflows/**'
 
   backend-test:
     name: Backend Tests
@@ -713,7 +759,8 @@ jobs:
             platform-backend/backend-service/target/site/jacoco/jacoco.xml
             platform-backend/backend-web/target/site/jacoco/jacoco.xml
           flags: backend
-          fail_ci_if_error: false
+          disable_search: true
+          fail_ci_if_error: true
 
       - name: Upload Verifier Coverage Report
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
@@ -722,7 +769,8 @@ jobs:
           use_oidc: true
           files: platform-verifier/sdk/target/site/jacoco/jacoco.xml
           flags: verifier
-          fail_ci_if_error: false
+          disable_search: true
+          fail_ci_if_error: true
 
       - name: Upload Public Verifier Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -739,7 +787,6 @@ jobs:
   frontend-test:
     name: Frontend Tests
     needs: [changes]
-    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -791,24 +838,40 @@ jobs:
           use_oidc: true
           files: platform-frontend/coverage/lcov.info
           flags: frontend
-          fail_ci_if_error: false
+          disable_search: true
+          fail_ci_if_error: true
 
   contract-consistency:
     name: Contract Consistency
     runs-on: ubuntu-latest
-    needs: [changes, backend-test]
-    if: needs.changes.outputs.backend == 'true'
+    needs: [changes]
+    if: needs.changes.outputs.contract == 'true'
     permissions:
       contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Download Backend OpenAPI Artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - name: Setup Java 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          name: backend-openapi
-          path: backend-openapi
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Install OpenAPI contract dependencies
+        run: |
+          mvn -f platform-api/pom.xml clean install -DskipTests -q
+          mvn -f platform-verifier/pom.xml -pl sdk -am clean install -DskipTests -q
+
+      - name: Export OpenAPI from the checked-out revision
+        run: >-
+          mvn -f platform-backend/pom.xml
+          -pl backend-web
+          -am
+          -Dtest=OpenApiContractExportTest
+          -Dsurefire.failIfNoSpecifiedTests=false
+          test
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -830,7 +893,7 @@ jobs:
 
       - name: Generate And Verify Frontend API Types
         working-directory: platform-frontend
-        run: OPENAPI_SOURCE=../backend-openapi/openapi.json pnpm types:gen:check
+        run: OPENAPI_SOURCE=../platform-backend/backend-web/target/openapi/openapi.json pnpm types:gen:check
 
       - name: Verify Contract Artifact Integrity
         run: |
@@ -842,7 +905,7 @@ jobs:
       - name: Generate Contract Fingerprints
         run: |
           mkdir -p contract-fingerprint
-          shasum -a 256 backend-openapi/openapi.json | awk '{print $1}' > contract-fingerprint/openapi.sha256
+          shasum -a 256 platform-backend/backend-web/target/openapi/openapi.json | awk '{print $1}' > contract-fingerprint/openapi.sha256
           shasum -a 256 platform-frontend/src/lib/api/types/generated.ts | awk '{print $1}' > contract-fingerprint/generated-ts.sha256
           shasum -a 256 platform-fisco/src/main/resources/contract-registry/artifacts.json | awk '{print $1}' > contract-fingerprint/catalog.sha256
           python3 tools/contracts/contract_fingerprint.py refresh \
@@ -860,8 +923,6 @@ jobs:
 
   security-scan:
     name: Security Scan
-    needs: [changes]
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.automation == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -881,7 +942,7 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy SARIF
-        if: always()
+        if: always() && github.event_name == 'push'
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: trivy-pr.sarif
@@ -898,11 +959,19 @@ jobs:
           vuln-type: os,library
           exit-code: '1'
 
+  docs-verification:
+    name: Docs Verification
+    needs: [changes]
+    if: needs.changes.outputs.docs == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/docs-consistency.yml
+
   build-check:
     name: Build Verification
     runs-on: ubuntu-latest
-    needs: [changes, backend-test, frontend-test, contract-consistency]
-    if: always() && !failure() && !cancelled() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.automation == 'true')
+    needs: [changes, backend-test, frontend-test, contract-consistency, security-scan]
+    if: always() && !failure() && !cancelled() && needs.changes.outputs.build == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -1136,3 +1205,39 @@ jobs:
           pnpm --version
           pnpm install --frozen-lockfile
           pnpm build
+
+  required-ci:
+    name: Required CI
+    needs:
+      - changes
+      - backend-test
+      - frontend-test
+      - contract-consistency
+      - security-scan
+      - docs-verification
+      - build-check
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Required CI policy tests
+        run: python3 -m unittest discover -s tools/ci/tests -v
+
+      - name: Enforce required and inapplicable job results
+        run: |
+          python3 tools/ci/required_ci_gate.py \
+            --backend-changed "${{ needs.changes.outputs.backend }}" \
+            --contract-changed "${{ needs.changes.outputs.contract }}" \
+            --docs-changed "${{ needs.changes.outputs.docs }}" \
+            --build-changed "${{ needs.changes.outputs.build }}" \
+            --changes-result "${{ needs.changes.result }}" \
+            --backend-test-result "${{ needs.backend-test.result }}" \
+            --frontend-test-result "${{ needs.frontend-test.result }}" \
+            --contract-consistency-result "${{ needs.contract-consistency.result }}" \
+            --security-scan-result "${{ needs.security-scan.result }}" \
+            --docs-verification-result "${{ needs.docs-verification.result }}" \
+            --build-check-result "${{ needs.build-check.result }}"

--- a/tools/ci/__init__.py
+++ b/tools/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Fail-closed continuous-integration governance helpers."""

--- a/tools/ci/required_ci_gate.py
+++ b/tools/ci/required_ci_gate.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Fail closed when a required or intentionally skipped CI job has an unsafe result."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+
+KNOWN_RESULTS = frozenset({"success", "failure", "cancelled", "skipped"})
+
+
+@dataclass(frozen=True)
+class GateInputs:
+    """Capture changed-path decisions and the terminal result of every governed job."""
+
+    backend_changed: bool
+    contract_changed: bool
+    docs_changed: bool
+    build_changed: bool
+    results: Mapping[str, str]
+
+
+def parse_change_flag(name: str, value: str) -> bool:
+    """Parse a GitHub Actions boolean output without silently accepting an empty value."""
+
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"{name} must be 'true' or 'false'; got {value!r}")
+
+
+def evaluate_gate(inputs: GateInputs) -> list[str]:
+    """Return every CI graph violation so one run exposes the complete unsafe state."""
+
+    expected_to_run = {
+        "changes": True,
+        "backend-test": inputs.backend_changed,
+        "frontend-test": True,
+        "contract-consistency": inputs.contract_changed,
+        "security-scan": True,
+        "docs-verification": inputs.docs_changed,
+        "build-check": inputs.build_changed,
+    }
+    violations: list[str] = []
+
+    for job, required in expected_to_run.items():
+        result = inputs.results.get(job, "")
+        if result not in KNOWN_RESULTS:
+            violations.append(f"{job}: unknown result {result!r}")
+            continue
+
+        expected_result = "success" if required else "skipped"
+        if result != expected_result:
+            applicability = "required" if required else "inapplicable"
+            violations.append(
+                f"{job}: result={result!r}, expected={expected_result!r} "
+                f"for {applicability} job"
+            )
+
+    return violations
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line contract used by the Required CI workflow job."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    for change_name in ("backend", "contract", "docs", "build"):
+        parser.add_argument(f"--{change_name}-changed", required=True)
+    for job_name in (
+        "changes",
+        "backend-test",
+        "frontend-test",
+        "contract-consistency",
+        "security-scan",
+        "docs-verification",
+        "build-check",
+    ):
+        parser.add_argument(f"--{job_name}-result", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Evaluate workflow results and return a non-zero status for any unsafe state."""
+
+    args = build_parser().parse_args(argv)
+    try:
+        inputs = GateInputs(
+            backend_changed=parse_change_flag("backend", args.backend_changed),
+            contract_changed=parse_change_flag("contract", args.contract_changed),
+            docs_changed=parse_change_flag("docs", args.docs_changed),
+            build_changed=parse_change_flag("build", args.build_changed),
+            results={
+                "changes": args.changes_result,
+                "backend-test": args.backend_test_result,
+                "frontend-test": args.frontend_test_result,
+                "contract-consistency": args.contract_consistency_result,
+                "security-scan": args.security_scan_result,
+                "docs-verification": args.docs_verification_result,
+                "build-check": args.build_check_result,
+            },
+        )
+    except ValueError as exc:
+        print(f"Required CI rejected change detection output: {exc}")
+        return 1
+
+    violations = evaluate_gate(inputs)
+    if violations:
+        print("Required CI rejected the workflow graph:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print("Required CI accepted all required successes and explicit inapplicable skips.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/tests/__init__.py
+++ b/tools/ci/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for fail-closed CI governance helpers."""

--- a/tools/ci/tests/test_required_ci_gate.py
+++ b/tools/ci/tests/test_required_ci_gate.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from typing import Mapping
+
+from tools.ci.required_ci_gate import GateInputs, evaluate_gate, main, parse_change_flag
+
+
+class RequiredCiGateTest(unittest.TestCase):
+    """Exercise success, failure, cancellation, skip, and unknown-result policy paths."""
+
+    def setUp(self) -> None:
+        """Create an all-applicable successful graph for focused mutations in each test."""
+
+        self.success_results = {
+            "changes": "success",
+            "backend-test": "success",
+            "frontend-test": "success",
+            "contract-consistency": "success",
+            "security-scan": "success",
+            "docs-verification": "success",
+            "build-check": "success",
+        }
+
+    def gate_inputs(
+        self,
+        *,
+        backend_changed: bool = True,
+        contract_changed: bool = True,
+        docs_changed: bool = True,
+        build_changed: bool = True,
+        results: Mapping[str, str] | None = None,
+    ) -> GateInputs:
+        """Build immutable gate inputs while allowing one policy dimension to change."""
+
+        return GateInputs(
+            backend_changed=backend_changed,
+            contract_changed=contract_changed,
+            docs_changed=docs_changed,
+            build_changed=build_changed,
+            results=self.success_results if results is None else results,
+        )
+
+    def test_accepts_all_required_successes(self) -> None:
+        """Accept the fully applicable happy path."""
+
+        self.assertEqual([], evaluate_gate(self.gate_inputs()))
+
+    def test_accepts_only_explicit_skips_for_inapplicable_jobs(self) -> None:
+        """Accept skipped conditional jobs while still requiring global jobs to succeed."""
+
+        results = dict(self.success_results)
+        for job in (
+            "backend-test",
+            "contract-consistency",
+            "docs-verification",
+            "build-check",
+        ):
+            results[job] = "skipped"
+
+        self.assertEqual(
+            [],
+            evaluate_gate(
+                self.gate_inputs(
+                    backend_changed=False,
+                    contract_changed=False,
+                    docs_changed=False,
+                    build_changed=False,
+                    results=results,
+                )
+            ),
+        )
+
+    def test_rejects_failure_and_cancelled_results(self) -> None:
+        """Reject terminal failures and cancellations for required jobs."""
+
+        results = dict(self.success_results)
+        results["security-scan"] = "failure"
+        results["frontend-test"] = "cancelled"
+
+        violations = evaluate_gate(self.gate_inputs(results=results))
+
+        self.assertTrue(any("security-scan" in violation for violation in violations))
+        self.assertTrue(any("frontend-test" in violation for violation in violations))
+
+    def test_rejects_unexpected_skip_for_required_job(self) -> None:
+        """Reject a conditional-graph error that skips an applicable contract check."""
+
+        results = dict(self.success_results)
+        results["contract-consistency"] = "skipped"
+
+        self.assertEqual(
+            [
+                "contract-consistency: result='skipped', expected='success' "
+                "for required job"
+            ],
+            evaluate_gate(self.gate_inputs(results=results)),
+        )
+
+    def test_rejects_unexpected_execution_for_inapplicable_job(self) -> None:
+        """Reject divergence between changed-path policy and the actual job graph."""
+
+        violations = evaluate_gate(self.gate_inputs(docs_changed=False))
+
+        self.assertEqual(
+            [
+                "docs-verification: result='success', expected='skipped' "
+                "for inapplicable job"
+            ],
+            violations,
+        )
+
+    def test_rejects_empty_and_unknown_results(self) -> None:
+        """Reject missing or future GitHub result values until policy explicitly handles them."""
+
+        results = dict(self.success_results)
+        results["changes"] = ""
+        results["build-check"] = "neutral"
+
+        violations = evaluate_gate(self.gate_inputs(results=results))
+
+        self.assertIn("changes: unknown result ''", violations)
+        self.assertIn("build-check: unknown result 'neutral'", violations)
+
+    def test_parses_only_exact_github_boolean_outputs(self) -> None:
+        """Reject empty, mixed-case, or otherwise ambiguous path-filter outputs."""
+
+        self.assertTrue(parse_change_flag("backend", "true"))
+        self.assertFalse(parse_change_flag("backend", "false"))
+        for invalid in ("", "True", "1", "yes"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    parse_change_flag("backend", invalid)
+
+    def test_command_returns_non_zero_for_invalid_change_output(self) -> None:
+        """Exercise the workflow-facing CLI fail-closed path for an empty output."""
+
+        args = [
+            "--backend-changed",
+            "",
+            "--contract-changed",
+            "false",
+            "--docs-changed",
+            "false",
+            "--build-changed",
+            "false",
+        ]
+        for job in self.success_results:
+            args.extend([f"--{job}-result", self.success_results[job]])
+
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(1, main(args))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/tests/test_required_ci_workflow.py
+++ b/tools/ci/tests/test_required_ci_workflow.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+TEST_WORKFLOW = PROJECT_ROOT / ".github/workflows/test.yml"
+DOCS_WORKFLOW = PROJECT_ROOT / ".github/workflows/docs-consistency.yml"
+CODECOV_CONFIG = PROJECT_ROOT / ".codecov.yml"
+
+
+def job_block(workflow: str, job_name: str) -> str:
+    """Extract one top-level workflow job without adding a YAML parser dependency to CI."""
+
+    match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [a-z0-9-]+:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"workflow job not found: {job_name}")
+    return match.group(0)
+
+
+class RequiredCiWorkflowTest(unittest.TestCase):
+    """Lock the workflow wiring that makes the Required CI result fail closed."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Read governance files once so each assertion examines the same revision."""
+
+        cls.test_workflow = TEST_WORKFLOW.read_text(encoding="utf-8")
+        cls.docs_workflow = DOCS_WORKFLOW.read_text(encoding="utf-8")
+        cls.codecov_config = CODECOV_CONFIG.read_text(encoding="utf-8")
+
+    def test_global_frontend_coverage_and_security_jobs_cannot_path_skip(self) -> None:
+        """Require real coverage upload and vulnerability scan results on every PR."""
+
+        frontend = job_block(self.test_workflow, "frontend-test")
+        security = job_block(self.test_workflow, "security-scan")
+
+        self.assertNotRegex(frontend, r"(?m)^    if:")
+        self.assertIn("fail_ci_if_error: true", frontend)
+        self.assertIn("disable_search: true", frontend)
+        self.assertNotRegex(security, r"(?m)^    if:")
+        self.assertIn("exit-code: '1'", security)
+
+    def test_contract_job_exports_openapi_from_the_checked_out_revision(self) -> None:
+        """Prevent frontend-only contract changes from consuming a stale backend artifact."""
+
+        contract = job_block(self.test_workflow, "contract-consistency")
+
+        self.assertIn("needs: [changes]", contract)
+        self.assertIn("needs.changes.outputs.contract == 'true'", contract)
+        self.assertIn("OpenApiContractExportTest", contract)
+        self.assertIn(
+            "../platform-backend/backend-web/target/openapi/openapi.json",
+            contract,
+        )
+        self.assertNotIn("actions/download-artifact", contract)
+
+    def test_docs_gate_is_reusable_audited_and_conditionally_governed(self) -> None:
+        """Require docs changes, including Dependabot lockfiles, to use the full docs gate."""
+
+        docs = job_block(self.test_workflow, "docs-verification")
+
+        self.assertIn("needs.changes.outputs.docs == 'true'", docs)
+        self.assertIn("uses: ./.github/workflows/docs-consistency.yml", docs)
+        self.assertIn("workflow_call:", self.docs_workflow)
+        self.assertIn("install --frozen-lockfile", self.docs_workflow)
+        self.assertIn("audit --audit-level high", self.docs_workflow)
+        self.assertIn("docs:build", self.docs_workflow)
+
+    def test_required_ci_aggregates_every_governed_job(self) -> None:
+        """Keep the stable required context connected to all conditional and global jobs."""
+
+        required_ci = job_block(self.test_workflow, "required-ci")
+        for dependency in (
+            "changes",
+            "backend-test",
+            "frontend-test",
+            "contract-consistency",
+            "security-scan",
+            "docs-verification",
+            "build-check",
+        ):
+            self.assertIn(f"      - {dependency}", required_ci)
+            self.assertIn(f"needs.{dependency}.result", required_ci)
+        self.assertIn("if: always()", required_ci)
+        self.assertIn("tools/ci/required_ci_gate.py", required_ci)
+
+    def test_build_waits_for_security_and_uses_explicit_path_policy(self) -> None:
+        """Prevent Build Verification from reporting success independently of security."""
+
+        build = job_block(self.test_workflow, "build-check")
+
+        self.assertIn("security-scan", build)
+        self.assertIn("needs.changes.outputs.build == 'true'", build)
+        self.assertIn("!failure()", build)
+        self.assertIn("!cancelled()", build)
+
+    def test_patch_coverage_policy_is_strict_and_fail_closed(self) -> None:
+        """Lock the required patch threshold and missing-report behavior."""
+
+        self.assertIn("target: 80%", self.codecov_config)
+        self.assertIn("threshold: 0%", self.codecov_config)
+        self.assertIn("informational: false", self.codecov_config)
+        self.assertIn("if_not_found: failure", self.codecov_config)
+        self.assertIn("if_ci_failed: error", self.codecov_config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/tests/test_required_ci_workflow.py
+++ b/tools/ci/tests/test_required_ci_workflow.py
@@ -46,6 +46,19 @@ class RequiredCiWorkflowTest(unittest.TestCase):
         self.assertNotRegex(security, r"(?m)^    if:")
         self.assertIn("exit-code: '1'", security)
 
+    def test_backend_coverage_files_use_codecov_supported_delimiters(self) -> None:
+        """Prevent newline-delimited paths from becoming one nonexistent Codecov filename."""
+
+        backend = job_block(self.test_workflow, "backend-test")
+        expected_files = (
+            "files: platform-backend/backend-common/target/site/jacoco/jacoco.xml,"
+            "platform-backend/backend-service/target/site/jacoco/jacoco.xml,"
+            "platform-backend/backend-web/target/site/jacoco/jacoco.xml"
+        )
+
+        self.assertIn(expected_files, backend)
+        self.assertNotIn("files: |", backend)
+
     def test_contract_job_exports_openapi_from_the_checked_out_revision(self) -> None:
         """Prevent frontend-only contract changes from consuming a stale backend artifact."""
 


### PR DESCRIPTION
## 变更范围

- 新增稳定的 `Required CI` 聚合门禁，按 changed-path 适用性校验 backend、frontend、contract、security、docs 与 build 的真实结论。
- 让 `Frontend Tests` 与 `Security Scan` 在每个 PR 上实际执行；安全失败会阻止 Build 和最终聚合结果。
- 将 contract path 扩展到 frontend API types/transport、生成脚本和合同工具；合同 job 从当前 checkout 自行导出 OpenAPI，不再依赖 backend job artifact。
- 将 docs consistency 改为 Test Suite 可复用工作流，并加入 frozen install、高危依赖审计与站点构建。
- 将 Codecov patch 固定为严格 80%（0% 容差），missing report、CI failure 与 upload error 均失败关闭。
- 新增 14 项受控门禁/工作流测试，覆盖成功、明确不适用、failure、cancelled、unexpected skip/execution、空值和未知结果。

## 根因与影响

旧保护规则直接绑定多个 conditional jobs：docs-only、frontend generated-only 等变更可以让受保护 context 以 skipped 结束；Security Scan 不在 Build 依赖图，Codecov upload 允许 fail-open，docs Dependabot 也没有受保护的 audit/build 路径。本变更提供一个稳定且始终产生的聚合结论，并把外部 patch coverage 作为独立严格 context。

仓库保护规则会在本 PR 真实产生 `Required CI` 与 `codecov/patch` 后单独同步，避免先引用不存在的 context 锁死合并。

## 本地验证

- `actionlint -color`
- `git diff --check`
- `python3 -m unittest discover -s tools/ci/tests -v` — 14 tests
- frontend frozen install + High audit + format + lint + check + coverage — 564 tests, 91.26% statements/lines + build
- docs frozen install + High audit + VitePress build
- JDK 21 exact-revision OpenAPI export — 3 tests
- frontend `types:gen:check`
- contract tests/fingerprint — 59 tests, 2 entries verified
- docs routes/env/roadmap/versions consistency — all pass

## 合并条件

- 新增/既有适用 jobs 与 `codecov/patch` 在 PR head 上真实通过。
- 分支保护与 active ruleset 同步到稳定 contexts 后仍保持 PR 可合并。
- 不使用 admin bypass，不降低 audit/coverage/security 阈值。
