### PR TITLE
fix: use direct official solc dependency archives

### DIFF
--- a/tools/contracts/fisco-solc-toolchains.json
+++ b/tools/contracts/fisco-solc-toolchains.json
@@ -16,19 +16,19 @@
   "sourceDependencies": [
     {
       "name": "fmt-8.0.1",
-      "url": "https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz",
+      "url": "https://codeload.github.com/fmtlib/fmt/tar.gz/refs/tags/8.0.1",
       "path": "deps/downloads/fmt-8.0.1.tar.gz",
       "sha256": "b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01"
     },
     {
       "name": "jsoncpp-1.9.3",
-      "url": "https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz",
+      "url": "https://codeload.github.com/open-source-parsers/jsoncpp/tar.gz/refs/tags/1.9.3",
       "path": "deps/downloads/jsoncpp-1.9.3.tar.gz",
       "sha256": "8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d"
     },
     {
       "name": "range-v3-0.11.0",
-      "url": "https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz",
+      "url": "https://codeload.github.com/ericniebler/range-v3/tar.gz/refs/tags/0.11.0",
       "path": "deps/downloads/range-v3-0.11.0.tar.gz",
       "sha256": "376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c"
     },


### PR DESCRIPTION
## Scope
Resolve F-006 by changing only the three fmt/jsoncpp/range-v3 dependency download URLs from the GitHub archive gateway to equivalent official codeload endpoints. All SHA-256 values, source/compiler identities, extraction paths, build flags and security gates remain unchanged. No host configuration or secrets are included.

## Evidence
- Fresh real downloads from all three codeload URLs match the original manifest SHA-256 values exactly; deployment-host downloads independently matched the same values.
- Programmatic baseline comparison confirms the manifest differs only in those three URL fields.
- `python3 -m unittest tools.contracts.tests.test_provision_fisco_solc -v`: 28 tests passed, including cache safety regressions.
- Contract catalog verification and `git diff --check` passed.
- Existing exact reproduction CI will rebuild both compiler variants and compare all 12 signed artifacts.

## Deployment boundary
Wait for the preceding cache-safety exact-main baseline and this PR CI before merging. After merge, reprovision from the exact main revision and verify without chain writes. No runtime behavior or documentation command changes are introduced.