### PR TITLE
fix: 修复服务就绪探测与生命周期失败退出码

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,7 +176,7 @@ CONTRACT_DEPLOYMENT_RECEIPT_DIR=log/contract-deployments
 # ==============================================================================
 # 服务端口配置
 # ==============================================================================
-# Backend Web API 端口 (生产环境 80，开发环境 8000)
+# Backend Web API port (prod YAML defaults to 443; this template overrides it)
 SERVER_PORT=8000
 
 # Dubbo Triple 协议端口
@@ -191,6 +191,15 @@ DUBBO_HOST=127.0.0.1
 QOS_BACKEND_PORT=22330
 QOS_FISCO_PORT=22331
 QOS_STORAGE_PORT=22332
+
+# Lifecycle probes require curl and python3. Provider QoS remains loopback-only.
+# Backend probes follow ${SERVER_PORT}, ${SERVER_ADDRESS},
+# ${SERVER_SSL_ENABLED}/${SSL_ENABLED} and ${SERVER_SERVLET_CONTEXT_PATH}.
+# Optional ${BACKEND_HEALTH_HOST} selects a reachable host matching the certificate.
+# Optional ${CURL_CA_BUNDLE} selects the trusted CA file; TLS verification stays on.
+HEALTH_CHECK_TIMEOUT=60
+HEALTH_CHECK_INTERVAL=2
+HEALTH_CHECK_REQUEST_TIMEOUT=3
 
 # ==============================================================================
 # 日志配置

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（316 files）
+## 当前测试文件快照（317 files）
 
 > 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -18,11 +18,11 @@
 | `platform-verifier` | 15 |
 | `platform-fisco` | 12 |
 | `platform-api` | 3 |
-| `tools/ci` | 2 |
+| `tools/ci` | 3 |
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
-| `tools` | 7 |
-| `total` | 316 |
+| `tools` | 8 |
+| `total` | 317 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,7 +115,8 @@ status; it does not run a background readiness wait.
 - `HEALTH_CHECK_TIMEOUT=60` bounds each startup readiness wait including requests;
   `HEALTH_CHECK_INTERVAL=2` and `HEALTH_CHECK_REQUEST_TIMEOUT=3` control polling
   and each connection/request timeout, in positive integer seconds. Local probes
-  bypass HTTP proxies and do not follow redirects.
+  bypass HTTP proxies, ignore user curlrc files, and do not follow redirects or
+  retry individual HTTP requests automatically.
 
 A stopped, replaced, unhealthy or timed-out process returns nonzero. An existing
 PID alone no longer makes `start` succeed. Multi-service commands continue checking

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,6 +85,52 @@ SW_AGENT_COLLECTOR_BACKEND_SERVICES=127.0.0.1:11800
 
 ## 5. 日志文件
 
+### Readiness and exit status
+
+`start` (background), `restart`, and `status` require **both** an identity-validated
+Java PID and a successful readiness response. Install `curl` and `python3` on the
+application host. Foreground start still uses `exec java` and returns Java's exit
+status; it does not run a background readiness wait.
+
+- Storage probes `http://127.0.0.1:${QOS_STORAGE_PORT:-22332}/ready`.
+- FISCO probes `http://127.0.0.1:${QOS_FISCO_PORT:-22331}/ready`.
+- Both provider responses must be HTTP success with the JSON boolean `true`.
+  Triple ports (`DUBBO_STORAGE_PORT`, `DUBBO_FISCO_PORT`) and `DUBBO_HOST` are RPC
+  configuration, not HTTP Actuator endpoints. Keep QoS foreign access disabled.
+- Backend probes `/actuator/health` under `SERVER_SERVLET_CONTEXT_PATH` and
+  requires a top-level JSON `status` equal to `UP`. With the `prod` profile,
+  defaults match the checked-in YAML: HTTPS, port 443, `/record-platform`.
+  Other profiles default to HTTP, port 8080, empty context; supply matching
+  environment overrides for custom/Nacos profiles.
+- `SERVER_PORT`, `SERVER_ADDRESS`, `SERVER_SSL_ENABLED` (or prod `SSL_ENABLED`),
+  and `SERVER_SERVLET_CONTEXT_PATH` override those defaults. Wildcard bind
+  addresses probe loopback. `BACKEND_HEALTH_HOST` overrides only the probe host
+  (for example, a local DNS name matching the TLS certificate). TLS verification
+  is never disabled: configure a trusted CA with curl's `CURL_CA_BUNDLE` as needed.
+  Arbitrary remote configuration and separate management ports are not inferred;
+  keep the health endpoint on the configured application listener.
+- Legacy `BACKEND_PORT`, `STORAGE_PORT`, and `FISCO_PORT` remain fallback aliases
+  for `SERVER_PORT`, `DUBBO_STORAGE_PORT`, and `DUBBO_FISCO_PORT`; canonical
+  variables win and the aliases are exported into actual application settings.
+- `HEALTH_CHECK_TIMEOUT=60` bounds each startup readiness wait including requests;
+  `HEALTH_CHECK_INTERVAL=2` and `HEALTH_CHECK_REQUEST_TIMEOUT=3` control polling
+  and each connection/request timeout, in positive integer seconds. Local probes
+  bypass HTTP proxies and do not follow redirects.
+
+A stopped, replaced, unhealthy or timed-out process returns nonzero. An existing
+PID alone no longer makes `start` succeed. Multi-service commands continue checking
+the requested services but retain any earlier failure in their final exit status.
+A timeout does not kill an identity-valid running process; inspect logs or stop it
+explicitly before retrying. QoS readiness proves Dubbo bootstrap/provider readiness,
+not an end-to-end file upload, object-store write, or blockchain transaction.
+
+Regression checks (also run by the required CI policy-test job):
+
+```bash
+bash -n scripts/start.sh scripts/env.sh
+python3 -m unittest discover -s tools/ci/tests -p 'test_service_readiness.py' -v
+```
+
 日志保存在 `log/` 目录：
 
 | 文件               | 服务       |

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -6,7 +6,8 @@
 # 路径配置
 # ================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+export PROJECT_ROOT
 
 # 加载 .env 文件；脚本自检或 CI 可通过 RECORD_PLATFORM_SKIP_DOTENV=true 跳过。
 if [ "${RECORD_PLATFORM_SKIP_DOTENV:-false}" != "true" ] && [ -f "$PROJECT_ROOT/.env" ]; then
