### PR TITLE
fix: pin published Jaeger monitoring image

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -134,7 +134,7 @@ services:
   # ── Observability (OpenTelemetry) ──────────────────────────────────────────
 
   jaeger:
-    image: jaegertracing/all-in-one:1.68
+    image: jaegertracing/all-in-one:1.68.0@sha256:6279882637ae03e70f519965d2ba5ca84cb785f4baf4f0d7237e827a37c33a42
     container_name: jaeger
     ports:
       - "${OBSERVABILITY_BIND_ADDRESS:-127.0.0.1}:${JAEGER_UI_PORT:-16686}:16686"

--- a/docs/en/deployment/docker-compose.md
+++ b/docs/en/deployment/docker-compose.md
@@ -133,7 +133,7 @@ services:
   # ── Observability (OpenTelemetry) ──────────────────────────────────────────
 
   jaeger:
-    image: jaegertracing/all-in-one:1.68
+    image: jaegertracing/all-in-one:1.68.0@sha256:6279882637ae03e70f519965d2ba5ca84cb785f4baf4f0d7237e827a37c33a42
     container_name: jaeger
     ports:
       - "${OBSERVABILITY_BIND_ADDRESS:-127.0.0.1}:${JAEGER_UI_PORT:-16686}:16686"   # Jaeger UI

--- a/docs/zh/deployment/docker-compose.md
+++ b/docs/zh/deployment/docker-compose.md
@@ -133,7 +133,7 @@ services:
   # ── Observability (OpenTelemetry) ──────────────────────────────────────────
 
   jaeger:
-    image: jaegertracing/all-in-one:1.68
+    image: jaegertracing/all-in-one:1.68.0@sha256:6279882637ae03e70f519965d2ba5ca84cb785f4baf4f0d7237e827a37c33a42
     container_name: jaeger
     ports:
       - "${OBSERVABILITY_BIND_ADDRESS:-127.0.0.1}:${JAEGER_UI_PORT:-16686}:16686"   # Jaeger UI

--- a/tools/ci/tests/test_required_ci_workflow.py
+++ b/tools/ci/tests/test_required_ci_workflow.py
@@ -123,5 +123,27 @@ class RequiredCiWorkflowTest(unittest.TestCase):
         self.assertIn("if_ci_failed: error", self.codecov_config)
 
 
+class MonitoringImageTest(unittest.TestCase):
+    """Prevent the nonexistent Jaeger minor-only tag and documentation image drift."""
+
+    def test_compose_and_docs_use_verified_jaeger_image(self) -> None:
+        """Require exactly one identical, immutable Jaeger image in each deployment asset."""
+        expected_image = (
+            "jaegertracing/all-in-one:1.68.0@sha256:"
+            "6279882637ae03e70f519965d2ba5ca84cb785f4baf4f0d7237e827a37c33a42"
+        )
+        for relative_path in (
+            "docker-compose.infra.yml",
+            "docs/en/deployment/docker-compose.md",
+            "docs/zh/deployment/docker-compose.md",
+        ):
+            with self.subTest(path=relative_path):
+                content = (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+                images = re.findall(
+                    r"(?m)^\s+image:\s*(jaegertracing/all-in-one:\S+)", content
+                )
+                self.assertEqual(images, [expected_image])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Replace the nonexistent Jaeger minor-only tag in infrastructure Compose and both deployment guides with official 1.68.0, pinned to its verified multi-platform manifest digest.
- Preserve existing OTLP listeners, loopback publication, health checks and Collector dependency ordering.
- Add a regression contract to the existing Required CI test suite that enforces identical immutable references in all three deployment assets.

## Verification
- Official Jaeger 1.68 deployment documentation specifies all-in-one:1.68.0; Docker Hub tag API independently returned the pinned digest.
- Python 3.11 CI governance suite: 16 tests passed; documentation suite: 8 tests passed.
- Negative regression: simulated old-tag restoration rejected for all three assets.
- Documentation env, roadmap, versions and evidence consistency checks passed.
- Frozen docs install, High-level dependency audit and VitePress build passed.
- Compose YAML parsed successfully; git diff --check passed.
- No local Docker runtime is available. Container pull/start/health and exact-main deployment remain required follow-up acceptance on the deployment host after merge. No host configuration, credentials or secrets are included.

## Scope
Closes the repository cause of deployment finding F-004. The finding remains open until exact-main live monitoring acceptance completes.