### PR TITLE
fix: upgrade nanoid security baseline

### DIFF
--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   dompurify: 3.4.13
   esbuild@0.21.5: 0.25.0
   lodash-es: '>=4.18.0'
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss: 8.5.23
   preact: 10.28.4
   rollup: 4.59.0
@@ -1180,8 +1180,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2526,7 +2526,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   non-layered-tidy-tree-layout@2.0.2:
     optional: true
@@ -2556,7 +2556,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -9,14 +9,13 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - dompurify@3.4.13
   - mermaid@11.16.1
-  - nanoid@3.3.17
 trustPolicy: no-downgrade
 
 overrides:
   dompurify: 3.4.13
   esbuild@0.21.5: 0.25.0
   lodash-es: '>=4.18.0'
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss: 8.5.23
   preact: 10.28.4
   rollup: 4.59.0

--- a/platform-frontend/pnpm-lock.yaml
+++ b/platform-frontend/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   minimatch@5: 5.1.8
   minimatch@9: 9.0.7
   picomatch@<4.0.4: 4.0.4
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   rollup: 4.59.0
   undici@>=7.0.0 <7.29.0: 7.29.0
@@ -1784,8 +1784,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3972,7 +3972,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4074,7 +4074,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/platform-frontend/pnpm-workspace.yaml
+++ b/platform-frontend/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ overrides:
   minimatch@5: 5.1.8
   minimatch@9: 9.0.7
   picomatch@<4.0.4: 4.0.4
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   rollup: 4.59.0
   undici@>=7.0.0 <7.29.0: 7.29.0


### PR DESCRIPTION
## Scope

- update both pnpm workspace overrides from vulnerable nanoid 3.3.17 to patched 3.3.18
- regenerate both lockfiles without unrelated dependency churn
- remove the stale docs release-age exception for nanoid 3.3.17

## Security validation

- `pnpm why nanoid` resolves only 3.3.18 in both workspaces
- low- and high-severity audits report no known vulnerabilities
- two frozen installs preserve both lockfile hashes
- independent bypass/regression review found no actionable issue

## Compatibility validation

- frontend format, lint, Svelte check, coverage (566 tests), and production build pass
- docs build and documentation consistency checks pass
- Required CI policy tests pass