@@ -44,9 +45,16 @@ chmod 700 "$PID_DIR" 2>/dev/null || true
 # ================================
 # 服务端口配置 (用于健康检查)
 # ================================
-export STORAGE_PORT="${STORAGE_PORT:-8092}"
-export FISCO_PORT="${FISCO_PORT:-8091}"
-export BACKEND_PORT="${BACKEND_PORT:-8000}"
+export DUBBO_STORAGE_PORT="${DUBBO_STORAGE_PORT:-${STORAGE_PORT:-8092}}"
+export DUBBO_FISCO_PORT="${DUBBO_FISCO_PORT:-${FISCO_PORT:-8091}}"
+export STORAGE_PORT="$DUBBO_STORAGE_PORT"
+export FISCO_PORT="$DUBBO_FISCO_PORT"
+# Keep legacy overrides aligned with the application's actual configuration.
+if [ -z "${SERVER_PORT:-}" ] && [ -n "${BACKEND_PORT:-}" ]; then
+    export SERVER_PORT="$BACKEND_PORT"
+fi
+export QOS_STORAGE_PORT="${QOS_STORAGE_PORT:-22332}"
+export QOS_FISCO_PORT="${QOS_FISCO_PORT:-22331}"
 
 # ================================
 # SkyWalking 配置

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -361,7 +361,8 @@ get_readiness_url() {
 # Require HTTP success and the expected body; a socket or nested UP is insufficient.
 probe_readiness() {
     local svc=$1 timeout=${2:-$HEALTH_CHECK_REQUEST_TIMEOUT} response status
-    response=$(curl --silent --show-error --fail --noproxy '*' \
+    # Disable curlrc first so user redirect/retry defaults cannot weaken this probe.
+    response=$(curl -q --silent --show-error --fail --noproxy '*' \
         --connect-timeout "$timeout" --max-time "$timeout" \
         --write-out $'\n%{http_code}' \
         "$(get_readiness_url "$svc")" 2>/dev/null) || return 1

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,8 +30,9 @@ source "$SCRIPT_DIR/env.sh"
 # ================================
 SERVICE_ORDER=("storage" "fisco" "backend")
 
-HEALTH_CHECK_TIMEOUT=60
-HEALTH_CHECK_INTERVAL=2
+HEALTH_CHECK_TIMEOUT=${HEALTH_CHECK_TIMEOUT:-60}
+HEALTH_CHECK_INTERVAL=${HEALTH_CHECK_INTERVAL:-2}
+HEALTH_CHECK_REQUEST_TIMEOUT=${HEALTH_CHECK_REQUEST_TIMEOUT:-3}
 
 # 获取服务对应的 JAR 路径。
 get_service_jar() {
@@ -73,7 +74,13 @@ get_service_port() {
     case "$1" in
         storage) echo "$STORAGE_PORT" ;;
         fisco) echo "$FISCO_PORT" ;;
-        backend) echo "$BACKEND_PORT" ;;
+        backend)
+            if [[ ",$SPRING_PROFILE," == *,prod,* ]]; then
+                echo "${SERVER_PORT:-443}"
+            else
+                echo "${SERVER_PORT:-8080}"
+            fi
+            ;;
         *) echo "" ;;
     esac
 }
@@ -294,7 +301,8 @@ get_pid_file() {
 
 get_pid() {
     local svc=$1
-    local pid_file=$(get_pid_file "$svc")
+    local pid_file
+    pid_file=$(get_pid_file "$svc")
     
     if [ -f "$pid_file" ]; then
         local pid
@@ -312,34 +320,86 @@ get_pid() {
 save_pid() {
     local svc=$1
     local pid=$2
-    local pid_file=$(get_pid_file "$svc")
+    local pid_file
+    pid_file=$(get_pid_file "$svc")
     echo "$pid" > "$pid_file"
 }
 
 remove_pid() {
     local svc=$1
-    local pid_file=$(get_pid_file "$svc")
+    local pid_file
+    pid_file=$(get_pid_file "$svc")
     rm -f "$pid_file"
 }
 
+# Resolve the probe from runtime configuration, never from a provider RPC port.
+get_readiness_url() {
+    local scheme=http context="" host="${BACKEND_HEALTH_HOST:-${SERVER_ADDRESS:-127.0.0.1}}"
+    case "$1" in
+        storage) echo "http://127.0.0.1:$QOS_STORAGE_PORT/ready" ;;
+        fisco) echo "http://127.0.0.1:$QOS_FISCO_PORT/ready" ;;
+        backend)
+            if [[ ",$SPRING_PROFILE," == *,prod,* ]]; then
+                context=/record-platform
+                if [ "${SERVER_SSL_ENABLED:-${SSL_ENABLED:-true}}" = true ]; then
+                    scheme=https
+                fi
+            elif [ "${SERVER_SSL_ENABLED:-false}" = true ]; then
+                scheme=https
+            fi
+            context="${SERVER_SERVLET_CONTEXT_PATH-$context}"
+            case "$host" in
+                0.0.0.0|::|\[::\]) host=127.0.0.1 ;;
+                *:*) [[ "$host" == \[*\] ]] || host="[$host]" ;;
+            esac
+            echo "$scheme://$host:$(get_service_port backend)${context%/}/actuator/health"
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+# Require HTTP success and the expected body; a socket or nested UP is insufficient.
+probe_readiness() {
+    local svc=$1 timeout=${2:-$HEALTH_CHECK_REQUEST_TIMEOUT} response status
+    response=$(curl --silent --show-error --fail --noproxy '*' \
+        --connect-timeout "$timeout" --max-time "$timeout" \
+        --write-out $'\n%{http_code}' \
+        "$(get_readiness_url "$svc")" 2>/dev/null) || return 1
+    status=${response##*$'\n'}
+    [[ "$status" =~ ^2[0-9][0-9]$ ]] || return 1
+    response=${response%$'\n'*}
+    printf '%s' "$response" | python3 -c '
+import json, sys
+try:
+    value = json.load(sys.stdin)
+    ready = (isinstance(value, dict) and value.get("status") == "UP") if sys.argv[1] == "backend" else value is True
+except (ValueError, TypeError):
+    ready = False
+sys.exit(0 if ready else 1)
+' "$svc"
+}
+
+# Bound the complete wait, including curl time, and reject dead/replaced processes.
 wait_for_health() {
     local svc=$1
-    local port
-    port=$(get_service_port "$svc")
-    local elapsed=0
-    
-    if [ -z "$port" ]; then
-        return 0
-    fi
-    
+    local deadline=$((SECONDS + HEALTH_CHECK_TIMEOUT)) remaining request_timeout pause pid
+    pid=$(get_pid "$svc")
+    [ -n "$pid" ] || return 1
     echo "  等待健康检查 (最多 ${HEALTH_CHECK_TIMEOUT}s)..."
-    
-    while [ $elapsed -lt $HEALTH_CHECK_TIMEOUT ]; do
-        if curl -sf "http://localhost:$port/actuator/health" >/dev/null 2>&1; then
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        [ "$(get_pid "$svc")" = "$pid" ] || return 1
+        remaining=$((deadline - SECONDS))
+        request_timeout=$HEALTH_CHECK_REQUEST_TIMEOUT
+        [ "$request_timeout" -le "$remaining" ] || request_timeout=$remaining
+        [ "$request_timeout" -gt 0 ] || return 1
+        if probe_readiness "$svc" "$request_timeout" && [ "$(get_pid "$svc")" = "$pid" ]; then
             return 0
         fi
-        sleep $HEALTH_CHECK_INTERVAL
-        elapsed=$((elapsed + HEALTH_CHECK_INTERVAL))
+        remaining=$((deadline - SECONDS))
+        [ "$remaining" -gt 0 ] || break
+        pause=$HEALTH_CHECK_INTERVAL
+        [ "$pause" -le "$remaining" ] || pause=$remaining
+        sleep "$pause"
     done
     
     return 1
@@ -353,7 +413,8 @@ stop_service() {
     local name
     name=$(get_service_name "$svc")
     
-    local pid=$(get_pid "$svc")
+    local pid
+    pid=$(get_pid "$svc")
     
     if [ -n "$pid" ]; then
         echo "正在停止 $name (PID: $pid)..."
@@ -394,10 +455,12 @@ start_service() {
     local port
     port=$(get_service_port "$svc")
 
-    local existing_pid=$(get_pid "$svc")
+    local existing_pid
+    existing_pid=$(get_pid "$svc")
     if [ -n "$existing_pid" ]; then
         echo "⚠ $name 已在运行 (PID: $existing_pid)"
-        return 0
+        wait_for_health "$svc"
+        return $?
     fi
 
     echo "----------------------------------------"
@@ -411,7 +474,8 @@ start_service() {
     local java_opts="$COMMON_JVM_OPTS"
 
     if [ "$ENABLE_SKYWALKING" = true ]; then
-        local sw_opts=$(get_skywalking_opts "$sw_name" "$(hostname -s)")
+        local sw_opts
+        sw_opts=$(get_skywalking_opts "$sw_name" "$(hostname -s)")
         if [ -n "$sw_opts" ]; then
             java_opts="$java_opts $sw_opts"
             echo "  SkyWalking: 已启用"
@@ -423,7 +487,8 @@ start_service() {
     if [ "$ENABLE_OTEL" = true ]; then
         local otel_name
         otel_name=$(get_otel_name "$svc")
-        local otel_opts=$(get_otel_opts "$otel_name")
+        local otel_opts
+        otel_opts=$(get_otel_opts "$otel_name")
         if [ -n "$otel_opts" ]; then
             java_opts="$java_opts $otel_opts"
             echo "  OpenTelemetry: 已启用 (service=$otel_name)"
@@ -442,11 +507,11 @@ start_service() {
         cd "$PROJECT_ROOT" && exec java $java_opts -jar "$jar_path" --spring.profiles.active="$SPRING_PROFILE"
     else
         echo "  模式: 后台运行"
-        pushd "$PROJECT_ROOT" > /dev/null
+        pushd "$PROJECT_ROOT" > /dev/null || return 1
         nohup java $java_opts -jar "$jar_path" \
             --spring.profiles.active="$SPRING_PROFILE" > /dev/null 2>&1 &
         local new_pid=$!
-        popd > /dev/null
+        popd > /dev/null || return 1
         
         sleep 1
         if ! kill -0 $new_pid 2>/dev/null; then
@@ -460,8 +525,9 @@ start_service() {
         if wait_for_health "$svc"; then
             echo "✓ $name 启动成功，健康检查通过"
         else
-            echo "⚠ $name 已启动 (PID: $new_pid)，但健康检查超时"
+            echo "✗ $name 未就绪: 进程退出或健康检查超时 (PID: $new_pid)"
             echo "  请检查日志: $LOG_DIR"
+            return 1
         fi
     fi
 }
@@ -476,21 +542,19 @@ status_service() {
     local port
     port=$(get_service_port "$svc")
     
-    local pid=$(get_pid "$svc")
+    local pid
+    pid=$(get_pid "$svc")
     
     if [ -n "$pid" ]; then
-        local health_status="未知"
-        if [ -n "$port" ]; then
-            if curl -sf "http://localhost:$port/actuator/health" >/dev/null 2>&1; then
-                health_status="健康"
-            else
-                health_status="不健康"
-            fi
+        if probe_readiness "$svc" && [ "$(get_pid "$svc")" = "$pid" ]; then
+            echo "✓ $name: 运行中 (PID: $pid, 端口: $port, 状态: 就绪)"
+            return 0
         fi
-        echo "✓ $name: 运行中 (PID: $pid, 端口: $port, 状态: $health_status)"
+        echo "✗ $name: 运行中但未就绪 (PID: $pid, 端口: $port)"
     else
         echo "○ $name: 未运行"
     fi
+    return 1
 }
 
 # ================================
@@ -500,12 +564,20 @@ echo "========================================"
 echo "RecordPlatform 服务管理"
 echo "========================================"
 
+# Reject invalid timing before launching any process.
+for timing in "$HEALTH_CHECK_TIMEOUT" "$HEALTH_CHECK_INTERVAL" "$HEALTH_CHECK_REQUEST_TIMEOUT"; do
+    if ! [[ "$timing" =~ ^[1-9][0-9]*$ ]]; then
+        echo "错误: 健康检查时间必须为正整数秒"
+        exit 1
+    fi
+done
+RESULT=0
 case "$COMMAND" in
     start)
         echo "命令: 启动服务"
         echo ""
         for svc in "${SERVICES[@]}"; do
-            start_service "$svc" "$FOREGROUND"
+            start_service "$svc" "$FOREGROUND" || RESULT=1
             # 全部启动时，服务间等待
             if [ "$ALL_SERVICES_SELECTED" = true ] && [ "$svc" != "backend" ]; then
                 echo "等待 10 秒..."
@@ -519,7 +591,7 @@ case "$COMMAND" in
         echo ""
         # 反向顺序停止
         for ((i=${#SERVICES[@]}-1; i>=0; i--)); do
-            stop_service "${SERVICES[$i]}"
+            stop_service "${SERVICES[$i]}" || RESULT=1
         done
         ;;
         
@@ -528,7 +600,7 @@ case "$COMMAND" in
         echo ""
         # 先停止（反向）
         for ((i=${#SERVICES[@]}-1; i>=0; i--)); do
-            stop_service "${SERVICES[$i]}"
+            stop_service "${SERVICES[$i]}" || RESULT=1
         done
         echo ""
         echo "等待 3 秒..."
@@ -536,7 +608,7 @@ case "$COMMAND" in
         echo ""
         # 再启动
         for svc in "${SERVICES[@]}"; do
-            start_service "$svc" false
+            start_service "$svc" false || RESULT=1
             if [ "$ALL_SERVICES_SELECTED" = true ] && [ "$svc" != "backend" ]; then
                 echo "等待 10 秒..."
                 sleep 10
@@ -548,7 +620,7 @@ case "$COMMAND" in
         echo "命令: 查看状态"
         echo ""
         for svc in "${SERVICES[@]}"; do
-            status_service "$svc"
+            status_service "$svc" || RESULT=1
         done
         ;;
         
@@ -561,7 +633,12 @@ esac
 
 echo ""
 echo "========================================"
-echo "操作完成"
+if [ "$RESULT" -eq 0 ]; then
+    echo "操作完成"
+else
+    echo "操作失败: 至少一个服务未就绪或操作失败"
+fi
 echo "PID 目录: $PID_DIR"
 echo "日志目录: $LOG_DIR"
 echo "========================================"
+exit "$RESULT"

--- a/tools/ci/tests/test_service_readiness.py
+++ b/tools/ci/tests/test_service_readiness.py
@@ -225,14 +225,23 @@ print('200')
     def test_real_curl_qos_http_semantics(self) -> None:
         """A real loopback HTTP server exercises curl status and body validation."""
         responses = []
+        requests = []
 
         class Handler(BaseHTTPRequestHandler):
             """Serve a controllable QoS-shaped response without a Triple listener."""
 
             def do_GET(self) -> None:
                 """Return the next deterministic test response."""
+                requests.append(self.path)
+                if self.path == "/redirected-ready":
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b"true")
+                    return
                 status, body = responses.pop(0)
                 self.send_response(status)
+                if status == 302:
+                    self.send_header("Location", "/redirected-ready")
                 self.end_headers()
                 self.wfile.write(body)
 
@@ -246,15 +255,21 @@ print('200')
         thread.start()
         self.running("storage")
         self.env.update(QOS_STORAGE_PORT=str(server.server_port), DUBBO_HOST="192.0.2.10",
-                        DUBBO_STORAGE_PORT="1", http_proxy="http://127.0.0.1:1")
+                        DUBBO_STORAGE_PORT="1", http_proxy="http://127.0.0.1:1",
+                        CURL_HOME=str(self.root))
+        (self.root / ".curlrc").write_text(
+            "location\nretry = 3\nretry-delay = 1\n", encoding="utf-8"
+        )
         try:
             for status, body, ready in ((200, b"true\n", True), (503, b"true", False),
                                         (302, b"true", False), (200, b"false", False),
                                         (200, b"not JSON", False)):
                 with self.subTest(status=status, body=body):
+                    requests.clear()
                     responses.append((status, body))
                     result = self.command("status", "storage")
                     self.assertEqual(ready, result.returncode == 0, result.stdout)
+                    self.assertEqual(["/ready"], requests)
         finally:
             server.shutdown()
             server.server_close()

--- a/tools/ci/tests/test_service_readiness.py
+++ b/tools/ci/tests/test_service_readiness.py
@@ -1,0 +1,290 @@
+"""Exercise lifecycle commands in an isolated release with controlled processes/probes."""
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class ServiceReadinessTest(unittest.TestCase):
+    """Run the actual shell entrypoint without Java services or infrastructure."""
+
+    def setUp(self) -> None:
+        """Create a secret-free release and instrument only Java and HTTP boundaries."""
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        for directory in ("bin", "jars", "run", "fake"):
+            (self.root / directory).mkdir()
+        for name in ("start.sh", "env.sh"):
+            shutil.copyfile(ROOT / "scripts" / name, self.root / "bin" / name)
+        self.env = {
+            "PATH": f"{self.root / 'fake'}:{os.environ['PATH']}",
+            "RECORD_PLATFORM_SKIP_DOTENV": "true",
+            "HEALTH_CHECK_TIMEOUT": "2",
+            "HEALTH_CHECK_INTERVAL": "1",
+            "HEALTH_CHECK_REQUEST_TIMEOUT": "1",
+            "SSL_ENABLED": "false",
+            "PROBE_LOG": str(self.root / "probes.jsonl"),
+            "JAVA_LOG": str(self.root / "java.jsonl"),
+            "PROBE_BODY": "true",
+        }
+        self.processes: list[subprocess.Popen] = []
+        self.write_executable("java", '''#!/usr/bin/env python3
+import json, os, sys, time
+with open(os.environ['JAVA_LOG'], 'a') as log:
+    log.write(json.dumps(sys.argv[1:]) + '\\n')
+if os.environ.get('JAVA_EXIT'):
+    sys.exit(int(os.environ['JAVA_EXIT']))
+time.sleep(float(os.environ.get('JAVA_LIFETIME', '60')))
+''')
+        self.write_executable("curl", '''#!/usr/bin/env python3
+import json, os, sys, time
+with open(os.environ['PROBE_LOG'], 'a') as log:
+    log.write(json.dumps(sys.argv[1:]) + '\\n')
+if os.environ.get('PROBE_HANG'):
+    time.sleep(float(sys.argv[sys.argv.index('--max-time') + 1]))
+    sys.exit(28)
+if os.environ.get('PROBE_FAIL_URL', '!') in sys.argv[-1]:
+    sys.exit(22)
+print(os.environ['PROBE_BODY'])
+print('200')
+''')
+        for service in ("storage", "fisco", "backend"):
+            self.jar(service).touch()
+
+    def tearDown(self) -> None:
+        """Stop only fixture-owned processes before removing their temporary release."""
+        for pid_file in (self.root / "run").glob("*.pid"):
+            try:
+                pid = int(pid_file.read_text())
+                if pid != os.getpid():
+                    os.kill(pid, 15)
+            except (ValueError, ProcessLookupError):
+                pass
+        for process in self.processes:
+            if process.poll() is None:
+                process.terminate()
+            process.wait(timeout=5)
+        self.temp.cleanup()
+
+    def write_executable(self, name: str, content: str) -> None:
+        """Install one deterministic boundary fixture."""
+        path = self.root / "fake" / name
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def jar(self, service: str) -> Path:
+        """Resolve the same packaged JAR names as env.sh."""
+        name = "backend-web" if service == "backend" else f"platform-{service}"
+        return self.root / "jars" / f"{name}-0.0.2-SNAPSHOT.jar"
+
+    def running(self, service: str) -> subprocess.Popen:
+        """Start an identity-valid process and publish its isolated PID file."""
+        process = subprocess.Popen(
+            [str(self.root / "fake" / "java"), "-jar", str(self.jar(service))],
+            env=self.env,
+        )
+        self.processes.append(process)
+        (self.root / "run" / f"{service}.pid").write_text(str(process.pid))
+        return process
+
+    def command(self, *args: str) -> subprocess.CompletedProcess:
+        """Invoke the real lifecycle command with a hard test-level deadline."""
+        return subprocess.run(
+            ["bash", str(self.root / "bin" / "start.sh"), *args],
+            env=self.env, text=True, capture_output=True, timeout=12,
+        )
+
+    def probes(self) -> list[list[str]]:
+        """Read requests recorded by the HTTP fixture."""
+        path = self.root / "probes.jsonl"
+        return [json.loads(line) for line in path.read_text().splitlines()] if path.exists() else []
+
+    def test_lan_providers_use_configured_loopback_qos(self) -> None:
+        """Neither LAN-only Triple endpoint is used for HTTP readiness."""
+        self.env.update(DUBBO_HOST="192.0.2.10", DUBBO_STORAGE_PORT="18092",
+                        DUBBO_FISCO_PORT="18091", QOS_STORAGE_PORT="32332", QOS_FISCO_PORT="32331")
+        self.running("storage")
+        self.running("fisco")
+        result = self.command("status", "storage", "fisco")
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(["http://127.0.0.1:32332/ready", "http://127.0.0.1:32331/ready"],
+                         [probe[-1] for probe in self.probes()])
+        for probe in self.probes():
+            for required in ("--max-time", "--connect-timeout", "--fail", "--noproxy"):
+                self.assertIn(required, probe)
+
+    def test_backend_profile_context_port_and_host(self) -> None:
+        """Use actual prod defaults and explicit operator HTTP overrides."""
+        self.running("backend")
+        self.env["PROBE_BODY"] = '{"status":"UP"}'
+        cases = [({}, "prod", "http://127.0.0.1:443/record-platform/actuator/health"),
+                 ({"SSL_ENABLED": "true"}, "prod", "https://127.0.0.1:443/record-platform/actuator/health"),
+                 ({"SERVER_PORT": "8800", "SERVER_SERVLET_CONTEXT_PATH": "/custom/", "SERVER_ADDRESS": "192.0.2.11"},
+                  "prod", "https://192.0.2.11:8800/custom/actuator/health"),
+                 ({"SERVER_SERVLET_CONTEXT_PATH": "", "SERVER_ADDRESS": "0.0.0.0"},
+                  "dev", "http://127.0.0.1:8800/actuator/health")]
+        for overrides, profile, expected in cases:
+            with self.subTest(expected=expected):
+                self.env.update(overrides)
+                result = self.command("status", "backend", "--profile", profile)
+                self.assertEqual(0, result.returncode, result.stdout)
+                self.assertEqual(expected, self.probes()[-1][-1])
+
+    def test_provider_body_fail_closed(self) -> None:
+        """Reject false, malformed, stringified and unrelated success payloads."""
+        self.running("storage")
+        for body in ("false", '"true"', '{"status":"UP"}', "true garbage", "", "1"):
+            with self.subTest(body=body):
+                self.env["PROBE_BODY"] = body
+                result = self.command("status", "storage")
+                self.assertNotEqual(0, result.returncode)
+                self.assertNotIn("✓", result.stdout)
+
+    def test_backend_requires_top_level_up(self) -> None:
+        """A nested UP or HTTP 200 alone must not imply backend health."""
+        self.running("backend")
+        for body in ('{"status":"DOWN","components":{"x":{"status":"UP"}}}',
+                     '{"components":{"x":{"status":"UP"}}}', "true", "UP", "{}"):
+            with self.subTest(body=body):
+                self.env["PROBE_BODY"] = body
+                self.assertNotEqual(0, self.command("status", "backend").returncode)
+
+    def test_existing_unready_process_start_fails(self) -> None:
+        """An existing but unready service cannot short-circuit startup success."""
+        self.running("storage")
+        self.env["PROBE_BODY"] = "false"
+        self.assertNotEqual(0, self.command("start", "storage").returncode)
+
+    def test_background_start_success_and_timeout(self) -> None:
+        """New-process readiness determines startup status, not process existence."""
+        result = self.command("start", "storage")
+        self.assertEqual(0, result.returncode, result.stdout)
+        self.assertIn("启动成功", result.stdout)
+        self.env["PROBE_BODY"] = "false"
+        result = self.command("start", "fisco")
+        self.assertNotEqual(0, result.returncode)
+        self.assertNotIn("启动成功", result.stdout)
+
+    def test_dead_process_and_unrelated_pid_are_not_ready(self) -> None:
+        """PID identity protection prevents probing or accepting another process."""
+        process = self.running("storage")
+        process.terminate()
+        process.wait(timeout=5)
+        self.assertNotEqual(0, self.command("status", "storage").returncode)
+        (self.root / "run" / "storage.pid").write_text(str(os.getpid()))
+        self.assertNotEqual(0, self.command("status", "storage").returncode)
+        self.assertEqual([], self.probes())
+        os.kill(os.getpid(), 0)
+
+    def test_failed_launch_and_foreground_exit(self) -> None:
+        """Propagate Java failure and retain foreground exec/profile semantics."""
+        self.env["JAVA_EXIT"] = "7"
+        self.assertNotEqual(0, self.command("start", "storage").returncode)
+        result = self.command("start", "backend", "--foreground", "--profile=dev")
+        self.assertEqual(7, result.returncode)
+        args = json.loads((self.root / "java.jsonl").read_text().splitlines()[-1])
+        self.assertIn("--spring.profiles.active=dev", args)
+
+    def test_aggregate_start_restart_and_status_preserve_failure(self) -> None:
+        """A later successful service never masks an earlier service failure."""
+        self.jar("storage").unlink()
+        for command in ("start", "restart", "status"):
+            with self.subTest(command=command):
+                result = self.command(command, "storage", "fisco")
+                self.assertNotEqual(0, result.returncode, result.stdout)
+                self.assertNotIn("操作完成", result.stdout)
+
+    def test_hanging_request_respects_wait_budget(self) -> None:
+        """The request timeout is clamped to the remaining startup budget."""
+        self.running("storage")
+        self.env.update(PROBE_HANG="true", HEALTH_CHECK_REQUEST_TIMEOUT="30", HEALTH_CHECK_TIMEOUT="1")
+        started = time.monotonic()
+        self.assertNotEqual(0, self.command("start", "storage").returncode)
+        self.assertLess(time.monotonic() - started, 3)
+        probe = self.probes()[-1]
+        self.assertEqual("1", probe[probe.index("--max-time") + 1])
+
+    def test_http_error_and_invalid_timing_fail(self) -> None:
+        """HTTP errors and invalid timing settings cannot produce success."""
+        self.running("storage")
+        self.env["PROBE_FAIL_URL"] = "/ready"
+        self.assertNotEqual(0, self.command("status", "storage").returncode)
+        self.env["HEALTH_CHECK_TIMEOUT"] = "0"
+        self.assertNotEqual(0, self.command("start", "storage").returncode)
+
+    def test_real_curl_qos_http_semantics(self) -> None:
+        """A real loopback HTTP server exercises curl status and body validation."""
+        responses = []
+
+        class Handler(BaseHTTPRequestHandler):
+            """Serve a controllable QoS-shaped response without a Triple listener."""
+
+            def do_GET(self) -> None:
+                """Return the next deterministic test response."""
+                status, body = responses.pop(0)
+                self.send_response(status)
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:
+                """Suppress unrelated HTTP fixture logging."""
+
+        # Move the fake aside so PATH resolves the platform's real curl.
+        (self.root / "fake" / "curl").rename(self.root / "fake" / "curl.fixture")
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.running("storage")
+        self.env.update(QOS_STORAGE_PORT=str(server.server_port), DUBBO_HOST="192.0.2.10",
+                        DUBBO_STORAGE_PORT="1", http_proxy="http://127.0.0.1:1")
+        try:
+            for status, body, ready in ((200, b"true\n", True), (503, b"true", False),
+                                        (302, b"true", False), (200, b"false", False),
+                                        (200, b"not JSON", False)):
+                with self.subTest(status=status, body=body):
+                    responses.append((status, body))
+                    result = self.command("status", "storage")
+                    self.assertEqual(ready, result.returncode == 0, result.stdout)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    def test_process_dies_during_startup_wait(self) -> None:
+        """A process disappearing after launch fails before the full wait deadline."""
+        self.env.update(JAVA_LIFETIME="2", HEALTH_CHECK_TIMEOUT="6", PROBE_BODY="false")
+        started = time.monotonic()
+        result = self.command("start", "storage")
+        self.assertNotEqual(0, result.returncode)
+        self.assertNotIn("启动成功", result.stdout)
+        self.assertLess(time.monotonic() - started, 5)
+
+    def test_legacy_ports_and_canonical_precedence(self) -> None:
+        """Legacy aliases configure the application, while canonical ports win."""
+        self.running("backend")
+        self.env.update(BACKEND_PORT="9000", PROBE_BODY='{"status":"UP"}')
+        self.assertEqual(0, self.command("status", "backend").returncode)
+        self.assertIn(":9000/", self.probes()[-1][-1])
+        self.env["SERVER_PORT"] = "9100"
+        self.assertEqual(0, self.command("status", "backend").returncode)
+        self.assertIn(":9100/", self.probes()[-1][-1])
+
+    def test_unrelated_pid_stop_is_safe(self) -> None:
+        """Stop ignores the test runner PID instead of signalling it."""
+        (self.root / "run" / "storage.pid").write_text(str(os.getpid()))
+        self.assertEqual(0, self.command("stop", "storage").returncode)
+        os.kill(os.getpid(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题与修复
修复部署发现 F-011：storage/fisco 原先错误地在 Dubbo Triple 端口请求 HTTP Actuator，健康检查超时后仍返回成功。

- Provider 改为配置的 loopback QoS /ready，严格验证 HTTP 2xx 与 JSON true。
- Backend 依据 profile、实际端口、TLS、bind host 和 context path 验证 Actuator 顶层 UP；不关闭 TLS 校验。
- 探测连接/请求/整体等待有界，前后验证同一 PID；启动、重启和状态查询保留聚合失败码，保持 foreground exec。
- 兼容旧端口别名，更新模板和部署说明；新增 15 个隔离回归用例，含真实本地 HTTP 服务与真实 curl。
- 不含 F-012 OTLP 默认值变更，不含部署凭据或私有环境信息。

## 验证
- python3 -m unittest discover -s tools/ci/tests -v：31 tests passed。
- bash -n scripts/start.sh scripts/env.sh：通过。
- shellcheck -S warning scripts/start.sh scripts/env.sh：通过。
- docs env/versions/roadmap/evidence 四项一致性：通过。
- Python 3.14 tools/docs/tests：8 tests passed（macOS 系统 Python 3.9 不支持已有 docs checker 的 zip strict，使用当前 Homebrew Python 验证）。
- mvn -f platform-backend/pom.xml test -pl backend-common,backend-service,backend-web -am -q：通过；此为本地单元测试，存在按配置跳过的集成测试，不声称已验证生产环境。
- git diff --check：通过。

## 合并与运行验收
等待主会话确认 PR #351 exact-main 全部门禁和本 PR CI/review 后合并；本 PR 未执行远端部署。合并后必须从 exact main 更新并真实复验 storage/FISCO/backend 启动。QoS ready 不是端到端存储/区块链业务验收。