### PR TITLE
fix: 完成数据库权限、k6 兼容和指标采集认证修复

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,13 @@ RATE_LIMIT_TRUSTED_PROXY_CIDRS=
 # 后端调用 FISCO Dubbo provider 的共享令牌，backend 与 fisco 必须保持一致
 BLOCKCHAIN_RPC_TOKEN=replace_with_strong_blockchain_rpc_token
 
+# Optional machine-only GET/HEAD /actuator/prometheus authentication; disabled by default.
+# Provision a dedicated identity, not a business account. Never store its plaintext password here.
+# Single-quote the BCrypt hash in shell/dotenv files to preserve its literal dollar characters.
+PROMETHEUS_SCRAPE_ENABLED=false
+PROMETHEUS_SCRAPE_USERNAME=
+PROMETHEUS_SCRAPE_PASSWORD_HASH=''
+
 # UID 编码器配置 (用于用户 ID 混淆)
 # SALT: 建议 8-16 字符随机字符串
 # CLIENT_KEY: 建议 16-32 字符随机字符串

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -66,7 +66,7 @@ jobs:
       TENANT_ID: ${{ secrets.TENANT_ID }}
       USERNAME: ${{ secrets.USERNAME }}
       PASSWORD: ${{ secrets.PASSWORD }}
-      K6_DOCKER_IMAGE: grafana/k6@sha256:8cd78f9d0de5f50bc8821cceecf356d5d9e839e6611c226a3fcf13c591080fbd
+      K6_DOCKER_IMAGE: grafana/k6@sha256:70af91f86cd8e142e0544a4edaf79835a80033f71974b92edd5ac36fd4442a7b # 0.57.0
       CLEANUP: "true"
       ENVIRONMENT_FINGERPRINT: ${{ inputs.environment_fingerprint }}
       SMOKE_FILE_QUERY_VUS: ${{ inputs.concurrency }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1224,6 +1224,11 @@ jobs:
       - name: Run Required CI policy tests
         run: python3 -m unittest discover -s tools/ci/tests -v
 
+      - name: Initialize pinned k6 runtime without network access
+        run: |
+          node --experimental-vm-modules --test tools/k6/tests/*.test.mjs
+          bash tools/k6/check-runtime.sh docker
+
       - name: Enforce required and inapplicable job results
         run: |
           python3 tools/ci/required_ci_gate.py \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 212 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 211 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 212 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 38（V1.0.0 ~ V1.20.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（319 files）
+## 当前测试文件快照（320 files）
 
 > 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -11,8 +11,8 @@
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
 | `platform-backend/backend-service` | 96 |
-| `platform-backend/backend-web` | 101 |
-| `platform-backend` | 211 |
+| `platform-backend/backend-web` | 102 |
+| `platform-backend` | 212 |
 | `platform-storage` | 28 |
 | `platform-frontend` | 41 |
 | `platform-verifier` | 15 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 9 |
-| `total` | 319 |
+| `total` | 320 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/docs/en/deployment/environment-setup.md
+++ b/docs/en/deployment/environment-setup.md
@@ -94,6 +94,12 @@ Verify status:
 docker compose -f docker-compose.infra.yml ps
 ```
 
+### Provision the migration account before first startup
+
+Creating the database does not complete Flyway permission setup. On the observed Flyway 11.7.2 / Druid 1.2.28 / MySQL 8.4 path, the migration account also needs SELECT on exactly `performance_schema.user_variables_by_thread`; a denial may surface later as `connection disabled` while reading `foreign_key_checks`.
+
+Follow the canonical [MySQL bootstrap permissions](../../operations/flyway-release-compatibility.md#mysql-bootstrap-permissions) procedure for the precise grant, effective-grant/probe verification, session-variable exposure warning, and migration/runtime credential separation and retirement. Restrict the account's source host and keep credentials private. Neither infrastructure health nor `env-check.sh --fix` establishes this grant; do not use broad grants or disable Flyway to make startup pass. Existing databases still follow the [normal migration path](../../operations/flyway-release-compatibility.md#_6-normal-fresh-and-v0-0-2-upgrade-path) with validation enabled.
+
 ## Step 3: Configure Nacos
 
 Nacos serves as the configuration center. Application configs must be imported.

--- a/docs/en/deployment/monitoring.md
+++ b/docs/en/deployment/monitoring.md
@@ -113,14 +113,64 @@ saga:
 
 ## Prometheus Configuration
 
+### Dedicated Scrape Identity
+
+Backend metrics are **not anonymous**. The optional machine identity is disabled by
+default; existing admin/monitor Bearer access still requires the matching business
+tenant. Enable the machine path explicitly with these backend settings:
+
+| Environment variable | Application property | Default |
+|---|---|---|
+| `PROMETHEUS_SCRAPE_ENABLED` | `security.prometheus-scrape.enabled` | `false` |
+| `PROMETHEUS_SCRAPE_USERNAME` | `security.prometheus-scrape.username` | empty |
+| `PROMETHEUS_SCRAPE_PASSWORD_HASH` | `security.prometheus-scrape.password-hash` | empty |
+
+Use a dedicated username (1–64 ASCII letters/digits, dot, underscore or hyphen;
+first character must be alphanumeric) and a BCrypt hash (`$2a$`, `$2b$`, or `$2y$`).
+Enabled configuration with missing or invalid values fails startup; plaintext and
+`{noop}` passwords are rejected. Only exact `GET`/`HEAD /actuator/prometheus`, below
+the configured servlet context path, accept this Basic identity. It has only
+`PROMETHEUS_SCRAPE`, **not** an admin/monitor business role. It cannot authenticate
+files, audit/log APIs, other actuator endpoints, descendants, or write methods.
+Caller tenant headers are ignored on this machine route and create no business
+tenant context. Do not add an invented `X-Tenant-ID` header to the scraper.
+
+Provision a strong random password in a local secret manager, then store it in a
+private Prometheus `password_file` (owner-only `0600`, containing only the password,
+with no trailing newline). Generate a BCrypt hash interactively using a trusted
+tool such as `htpasswd -cB -C 12 /private/path/scrape.htpasswd collector`; enter the
+same password at its prompt, never pass it with `-b`. Store **only the hash** in the
+backend's private configuration, never the `username:` prefix. Protect any hash
+file too. Username/hash/password files and certificates must not be committed.
+
+Single-quote the complete hash in shell or dotenv assignments so literal `$`
+characters survive; unquoted/double-quoted shell assignments expand them. Export
+these variables to the backend process (a Compose `.env` file alone does not inject
+container environment). A YAML application property containing the hash also needs
+safe quoting. Never enable credential-bearing debug dumps or put passwords in URLs.
+This feature does not configure TLS: expose it only through verified HTTPS, directly
+or through an explicitly managed private reverse proxy. Preserve existing backend
+TLS/forwarded-header policy; arbitrary forwarded headers do not establish trust.
+
 ### Scrape Config
+
+The following is an operator template, **not** a ready-to-run endpoint or credential.
+Replace the DNS name/port and mount private files read-only. The certificate SAN must
+match the target name; `ca_file` contains the trusted CA or explicitly trusted public
+self-signed certificate. TLS certificate verification must remain enabled.
 
 ```yaml
 scrape_configs:
   - job_name: 'recordplatform-backend'
+    scheme: https
     metrics_path: '/record-platform/actuator/prometheus'
+    basic_auth:
+      username: 'collector'
+      password_file: '/run/secrets/prometheus-scrape-password'
+    tls_config:
+      ca_file: '/run/secrets/backend-ca.crt'
     static_configs:
-      - targets: ['backend:8000']
+      - targets: ['backend.example.internal:443']
 
   # Storage and FISCO are Dubbo providers without embedded HTTP servers,
   # so they do not expose /actuator/prometheus directly.
@@ -130,6 +180,39 @@ scrape_configs:
     static_configs:
       - targets: ['otel-collector:8889']
 ```
+
+### Rotation and Operator Acceptance
+
+Changing the backend username/hash requires a **backend restart**. Publish the new
+hash and matching private password file together, restart the backend, then validate
+the Prometheus configuration with `promtool check config` and reload Prometheus
+(SIGHUP or its explicitly enabled lifecycle reload endpoint). Single-credential
+rotation can cause a brief scrape gap; no zero-downtime overlap is promised. Verify
+the new password succeeds and the old password is rejected before retiring it.
+
+Run these checks yourself after deployment; the source tests are not live-server
+acceptance. `curl --user collector` prompts for the password, keeping it out of
+arguments/history. Use the trusted public certificate/CA, never disable verification:
+
+```bash
+curl -q --cacert /private/path/backend-ca.crt --user collector --fail \
+  https://backend.example.internal/record-platform/actuator/prometheus
+curl -q --cacert /private/path/backend-ca.crt --user collector --head \
+  https://backend.example.internal/record-platform/actuator/prometheus
+curl -q --cacert /private/path/backend-ca.crt --user collector --write-out '%{http_code}\n' \
+  https://backend.example.internal/record-platform/actuator/info
+```
+
+The first two must return 200 (GET contains actual metrics). Other protected paths
+must not return metric/business data with scrape credentials. Repeat the first
+request with a wrong/old password: expect 401 and no metrics. With no credentials
+and no tenant, the existing outer tenant filter returns 400; with a tenant but no
+authentication it returns 401. Confirm the backend target is UP in Prometheus and
+fresh business samples arrive; OTel/JVM samples alone do not prove this target.
+Existing Bearer admin/monitor and ordinary application login should still work.
+
+References: [Spring Basic authentication](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/basic.html),
+[Prometheus HTTP authentication and TLS configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/).
 
 ### Alert Rules
 

--- a/docs/en/perf/k6-loadtest.md
+++ b/docs/en/perf/k6-loadtest.md
@@ -16,17 +16,45 @@ The repository provides repeatable, gated, and archivable k6 scenarios for query
 
 The external-environment workflow is manually triggered and is not a required pull-request check. Pull requests use the real MinIO/Redis/Toxiproxy integration gate from `platform-storage -Pit`; do not describe a manual k6 run as a PR gate.
 
+`Required CI` additionally initializes all seven k6 entrypoints and their supported scenario selections under the pinned image with networking disabled, then executes local fixture assertions. This is a runtime/fixture gate, not a deployed-service smoke test.
+
 ## Prerequisites
 
 - Backend reachable at `BASE_URL` (default `http://localhost:8000/record-platform/api/v1`).
 - `TENANT_ID`, `USERNAME`, and `PASSWORD` provided explicitly; login also requires `X-Tenant-ID`.
-- Local k6 installed with `brew install k6`, or the explicit Docker engine.
+- A verified k6 **0.57.0** release binary, or the explicit Docker engine. This is the tested compatibility baseline, not a claim that it is the latest or long-term-supported release. Newer binaries require independent compatibility validation.
 
 `--engine auto` only selects a local k6 binary. Docker execution requires `--engine docker` and a digest-pinned `K6_DOCKER_IMAGE`. The workflow pins:
 
 ```text
-grafana/k6@sha256:8cd78f9d0de5f50bc8821cceecf356d5d9e839e6611c226a3fcf13c591080fbd
+grafana/k6@sha256:70af91f86cd8e142e0544a4edaf79835a80033f71974b92edd5ac36fd4442a7b
 ```
+
+The old 0.49.0 default parser rejects object spread; its `base` mode also fails on the imported module graph. [k6 0.57.0](https://github.com/grafana/k6/releases/tag/v0.57.0) supplies modern syntax without an experimental compatibility flag. `tools/k6/runtime.env` is the canonical pin. For a local binary, verify the archive against the release checksum file before adding its directory to `PATH`.
+
+```bash
+# No target access, login, uploads, or cleanup:
+bash tools/k6/check-runtime.sh docker
+# Equivalent runtime check with the matching verified release binary:
+K6_BINARY=/path/to/k6-v0.57.0/k6 bash tools/k6/check-runtime.sh local
+```
+
+### Private HTTPS and User-Run Acceptance
+
+Trust the issuing CA or explicitly approved self-signed **public** certificate in the local OS trust store for native k6. Docker does not inherit macOS Keychain trust: set `K6_CA_CERT_FILE` to a readable local PEM trust bundle; both wrappers mount it read-only and set the container's `SSL_CERT_FILE`. The certificate must cover both API and presigned object-storage hosts. Never supply a private key or disable TLS verification. Keep credentials, certificates and result artifacts outside Git.
+
+After deploying the intended `main` revision, privately export `BASE_URL`, `TENANT_ID`, `USERNAME`, and `PASSWORD` for a disposable account, then run:
+
+```bash
+source tools/k6/runtime.env
+export K6_DOCKER_IMAGE="$K6_TESTED_IMAGE"
+export K6_CA_CERT_FILE=/private/path/public-trust-bundle.pem
+export VUS=1 DURATION=15s DIRECT_TOTAL_CHUNKS=2 DIRECT_CHUNK_SIZE=65536 CLEANUP=true
+bash tools/k6/run-local.sh --profile smoke --scenario direct-path --engine docker \
+  --run-id "acceptance-$(date +%Y%m%d%H%M%S)"
+```
+
+Require exit zero, non-zero completed-file/flow/cleanup samples, unchanged size/SHA-256 checks, and zero flow/cleanup failures. Verify the chain receipt separately if chain-level acceptance is required: this suite verifies file/manifest/object lifecycle, not an independent chain RPC receipt. Cleanup means the application's logical deletion; physical retention/sweep remains governed by server policy. Initialization alone does not establish deployed-service acceptance.
 
 ## Run Profiles
 
@@ -47,6 +75,8 @@ Supported values are:
 - `K6_SCENARIO=all|file-query|chunk-upload|core-mixed|direct-path`
 - `K6_ENGINE=auto|local|docker`
 
+`core-mixed` is a smoke-only selection; load supports `all|file-query|chunk-upload|direct-path`.
+
 The manual `.github/workflows/perf-smoke.yml` workflow defaults to `direct-path/smoke` and exposes profile, scenario, concurrency, duration, environment fingerprint, baseline path, resource snapshot path, and lifecycle snapshot path.
 
 ## Direct-Path Contract
@@ -61,6 +91,8 @@ Each direct iteration performs the complete lifecycle:
 6. Delete the created file and verify cleanup evidence.
 
 Raw presigned PUT/GET requests must not receive platform `Authorization`, `X-Tenant-ID`, or JSON headers. ETag is only an object-version condition; SHA-256 is the content identity. The direct suite disables k6 `url`/`name` system tags and forces `--log-output none`, preventing signed query parameters from entering metrics, logs, failure samples, or artifacts.
+
+Both upload paths use `.txt` / `text/plain` and genuine printable ASCII/newline `ArrayBuffer` payloads, not renamed random binary data. The shared fixture preserves exact configured part sizes and derives deterministic content from run, VU, iteration, and part identity to avoid accidental cross-run deduplication. Production extension/MIME validation is unchanged. Give every run a new `RUN_ID`; repeating the same ID intentionally repeats fixture content.
 
 ## Thresholds
 

--- a/docs/en/troubleshooting/common-issues.md
+++ b/docs/en/troubleshooting/common-issues.md
@@ -38,6 +38,12 @@ Solutions for frequently encountered problems.
    kill -9 <PID>
    ```
 
+### Flyway reports `connection disabled` for `foreign_key_checks`
+
+On the observed Flyway 11.7.2 / Druid 1.2.28 / MySQL 8.4 deployment path, first check for an earlier SELECT denial on `performance_schema.user_variables_by_thread`. Druid may discard that connection before Flyway reads `foreign_key_checks`; the final exception alone does not imply corrupt migrations.
+
+Use [MySQL bootstrap permissions](../../operations/flyway-release-compatibility.md#mysql-bootstrap-permissions) to grant only the required single-table SELECT to the restricted migration account, verify its effective grants and probe as that account, and review the session-variable exposure and revocation/startup implications. Do not use an administrator application account, broad system-schema grants, migration disabling or automatic history repair as a workaround. For a different first exception or dependency version, diagnose that evidence separately.
+
 ### Dubbo Service Registration Failed
 
 **Symptom**: Provider services not visible in Nacos console.

--- a/docs/operations/flyway-release-compatibility.md
+++ b/docs/operations/flyway-release-compatibility.md
@@ -1,5 +1,56 @@
 # Flyway v0.0.2 Release Compatibility Runbook
 
+## MySQL bootstrap permissions
+
+**A connection-initialization permission failure is not evidence of damaged migration history.** For this failure, use the permission checks below, not the historical rewrite recovery in section 5. Keep normal Flyway migration and validation enabled; do not edit history or run automatic repair.
+
+### Diagnose the version-scoped failure
+
+The observed deployment path uses **Flyway 11.7.2, Druid 1.2.28 and MySQL 8.4**. During connection initialization, Flyway probes user-variable reset capability with:
+
+```sql
+SELECT variable_name FROM performance_schema.user_variables_by_thread WHERE variable_value IS NOT NULL;
+```
+
+MySQL denies this query when the migration account has only application-schema privileges. On the observed Druid path the denied SELECT causes the connection to be discarded; the later `SELECT @@foreign_key_checks` then fails with `connection disabled`. Inspect the **first** SQL exception, not only the final foreign-key-check message. This is not a universal grant requirement for every Flyway version, connection pool or MySQL-compatible service. Recheck the resolved versions and probe after dependency changes.
+
+The older [Flyway #3202 report](https://github.com/flyway/flyway/issues/3202) records the same probe denial, and [Druid #3626](https://github.com/alibaba/druid/issues/3626) records the denied-query/disabled-connection chain. They corroborate the symptom, not the current deployment versions or a universal workaround.
+
+### Grant and verify only the required capability
+
+Have an authorized database operator provision a dedicated migration account with the schema-local privileges required by the reviewed migrations, including their table and routine DDL. For the path above, add only this system-table privilege. Replace the literal placeholders with the approved account and its restricted source host; do not broaden its host to `%` or use a database administrator as the application identity.
+
+```sql
+GRANT SELECT ON performance_schema.user_variables_by_thread TO '<migration-user>'@'<migration-host>';
+SHOW GRANTS FOR '<migration-user>'@'<migration-host>';
+```
+
+Inspect the complete effective grant set, including any active roles: only the intended application-schema privileges and this single-table SELECT are allowed for this bootstrap procedure. Do not substitute global SELECT, a `performance_schema` wildcard grant, or `GRANT OPTION`.
+
+Reconnect **as the exact migration account from the same source host used by the backend**, with credentials supplied privately, then run:
+
+```sql
+SELECT CURRENT_USER(), CURRENT_ROLE();
+SHOW GRANTS;
+SELECT variable_name FROM performance_schema.user_variables_by_thread WHERE variable_value IS NOT NULL;
+SELECT @@foreign_key_checks;
+```
+
+The probe must succeed even if it returns zero rows. The MySQL grant target must match `CURRENT_USER()`; have the operator review inherited role privileges if `CURRENT_ROLE()` is not `NONE`. Do not export query results or account details into public logs. Perform one normal migration/startup attempt with the intended artifact, and verify `flyway_schema_history` has no failed rows and matches that artifact's migration set. A fresh validation of the observed artifact completed all 38 migrations from `1.0.0` through `1.20.0`; this is bounded historical evidence, not a hard-coded expected count for future releases. Application readiness is a separate check and may still fail for unrelated dependencies.
+
+### Protect and retire migration credentials
+
+This table exposes **session user-variable names and values**, potentially from other sessions; table-level SELECT is not restricted to the application schema or only the names in Flyway's query. Treat it as a migration capability, not ordinary business-data access. See the [MySQL 8.4 table definition](https://dev.mysql.com/doc/refman/8.4/en/performance-schema-user-variable-tables.html). Use separate migration/runtime credentials where the deployment supports them; do not silently change the current startup migration model or disable Flyway to hide a missing grant. Keep passwords in local secret storage, never in SQL examples or command history.
+
+When rotating credentials, provision and verify the replacement account and its source-host restriction first, switch the migration configuration, and confirm normal migration/startup before retiring the old credential. Revoke this grant only after proving that the account no longer performs migrations or startup probes:
+
+```sql
+REVOKE SELECT ON performance_schema.user_variables_by_thread FROM '<migration-user>'@'<migration-host>';
+SHOW GRANTS FOR '<migration-user>'@'<migration-host>';
+```
+
+Revoking it from an account still used by startup Flyway can break the next restart even when no migrations are pending. Reconnect with the retired account and confirm the focused probe is denied and no inherited role still supplies access; verify the replacement migration path separately. Retain sanitized grant/validation evidence, not session-variable values or credentials.
+
 ## 1. Scope and invariants
 
 This runbook applies when upgrading a RecordPlatform database that may have run migrations from release `v0.0.2` or from the known development rewrite that was formerly on `main`.
@@ -214,6 +265,8 @@ Re-run the history and schema queries from sections 2 and 4. Start one canary in
 ## 6. Normal fresh and v0.0.2 upgrade path
 
 For a fresh database or an exact canonical v0.0.2 database:
+
+Before migration, verify the dedicated account using [MySQL bootstrap permissions](#mysql-bootstrap-permissions). A system-table SELECT denial is handled there and does not justify the historical recovery commands.
 
 1. Back up the database if it already exists.
 2. Run `flyway:validate` for an existing database.

--- a/docs/zh/deployment/environment-setup.md
+++ b/docs/zh/deployment/environment-setup.md
@@ -94,6 +94,12 @@ docker compose -f docker-compose.infra.yml up -d --wait
 docker compose -f docker-compose.infra.yml ps
 ```
 
+### 首次启动前配置迁移账户
+
+创建数据库并不等于完成 Flyway 权限配置。在已验证的 Flyway 11.7.2 / Druid 1.2.28 / MySQL 8.4 路径中，迁移账户还需要且仅增加对 `performance_schema.user_variables_by_thread` 的 SELECT 权限；最初的拒绝可能最终表现为读取 `foreign_key_checks` 时提示 `connection disabled`。
+
+按统一的 [MySQL 初始化权限说明](../../operations/flyway-release-compatibility.md#mysql-bootstrap-permissions) 执行精确授权、有效权限与探测查询验证，并阅读会话变量暴露风险、迁移/运行账户分离和凭据撤销条件。限制账户来源主机，凭据仅保存在私密配置中。基础设施健康或 `env-check.sh --fix` 并不代表已完成该授权；禁止扩大到全局权限或关闭 Flyway 来绕过启动失败。已有数据库仍应保持校验开启，按[正常迁移流程](../../operations/flyway-release-compatibility.md#_6-normal-fresh-and-v0-0-2-upgrade-path)执行。
+
 ## 步骤 3：配置 Nacos
 
 Nacos 作为配置中心，需要导入应用配置。

--- a/docs/zh/deployment/monitoring.md
+++ b/docs/zh/deployment/monitoring.md
@@ -113,14 +113,55 @@ saga:
 
 ## Prometheus 配置
 
+### 专用采集身份
+
+后端指标**不允许匿名读取**。机器采集身份默认关闭；已有 admin/monitor Bearer
+访问仍需匹配的业务租户。通过以下后端配置显式启用机器采集：
+
+| 环境变量 | 应用属性 | 默认值 |
+|---|---|---|
+| `PROMETHEUS_SCRAPE_ENABLED` | `security.prometheus-scrape.enabled` | `false` |
+| `PROMETHEUS_SCRAPE_USERNAME` | `security.prometheus-scrape.username` | 空 |
+| `PROMETHEUS_SCRAPE_PASSWORD_HASH` | `security.prometheus-scrape.password-hash` | 空 |
+
+使用独立用户名（1–64 位 ASCII 字母/数字、点、下划线或连字符，首位必须是字母或
+数字）及 BCrypt 哈希（`$2a$`、`$2b$` 或 `$2y$`）。启用后缺失或非法配置会使
+启动失败，拒绝明文或 `{noop}` 密码。仅配置的 servlet context 下精确的
+`GET`/`HEAD /actuator/prometheus` 接受此 Basic 身份。它只有
+`PROMETHEUS_SCRAPE` 权限，**不是**业务 admin/monitor，不得访问文件、审计/日志、
+其他 actuator、子路径或写方法。机器路径忽略调用者租户头，不建立业务租户上下文；
+不要给采集器编造 `X-Tenant-ID`。
+
+在本地密码管理器生成强随机密码，保存至 Prometheus 私有 `password_file`
+（仅所有者可读写 `0600`，只包含密码且无末尾换行）。使用可信工具交互生成
+BCrypt，例如 `htpasswd -cB -C 12 /private/path/scrape.htpasswd collector`，在提示中
+输入同一密码，不要使用 `-b` 将密码放入命令行。后端私有配置只保存哈希，不含
+`username:` 前缀。哈希文件同样限制权限；真实用户名、哈希、密码文件和证书均不提交。
+
+shell/dotenv 中用单引号包裹完整哈希以保留 `$`；shell 未引用或双引号赋值会展开
+这些字符。变量必须实际导出给后端进程（Compose 的 `.env` 本身不会自动注入容器
+环境）；直接写应用 YAML 的哈希也需正确引用。禁止凭据调试转储或 URL 携带密码。
+此功能不配置 TLS：仅通过证书验证的 HTTPS 暴露，可由明确管理的内网反向代理终止
+TLS。保留已有后端 TLS/转发头策略，不能信任任意调用者提供的转发头。
+
 ### 抓取配置
+
+以下是需要替换的运维模板，不是可直接使用的地址或凭据。修改 DNS/端口并只读挂载
+私有文件；证书 SAN 必须匹配目标名称。`ca_file` 存放受信 CA 或显式信任的自签
+公钥证书，必须保持 TLS 证书校验。
 
 ```yaml
 scrape_configs:
   - job_name: 'recordplatform-backend'
+    scheme: https
     metrics_path: '/record-platform/actuator/prometheus'
+    basic_auth:
+      username: 'collector'
+      password_file: '/run/secrets/prometheus-scrape-password'
+    tls_config:
+      ca_file: '/run/secrets/backend-ca.crt'
     static_configs:
-      - targets: ['backend:8000']
+      - targets: ['backend.example.internal:443']
 
   # storage 和 fisco 是 Dubbo Provider，没有内嵌 HTTP 服务器，
   # 不直接暴露 /actuator/prometheus。通过 OTel Collector 的 Prometheus 导出端点采集。
@@ -129,6 +170,34 @@ scrape_configs:
     static_configs:
       - targets: ['otel-collector:8889']
 ```
+
+### 轮换与用户验收
+
+修改后端用户名/哈希需要**重启后端**。同时发布新哈希与匹配的私有密码文件，重启
+后端，再执行 `promtool check config` 并重载 Prometheus（SIGHUP 或显式开启的
+lifecycle reload 接口）。单凭据轮换可能短暂中断采集，不承诺零停机重叠。确认新
+密码成功、旧密码拒绝后再停用旧凭据。
+
+部署后由用户执行以下检查；源码测试不是服务器验收。`curl --user collector`
+会提示输入密码，避免出现在参数或历史中；使用受信 CA/公钥证书，不能跳过校验：
+
+```bash
+curl -q --cacert /private/path/backend-ca.crt --user collector --fail \
+  https://backend.example.internal/record-platform/actuator/prometheus
+curl -q --cacert /private/path/backend-ca.crt --user collector --head \
+  https://backend.example.internal/record-platform/actuator/prometheus
+curl -q --cacert /private/path/backend-ca.crt --user collector --write-out '%{http_code}\n' \
+  https://backend.example.internal/record-platform/actuator/info
+```
+
+前两项应返回 200（GET 含真实指标）。采集凭据访问其他受保护路径不得返回指标或
+业务数据。使用错误/旧密码重复第一项应返回 401 且无指标。无凭据又无租户时，
+既有外层租户过滤器返回 400；有租户但无认证时返回 401。确认 Prometheus 的后端
+target 为 UP 且出现新的业务指标；仅有 OTel/JVM 数据不代表后端 target 正常。
+已有 Bearer admin/monitor 访问和普通业务登录也应继续正常。
+
+参考：[Spring Basic authentication](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/basic.html)、
+[Prometheus HTTP authentication and TLS configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/)。
 
 ### 告警规则
 

--- a/docs/zh/perf/k6-loadtest.md
+++ b/docs/zh/perf/k6-loadtest.md
@@ -16,17 +16,45 @@
 
 外部环境性能工作流仅手工触发，不是 PR 强制检查。Pull request 的真实 MinIO/Redis/Toxiproxy 门禁来自 `platform-storage -Pit`；不能把手工 k6 运行描述为 PR 门禁。
 
+`Required CI` 另在禁用网络的固定镜像中初始化全部七个 k6 入口及其受支持场景，然后执行本地 fixture 断言。这是运行器/fixture 门禁，不是部署环境 smoke 测试。
+
 ## 前置条件
 
 - Backend 可通过 `BASE_URL` 访问，默认 `http://localhost:8000/record-platform/api/v1`。
 - 显式设置 `TENANT_ID`、`USERNAME`、`PASSWORD`；登录请求也必须携带 `X-Tenant-ID`。
-- 使用 `brew install k6` 安装本地 k6，或显式选择 Docker engine。
+- 使用校验过的 k6 **0.57.0** 发布二进制，或显式选择 Docker engine。这是已验证的兼容性基线，不宣称是最新版或长期维护版；更新版本需单独验证兼容性。
 
 `--engine auto` 只会选择本地 k6。Docker 执行要求 `--engine docker` 和 digest 固定的 `K6_DOCKER_IMAGE`。工作流固定为：
 
 ```text
-grafana/k6@sha256:8cd78f9d0de5f50bc8821cceecf356d5d9e839e6611c226a3fcf13c591080fbd
+grafana/k6@sha256:70af91f86cd8e142e0544a4edaf79835a80033f71974b92edd5ac36fd4442a7b
 ```
+
+原 0.49.0 默认解析器不支持对象展开，`base` 模式也不能解析当前导入图。[k6 0.57.0](https://github.com/grafana/k6/releases/tag/v0.57.0) 不需要实验兼容参数即可使用现代语法。`tools/k6/runtime.env` 是规范 pin；本地二进制必须先与官方 release checksum 文件核对，再将其目录加入 `PATH`。
+
+```bash
+# 不访问目标、不登录、不上传、不清理：
+bash tools/k6/check-runtime.sh docker
+# 用匹配且已校验的发布二进制执行同一运行器检查：
+K6_BINARY=/path/to/k6-v0.57.0/k6 bash tools/k6/check-runtime.sh local
+```
+
+### 私有 HTTPS 与用户自行验收
+
+原生 k6 使用本机系统信任库，应导入签发 CA 或明确批准的自签**公共**证书。Docker 不继承 macOS 钥匙串：将 `K6_CA_CERT_FILE` 设置为可读的本地 PEM 信任包，两个包装脚本会只读挂载并设置容器 `SSL_CERT_FILE`。证书必须覆盖 API 和预签名对象存储主机；不得传入私钥或关闭 TLS 校验。凭证、证书和结果产物均保留在 Git 外。
+
+部署目标 `main` 版本后，私下导出一次性测试账号的 `BASE_URL`、`TENANT_ID`、`USERNAME`、`PASSWORD`，再执行：
+
+```bash
+source tools/k6/runtime.env
+export K6_DOCKER_IMAGE="$K6_TESTED_IMAGE"
+export K6_CA_CERT_FILE=/private/path/public-trust-bundle.pem
+export VUS=1 DURATION=15s DIRECT_TOTAL_CHUNKS=2 DIRECT_CHUNK_SIZE=65536 CLEANUP=true
+bash tools/k6/run-local.sh --profile smoke --scenario direct-path --engine docker \
+  --run-id "acceptance-$(date +%Y%m%d%H%M%S)"
+```
+
+要求退出码为零，completed-file/flow/cleanup 样本非零，大小/SHA-256 检查全部通过，flow/cleanup 失败率为零。如需链级验收，另行核验链回执：本套件验证文件/manifest/对象生命周期，不独立查询链 RPC 回执。cleanup 表示应用逻辑删除，物理保留/清扫仍遵循服务器策略。仅初始化成功不能证明部署环境验收完成。
 
 ## 运行档位
 
@@ -47,6 +75,8 @@ bash tools/k6/run-local.sh --profile smoke --scenario direct-path --engine auto
 - `K6_SCENARIO=all|file-query|chunk-upload|core-mixed|direct-path`
 - `K6_ENGINE=auto|local|docker`
 
+`core-mixed` 仅支持 smoke；load 支持 `all|file-query|chunk-upload|direct-path`。
+
 手工 `.github/workflows/perf-smoke.yml` 默认执行 `direct-path/smoke`，可配置 profile、scenario、concurrency、duration、environment fingerprint、baseline path、resource snapshot path 和 lifecycle snapshot path。
 
 ## 直传闭环合同
@@ -61,6 +91,8 @@ bash tools/k6/run-local.sh --profile smoke --scenario direct-path --engine auto
 6. 删除创建的文件并验证清理证据。
 
 原始预签名 PUT/GET 不能携带平台 `Authorization`、`X-Tenant-ID` 或 JSON header。ETag 只用于对象版本条件，SHA-256 才是内容身份。direct suite 会禁用 k6 的 `url`/`name` 系统标签，并强制 `--log-output none`，防止签名查询参数进入指标、日志、失败样本或 artifact。
+
+两个上传路径都使用 `.txt` / `text/plain` 和真正的可打印 ASCII/换行 `ArrayBuffer`，不是把随机二进制改后缀。共享 fixture 保持配置的精确分片字节数，并由 run、VU、iteration、part 身份生成确定性内容，避免跨运行意外去重；生产扩展名/MIME 校验不变。每次运行使用新的 `RUN_ID`，重复同一 ID 会有意复用相同内容。
 
 ## 门槛
 

--- a/docs/zh/troubleshooting/common-issues.md
+++ b/docs/zh/troubleshooting/common-issues.md
@@ -38,6 +38,12 @@
    kill -9 <PID>
    ```
 
+### Flyway 读取 `foreign_key_checks` 时提示 `connection disabled`
+
+在已验证的 Flyway 11.7.2 / Druid 1.2.28 / MySQL 8.4 部署路径中，先检查更早的日志是否包含对 `performance_schema.user_variables_by_thread` 的 SELECT 拒绝。Druid 可能先丢弃该连接，之后 Flyway 才读取 `foreign_key_checks`；不能仅凭最终异常判断迁移历史损坏。
+
+按 [MySQL 初始化权限说明](../../operations/flyway-release-compatibility.md#mysql-bootstrap-permissions) 为受限迁移账户精确授予单表 SELECT，以该账户核验有效权限并执行探测查询，同时确认会话变量暴露风险及撤销权限对后续启动的影响。禁止使用管理员作为应用账户、扩大系统库权限、关闭迁移或自动修复历史作为绕过方式。若最初异常或依赖版本不同，应根据对应证据单独诊断。
+
 ### Dubbo 服务注册失败
 
 **症状**：Provider 服务在 Nacos 控制台不可见。

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/SensitiveDataMasker.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/SensitiveDataMasker.java
@@ -52,6 +52,7 @@ public final class SensitiveDataMasker {
      */
     private static final Set<String> SENSITIVE_FIELD_NAMES = Set.of(
             "password",
+            "passwordhash",
             "oldpassword",
             "old_password",
             "newpassword",

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
@@ -14,6 +14,17 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class SensitiveDataMaskerTest {
 
+    /** Treat stored password verifiers as secrets across configuration naming variants. */
+    @Test
+    void shouldMaskPasswordHashAliases() {
+        String sentinel = "synthetic-password-verifier";
+        for (String field : List.of("passwordHash", "password_hash", "password-hash", "PASSWORD_HASH")) {
+            assertTrue(SensitiveDataMasker.isSensitiveField(field));
+            assertFalse(SensitiveDataMasker.maskSensitiveFields(Map.of(field, sentinel)).toString().contains(sentinel));
+            assertFalse(SensitiveDataMasker.maskSensitiveFields("{\"" + field + "\":\"" + sentinel + "\"}").contains(sentinel));
+        }
+    }
+
     /** Exercise collection, serialization and Throwable limits through public log-copy entrypoints. */
     @Test
     void shouldOmitOverBudgetLogCopiesWithoutPublishingPrefixes() {

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/PrometheusScrapeSecurity.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/PrometheusScrapeSecurity.java
@@ -1,0 +1,143 @@
+package cn.flying.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.authentication.www.BasicAuthenticationConverter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.context.NullSecurityContextRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Enumeration;
+import java.util.regex.Pattern;
+
+/** Optional machine identity confined to the exact Prometheus read endpoint. */
+@Component
+public final class PrometheusScrapeSecurity {
+
+    public static final String AUTHORITY = "PROMETHEUS_SCRAPE";
+    private static final String PATH = "/actuator/prometheus";
+    private static final Pattern USERNAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_.-]{0,63}");
+    private static final Pattern HASH = Pattern.compile("\\$2[aby]\\$(0[4-9]|[12][0-9]|3[01])\\$[./A-Za-z0-9]{53}");
+    private final boolean enabled;
+    private final String username;
+    private final String passwordHash;
+
+    /** Validate secrets without binding-error diagnostics that echo rejected values. */
+    public PrometheusScrapeSecurity(
+            @Value("${security.prometheus-scrape.enabled:${PROMETHEUS_SCRAPE_ENABLED:false}}") boolean enabled,
+            @Value("${security.prometheus-scrape.username:${PROMETHEUS_SCRAPE_USERNAME:}}") String username,
+            @Value("${security.prometheus-scrape.password-hash:${PROMETHEUS_SCRAPE_PASSWORD_HASH:}}") String passwordHash) {
+        if (enabled && (username == null || !USERNAME.matcher(username).matches()
+                || passwordHash == null || !HASH.matcher(passwordHash).matches())) {
+            throw new IllegalArgumentException("Enabled Prometheus scrape authentication requires a dedicated username and BCrypt hash");
+        }
+        this.enabled = enabled;
+        this.username = username;
+        this.passwordHash = passwordHash;
+    }
+
+    /** Match only exact context-relative GET/HEAD requests, without path normalization. */
+    public boolean matches(HttpServletRequest request) {
+        if (!enabled || !("GET".equals(request.getMethod()) || "HEAD".equals(request.getMethod()))) {
+            return false;
+        }
+        return (request.getContextPath() + PATH).equals(request.getRequestURI());
+    }
+
+    /** Ignore tenant hints only for this machine credential form, never for Bearer callers. */
+    public boolean isScrapeAttempt(HttpServletRequest request) {
+        if (!matches(request)) {
+            return false;
+        }
+        Enumeration<String> headers = request.getHeaders(HttpHeaders.AUTHORIZATION);
+        while (headers != null && headers.hasMoreElements()) {
+            if (isBasic(headers.nextElement())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Create a chain-local provider/filter; none of these are global authentication beans. */
+    public BasicAuthenticationFilter createFilter() {
+        if (!enabled) {
+            throw new IllegalStateException("Prometheus scrape authentication is disabled");
+        }
+        var users = new InMemoryUserDetailsManager(User.withUsername(username).password(passwordHash)
+                .authorities(AUTHORITY).build());
+        var provider = new DaoAuthenticationProvider(users);
+        provider.setPasswordEncoder(new BCryptPasswordEncoder());
+        var filter = new BasicAuthenticationFilter(new ProviderManager(provider), (request, response, exception) -> {
+            response.setStatus(401);
+            response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"prometheus\"");
+            response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        }) {
+            /** Leave all other authentication paths under the existing application rules. */
+            @Override
+            protected boolean shouldNotFilter(HttpServletRequest request) {
+                return !matches(request);
+            }
+        };
+        filter.setSecurityContextRepository(new NullSecurityContextRepository());
+        filter.setAuthenticationConverter(this::convert);
+        return filter;
+    }
+
+    /** Expose only the non-secret feature state to the security-chain builder. */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /** Reject ambiguity and sanitize parser failures before the standard filter logs them. */
+    private Authentication convert(HttpServletRequest request) {
+        // Pure Bearer requests retain all existing JWT semantics and limits.
+        if (!isScrapeAttempt(request)) {
+            return null;
+        }
+        Enumeration<String> values = request.getHeaders(HttpHeaders.AUTHORIZATION);
+        if (values == null || !values.hasMoreElements()) {
+            return null;
+        }
+        String header = values.nextElement();
+        if (values.hasMoreElements() || header.length() > 1024 || header.indexOf(',') >= 0) {
+            throw invalidCredentials();
+        }
+        if (!header.regionMatches(true, 0, "Basic ", 0, 6)) {
+            throw invalidCredentials();
+        }
+        try {
+            Authentication authentication = new BasicAuthenticationConverter().convert(request);
+            // The framework logs usernames at TRACE; untrusted input must not reach that sink.
+            if (authentication == null || !username.equals(authentication.getName())) {
+                throw invalidCredentials();
+            }
+            return authentication;
+        } catch (AuthenticationException exception) {
+            throw invalidCredentials();
+        }
+    }
+
+    /** Recognize Basic's scheme boundary, including malformed missing-token attempts. */
+    private static boolean isBasic(String header) {
+        if (header == null) {
+            return false;
+        }
+        String value = header.trim();
+        return value.equalsIgnoreCase("Basic") || value.regionMatches(true, 0, "Basic ", 0, 6)
+                || value.regionMatches(true, 0, "Basic\t", 0, 6);
+    }
+
+    /** Return a fixed credential-free failure without retaining parser causes. */
+    private static BadCredentialsException invalidCredentials() {
+        return new BadCredentialsException("Invalid Prometheus scrape credentials");
+    }
+}

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
@@ -78,6 +78,9 @@ public class SecurityConfiguration {
     @Resource
     ObjectMapper objectMapper;
 
+    @Resource
+    PrometheusScrapeSecurity prometheusScrapeSecurity;
+
     /**
      * 针对于 SpringSecurity 6 的新版配置方法
      * @param http 配置器
@@ -87,7 +90,7 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         JsonUsernamePasswordAuthenticationFilter jsonLoginFilter = buildJsonLoginFilter();
-        return http
+        http
                 .authorizeHttpRequests(conf -> conf
                         // 公开端点
                         .requestMatchers(
@@ -122,6 +125,10 @@ public class SecurityConfiguration {
                                 UserRole.ROLE_MONITOR.getRole())
                         // 健康检查端点公开
                         .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
+                        .requestMatchers(prometheusScrapeSecurity::matches).hasAnyAuthority(
+                                PrometheusScrapeSecurity.AUTHORITY,
+                                "ROLE_" + UserRole.ROLE_ADMINISTER.getRole(),
+                                "ROLE_" + UserRole.ROLE_MONITOR.getRole())
                         // 监控端点需要管理员或监控员角色
                         .requestMatchers("/actuator/**").hasAnyRole(
                                 UserRole.ROLE_ADMINISTER.getRole(),
@@ -151,8 +158,11 @@ public class SecurityConfiguration {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(requestLogFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, RequestLogFilter.class)
-                .addFilterAt(jsonLoginFilter, UsernamePasswordAuthenticationFilter.class)
-                .build();
+                .addFilterAt(jsonLoginFilter, UsernamePasswordAuthenticationFilter.class);
+        if (prometheusScrapeSecurity.isEnabled()) {
+            http.addFilterBefore(prometheusScrapeSecurity.createFilter(), JwtAuthenticationFilter.class);
+        }
+        return http.build();
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
@@ -90,7 +90,14 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         JsonUsernamePasswordAuthenticationFilter jsonLoginFilter = buildJsonLoginFilter();
+        // Register custom filter orders before positioning the optional machine authentication filter.
         http
+                .addFilterBefore(requestLogFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, RequestLogFilter.class);
+        if (prometheusScrapeSecurity.isEnabled()) {
+            http.addFilterBefore(prometheusScrapeSecurity.createFilter(), JwtAuthenticationFilter.class);
+        }
+        return http
                 .authorizeHttpRequests(conf -> conf
                         // 公开端点
                         .requestMatchers(
@@ -156,13 +163,8 @@ public class SecurityConfiguration {
                 .csrf(AbstractHttpConfigurer::disable) // lgtm[java/spring-disabled-csrf-protection]
                 .sessionManagement(conf -> conf
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(requestLogFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtAuthenticationFilter, RequestLogFilter.class)
-                .addFilterAt(jsonLoginFilter, UsernamePasswordAuthenticationFilter.class);
-        if (prometheusScrapeSecurity.isEnabled()) {
-            http.addFilterBefore(prometheusScrapeSecurity.createFilter(), JwtAuthenticationFilter.class);
-        }
-        return http.build();
+                .addFilterAt(jsonLoginFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/TenantFilter.java
@@ -7,6 +7,7 @@ import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.ErrorPayloadFactory;
 import cn.flying.common.util.SensitiveDataMasker;
+import cn.flying.config.PrometheusScrapeSecurity;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +39,13 @@ public class TenantFilter extends OncePerRequestFilter {
     private static final String TENANT_HEADER = "X-Tenant-ID";
     private static final String SSE_CONNECT_PATH = "/api/v1/sse/connect";
     private static final String PUBLIC_KEY_GRANT_CONSUME_PATH = "/api/v1/public/key-grants/consume";
+
+    private final PrometheusScrapeSecurity prometheusScrapeSecurity;
+
+    /** Require the shared scrape policy so tenant and authentication predicates cannot drift. */
+    public TenantFilter(PrometheusScrapeSecurity prometheusScrapeSecurity) {
+        this.prometheusScrapeSecurity = prometheusScrapeSecurity;
+    }
 
     /**
      * 全局公开 proof 路径不依赖租户查询，必须忽略匿名调用者提供的租户头。
@@ -86,6 +94,14 @@ public class TenantFilter extends OncePerRequestFilter {
         try {
             // 防止线程复用导致的 TenantContext 泄漏（例如：前一次请求在错误分支提前返回未进入 JWT 过滤器清理）
             TenantContext.clear();
+
+            // Machine scrapes carry no business tenant; authentication still runs downstream.
+            if (prometheusScrapeSecurity.isScrapeAttempt(request)) {
+                request.removeAttribute(Const.ATTR_TENANT_ID);
+                MDC.remove(Const.ATTR_TENANT_ID);
+                filterChain.doFilter(request, response);
+                return;
+            }
 
             String requestUri = request.getRequestURI();
             String maskedRequestUri = SensitiveDataMasker.maskSensitivePathSegments(requestUri);

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
@@ -1,0 +1,438 @@
+package cn.flying.config;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import cn.flying.common.tenant.TenantContext;
+import cn.flying.common.util.Const;
+import cn.flying.common.util.JwtUtils;
+import cn.flying.filter.JwtAuthenticationFilter;
+import cn.flying.filter.RequestLogFilter;
+import cn.flying.filter.TenantFilter;
+import cn.flying.service.AccountService;
+import cn.flying.service.LoginSecurityService;
+import cn.flying.service.PermissionService;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/** Exercise the production security chain together with its outer servlet tenant filter. */
+class PrometheusScrapeSecurityTest {
+
+    private static final String USER = "synthetic-collector";
+    private static final String PASSWORD = "SyntheticScrapePassword-OnlyForTests-9273";
+    private static final String HASH = new BCryptPasswordEncoder(4).encode(PASSWORD);
+    private static final String CONTEXT = "/record-platform";
+    private AnnotationConfigWebApplicationContext context;
+
+    /** Dispose each isolated credential context and detect leaked request authority. */
+    @AfterEach
+    void closeContext() {
+        assertNull(TenantContext.getTenantId());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        SecurityContextHolder.clearContext();
+        MDC.clear();
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    /** Load the real application chain without business infrastructure or global scrape providers. */
+    private void start(boolean enabled, String hash) {
+        context = new AnnotationConfigWebApplicationContext();
+        context.setServletContext(new MockServletContext());
+        TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context,
+                "security.prometheus-scrape.enabled=" + enabled,
+                "security.prometheus-scrape.username=" + USER,
+                "security.prometheus-scrape.password-hash=" + hash);
+        context.addBeanFactoryPostProcessor(factory -> {
+            factory.registerSingleton("jwtUtils", mock(JwtUtils.class));
+            factory.registerSingleton("loginSecurityService", mock(LoginSecurityService.class));
+            factory.registerSingleton("permissionService", mock(PermissionService.class));
+        });
+        context.register(TestConfiguration.class);
+        context.refresh();
+    }
+
+    /** Build an exact context-relative request as a servlet container would expose it. */
+    private MockHttpServletRequest request(String method, String path, String authorization) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, CONTEXT + path);
+        request.setContextPath(CONTEXT);
+        request.setServletPath(path);
+        if (authorization != null) {
+            request.addHeader("Authorization", authorization);
+        }
+        return request;
+    }
+
+    /** Execute the real security chain and existing duplicate servlet registrations once per request. */
+    private MockHttpServletResponse perform(MockHttpServletRequest request, FilterChain endpoint) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        context.getBean(TenantFilter.class).doFilter(request, response, (outerRequest, outerResponse) ->
+                context.getBean(FilterChainProxy.class).doFilter(outerRequest, outerResponse, (securedRequest, securedResponse) ->
+                        context.getBean(RequestLogFilter.class).doFilter(securedRequest, securedResponse, (loggedRequest, loggedResponse) ->
+                                context.getBean(JwtAuthenticationFilter.class).doFilter(loggedRequest, loggedResponse, endpoint))));
+        assertNull(request.getSession(false));
+        assertNull(response.getHeader("Set-Cookie"));
+        assertNull(TenantContext.getTenantId());
+        assertNull(MDC.get(Const.ATTR_TENANT_ID));
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        return response;
+    }
+
+    /** Observe authorization at the endpoint rather than injecting a test SecurityContext. */
+    private MockHttpServletResponse perform(MockHttpServletRequest request) throws Exception {
+        return perform(request, (req, res) -> res.getWriter().write("synthetic_metric 1\n"));
+    }
+
+    /** Encode synthetic credentials without putting them in fixtures, logs or command arguments. */
+    private String basic(String username, String password) {
+        return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Authenticate a machine identity without business roles, tenant, session or persisted credentials. */
+    @ParameterizedTest
+    @ValueSource(strings = {"GET", "HEAD"})
+    void acceptsOnlyDedicatedAuthorityOnExactReads(String method) throws Exception {
+        start(true, HASH);
+        MockHttpServletResponse response = perform(request(method, "/actuator/prometheus", basic(USER, PASSWORD)), (req, res) -> {
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertEquals(USER, authentication.getName());
+            assertEquals(List.of(PrometheusScrapeSecurity.AUTHORITY), authentication.getAuthorities().stream().map(Object::toString).toList());
+            assertNull(authentication.getCredentials());
+            assertNull(((org.springframework.security.core.userdetails.UserDetails) authentication.getPrincipal()).getPassword());
+            assertNull(TenantContext.getTenantId());
+            assertNull(req.getAttribute(Const.ATTR_TENANT_ID));
+            assertNull(req.getAttribute(Const.ATTR_USER_ID));
+            res.getWriter().write("synthetic_metric 1\n");
+        });
+        assertEquals(200, response.getStatus());
+        assertTrue(response.getContentAsString().contains("synthetic_metric"));
+        assertTrue(context.getBeansOfType(BasicAuthenticationFilter.class).isEmpty());
+        assertEquals(1, context.getBeansOfType(UserDetailsService.class).size());
+        var filters = context.getBean(FilterChainProxy.class).getFilterChains().getFirst().getFilters();
+        assertEquals(1, filters.stream().filter(BasicAuthenticationFilter.class::isInstance).count());
+        assertTrue(filters.indexOf(filters.stream().filter(BasicAuthenticationFilter.class::isInstance).findFirst().orElseThrow())
+                < filters.indexOf(context.getBean(JwtAuthenticationFilter.class)));
+    }
+
+    /** Treat every caller tenant hint as irrelevant only on the authenticated machine route. */
+    @ParameterizedTest
+    @ValueSource(strings = {"", "0", "42", "-1", "bad-tenant", "9999999999999999999999999999"})
+    void ignoresForgedAndDuplicateTenantHints(String tenant) throws Exception {
+        start(true, HASH);
+        MockHttpServletRequest request = request("GET", "/actuator/prometheus", basic(USER, PASSWORD));
+        request.addHeader("X-Tenant-ID", tenant);
+        request.addHeader("X-Tenant-ID", "different");
+        request.addParameter("tenantId", "77");
+        TenantContext.setTenantId(999L);
+        request.setAttribute(Const.ATTR_TENANT_ID, 999L);
+        MDC.put(Const.ATTR_TENANT_ID, "999");
+        assertEquals(200, perform(request, (req, res) -> {
+            assertNull(TenantContext.getTenantId());
+            assertNull(req.getAttribute(Const.ATTR_TENANT_ID));
+        }).getStatus());
+    }
+
+    /** Deny wrong or ambiguous credentials before any metric handler executes. */
+    @Test
+    void rejectsInvalidAbsentAndDuplicateCredentials() throws Exception {
+        start(true, HASH);
+        for (String header : List.of(basic(USER, "wrong"), basic("wrong-user", PASSWORD), "Basic", "Basic !!!",
+                "Basic " + Base64.getEncoder().encodeToString("missing-colon".getBytes(StandardCharsets.UTF_8)),
+                "Basic\tinvalid", " Basic " + basic(USER, PASSWORD).substring(6),
+                basic(USER, PASSWORD) + ", " + basic(USER, PASSWORD), "Basic " + "x".repeat(1100))) {
+            MockHttpServletResponse response = perform(request("GET", "/actuator/prometheus", header));
+            assertEquals(401, response.getStatus());
+            assertFalse(response.getContentAsString().contains("synthetic_metric"));
+        }
+        for (List<String> headers : List.of(List.of(basic(USER, PASSWORD), basic(USER, PASSWORD)),
+                List.of("Bearer admin", basic(USER, PASSWORD)), List.of(basic(USER, PASSWORD), "Bearer admin"))) {
+            MockHttpServletRequest request = request("GET", "/actuator/prometheus", headers.getFirst());
+            request.addHeader("Authorization", headers.getLast());
+            assertEquals(401, perform(request).getStatus());
+        }
+        assertEquals(400, perform(request("GET", "/actuator/prometheus", null)).getStatus());
+        MockHttpServletRequest anonymous = request("GET", "/actuator/prometheus", null);
+        anonymous.addHeader("X-Tenant-ID", "42");
+        assertEquals(401, perform(anonymous).getStatus());
+    }
+
+    /** Refuse to use scrape credentials at other endpoints, descendants or write methods. */
+    @ParameterizedTest
+    @ValueSource(strings = {"/actuator/prometheus/child", "/actuator/prometheus/", "/actuator/prometheus-other",
+            "/actuator/info", "/actuator/env", "/api/v1/files", "/api/v1/system/logs", "/api/v1/audit"})
+    void rejectsOtherProtectedPaths(String path) throws Exception {
+        start(true, HASH);
+        MockHttpServletRequest request = request("GET", path, basic(USER, PASSWORD));
+        request.addHeader("X-Tenant-ID", "42");
+        assertEquals(401, perform(request).getStatus());
+    }
+
+    /** Preserve existing authentication for non-read methods even on the exact endpoint. */
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "DELETE", "PATCH", "OPTIONS"})
+    void rejectsWriteAndOptionsMethods(String method) throws Exception {
+        start(true, HASH);
+        MockHttpServletRequest request = request(method, "/actuator/prometheus", basic(USER, PASSWORD));
+        assertEquals(400, perform(request).getStatus());
+        request = request(method, "/actuator/prometheus", basic(USER, PASSWORD));
+        request.addHeader("X-Tenant-ID", "42");
+        assertEquals(401, perform(request).getStatus());
+    }
+
+    /** Keep Bearer operator access and reject ordinary users and cross-tenant JWTs. */
+    @Test
+    void preservesJwtRolesAndTenantValidation() throws Exception {
+        start(true, HASH);
+        configureJwt("admin");
+        configureJwt("monitor");
+        configureJwt("user");
+        for (String role : List.of("admin", "monitor", "user")) {
+            MockHttpServletRequest request = request("GET", "/actuator/prometheus", "Bearer " + role);
+            request.addHeader("X-Tenant-ID", "42");
+            assertEquals("user".equals(role) ? 403 : 200, perform(request).getStatus());
+        }
+        MockHttpServletRequest crossTenant = request("GET", "/actuator/prometheus", "Bearer admin");
+        crossTenant.addHeader("X-Tenant-ID", "43");
+        assertEquals(403, perform(crossTenant).getStatus());
+        assertEquals(400, perform(request("GET", "/actuator/prometheus", "Bearer admin")).getStatus());
+        JwtUtils jwt = context.getBean(JwtUtils.class);
+        DecodedJWT decoded = jwt.resolveJwt("Bearer admin");
+        String longBearer = "Bearer " + "synthetic-jwt-segment".repeat(100);
+        when(jwt.resolveJwt(longBearer)).thenReturn(decoded);
+        MockHttpServletRequest longRequest = request("GET", "/actuator/prometheus", longBearer);
+        longRequest.addHeader("X-Tenant-ID", "42");
+        assertEquals(200, perform(longRequest).getStatus());
+        verify(jwt).resolveJwt(longBearer);
+    }
+
+    /** Disable the new feature without changing the prior operator-only endpoint behavior. */
+    @Test
+    void disabledFeatureKeepsExistingAuthorization() throws Exception {
+        start(false, "not-a-hash");
+        assertEquals(400, perform(request("GET", "/actuator/prometheus", basic(USER, PASSWORD))).getStatus());
+        MockHttpServletRequest request = request("GET", "/actuator/prometheus", basic(USER, PASSWORD));
+        request.addHeader("X-Tenant-ID", "42");
+        assertEquals(401, perform(request).getStatus());
+        configureJwt("monitor");
+        request = request("GET", "/actuator/prometheus", "Bearer monitor");
+        request.addHeader("X-Tenant-ID", "42");
+        assertEquals(200, perform(request).getStatus());
+        assertThrows(IllegalStateException.class, () -> context.getBean(PrometheusScrapeSecurity.class).createFilter());
+    }
+
+    /** Prove the global manager continues to call AccountService for JSON and form logins. */
+    @Test
+    void preservesApplicationLoginManagerAndLogout() throws Exception {
+        start(true, HASH);
+        AccountService accounts = context.getBean(AccountService.class);
+        when(accounts.loadUserByUsername("business-user")).thenAnswer(invocation -> User.withUsername("business-user")
+                .password(new BCryptPasswordEncoder(4).encode("business-password")).roles("user").build());
+        when(accounts.loadUserByUsername(USER)).thenThrow(new UsernameNotFoundException("No business account"));
+        // A null JWT is an existing handled login-success branch, avoiding irrelevant DTO serialization.
+        cn.flying.dao.dto.Account account = new cn.flying.dao.dto.Account();
+        account.setId(7L);
+        account.setTenantId(42L);
+        account.setUsername("business-user");
+        when(accounts.findAccountByNameOrEmail("business-user")).thenReturn(account);
+        for (boolean json : List.of(true, false)) {
+            MockHttpServletRequest request = request("POST", "/api/v1/auth/login", null);
+            request.addHeader("X-Tenant-ID", "42");
+            if (json) {
+                request.setContentType("application/json");
+                request.setContent("{\"username\":\"business-user\",\"password\":\"business-password\"}".getBytes(StandardCharsets.UTF_8));
+            } else {
+                request.setContentType("application/x-www-form-urlencoded");
+                request.addParameter("username", "business-user");
+                request.addParameter("password", "business-password");
+            }
+            assertEquals(200, perform(request).getStatus());
+        }
+        verify(accounts, times(2)).findAccountByNameOrEmail("business-user");
+        AuthenticationManager manager = context.getBean(AuthenticationConfiguration.class).getAuthenticationManager();
+        assertThrows(org.springframework.security.core.AuthenticationException.class, () -> manager.authenticate(
+                org.springframework.security.authentication.UsernamePasswordAuthenticationToken.unauthenticated(USER, PASSWORD)));
+        verify(accounts).loadUserByUsername(USER);
+        MockHttpServletRequest scrapeLogin = request("POST", "/api/v1/auth/login", basic(USER, PASSWORD));
+        scrapeLogin.addHeader("X-Tenant-ID", "42");
+        scrapeLogin.addParameter("username", USER);
+        scrapeLogin.addParameter("password", PASSWORD);
+        assertEquals(401, perform(scrapeLogin).getStatus());
+        MockHttpServletRequest logout = request("POST", "/api/v1/auth/logout", "Bearer logout-token");
+        logout.addHeader("X-Tenant-ID", "42");
+        when(context.getBean(JwtUtils.class).invalidateJwt("Bearer logout-token")).thenReturn(true);
+        assertEquals(200, perform(logout).getStatus());
+        verify(context.getBean(JwtUtils.class)).invalidateJwt("Bearer logout-token");
+    }
+
+    /** Clear machine authority on exceptions and do not reuse it on a later anonymous request. */
+    @Test
+    void clearsContextsAfterSuccessAndFailure() throws Exception {
+        start(true, HASH);
+        assertEquals(200, perform(request("GET", "/actuator/prometheus", basic(USER, PASSWORD))).getStatus());
+        AtomicBoolean entered = new AtomicBoolean();
+        assertThrows(ServletException.class, () -> perform(request("GET", "/actuator/prometheus", basic(USER, PASSWORD)), (req, res) -> {
+            entered.set(true);
+            throw new ServletException("synthetic endpoint failure");
+        }));
+        assertTrue(entered.get());
+        assertNull(TenantContext.getTenantId());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(400, perform(request("GET", "/actuator/prometheus", null)).getStatus());
+    }
+
+    /** Apply credential rotation only through fresh backend configuration and reject the old password. */
+    @Test
+    void rotationInvalidatesOldCredential() throws Exception {
+        start(true, HASH);
+        assertEquals(200, perform(request("GET", "/actuator/prometheus", basic(USER, PASSWORD))).getStatus());
+        context.close();
+        String replacement = "SyntheticRotatedPassword-81594";
+        start(true, new BCryptPasswordEncoder(4).encode(replacement));
+        assertEquals(401, perform(request("GET", "/actuator/prometheus", basic(USER, PASSWORD))).getStatus());
+        assertEquals(200, perform(request("GET", "/actuator/prometheus", basic(USER, replacement))).getStatus());
+    }
+
+    /** Reject incomplete/plaintext/noop startup values without echoing any supplied secret. */
+    @Test
+    void rejectsInvalidConfigurationWithFixedDiagnostics() {
+        for (String hash : List.of("", PASSWORD, "{noop}" + PASSWORD, "$2a$99$" + "x".repeat(53))) {
+            IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                    () -> new PrometheusScrapeSecurity(true, USER, hash));
+            assertFalse(failure.getMessage().contains(PASSWORD));
+            assertNull(failure.getCause());
+        }
+        for (String username : List.of("", " ", "user:name", "line\nbreak")) {
+            assertThrows(IllegalArgumentException.class, () -> new PrometheusScrapeSecurity(true, username, HASH));
+        }
+        assertThrows(IllegalArgumentException.class, () -> new PrometheusScrapeSecurity(true, null, HASH));
+        assertThrows(IllegalArgumentException.class, () -> new PrometheusScrapeSecurity(true, USER, null));
+        Exception startupFailure = assertThrows(Exception.class, () -> start(true, PASSWORD));
+        for (Throwable cause = startupFailure; cause != null; cause = cause.getCause()) {
+            assertFalse(String.valueOf(cause.getMessage()).contains(PASSWORD));
+            assertFalse(String.valueOf(cause.getMessage()).contains(HASH));
+        }
+    }
+
+    /** Refuse path normalization aliases and servlet-path disagreement at the policy boundary. */
+    @Test
+    void matcherRequiresRawExactContextRelativePath() {
+        PrometheusScrapeSecurity policy = new PrometheusScrapeSecurity(true, USER, HASH);
+        for (String path : List.of("/actuator/prometheus/", "/actuator/prometheus;x=1", "/actuator//prometheus",
+                "/actuator/%70rometheus", "/actuator/../actuator/prometheus", "/actuator/prometheus%2fchild")) {
+            MockHttpServletRequest request = request("GET", path, basic(USER, PASSWORD));
+            request.setServletPath("/actuator/prometheus");
+            assertFalse(policy.matches(request));
+            assertFalse(policy.isScrapeAttempt(request));
+        }
+        assertTrue(policy.matches(request("GET", "/actuator/prometheus", basic(USER, PASSWORD))));
+        MockHttpServletRequest rootContext = new MockHttpServletRequest("HEAD", "/actuator/prometheus");
+        assertTrue(policy.matches(rootContext));
+        assertFalse(policy.isScrapeAttempt(rootContext));
+        rootContext.addHeader("Authorization", "Bearer unchanged");
+        assertFalse(policy.isScrapeAttempt(rootContext));
+        assertFalse(policy.isScrapeAttempt(request("GET", "/actuator/prometheus", "BasicOther token")));
+    }
+
+    /** Capture real framework/application logging, including TRACE, using synthetic secret sentinels. */
+    @Test
+    void neverLogsCredentialsOrUntrustedUsernames() throws Exception {
+        start(true, HASH);
+        Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        Logger filterLogger = (Logger) LoggerFactory.getLogger("cn.flying.config.PrometheusScrapeSecurity$1");
+        Logger providerLogger = (Logger) LoggerFactory.getLogger(org.springframework.security.authentication.dao.DaoAuthenticationProvider.class);
+        Logger requestLogger = (Logger) LoggerFactory.getLogger(RequestLogFilter.class);
+        Level oldFilter = filterLogger.getLevel();
+        Level oldProvider = providerLogger.getLevel();
+        Level oldRequest = requestLogger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        root.addAppender(appender);
+        filterLogger.setLevel(Level.TRACE);
+        providerLogger.setLevel(Level.TRACE);
+        requestLogger.setLevel(Level.INFO);
+        try {
+            for (String header : List.of(basic(USER, PASSWORD), basic(USER, "wrong"), basic(PASSWORD, PASSWORD),
+                    "Basic " + HASH, "Basic !!!")) {
+                perform(request("GET", "/actuator/prometheus", header));
+            }
+            String logs = appender.list.stream().map(event -> event.getFormattedMessage() + " "
+                    + java.util.Arrays.toString(event.getArgumentArray()) + " "
+                    + (event.getThrowableProxy() == null ? "" : ch.qos.logback.classic.spi.ThrowableProxyUtil.asString(event.getThrowableProxy())))
+                    .collect(java.util.stream.Collectors.joining("\n"));
+            assertFalse(logs.contains(PASSWORD));
+            assertFalse(logs.contains(HASH));
+            assertFalse(logs.contains(basic(USER, PASSWORD)));
+            assertTrue(logs.contains("请求处理耗时"));
+        } finally {
+            filterLogger.setLevel(oldFilter);
+            providerLogger.setLevel(oldProvider);
+            requestLogger.setLevel(oldRequest);
+            root.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    /** Supply decoded tokens at the JWT boundary while exercising the production role/tenant filter. */
+    private void configureJwt(String role) {
+        JwtUtils jwt = context.getBean(JwtUtils.class);
+        DecodedJWT token = mock(DecodedJWT.class);
+        when(jwt.resolveJwt("Bearer " + role)).thenReturn(token);
+        when(jwt.toId(token)).thenReturn(7L);
+        when(jwt.toTenantId(token)).thenReturn(42L);
+        when(jwt.toRole(token)).thenReturn(role);
+        when(jwt.toUser(token)).thenReturn(User.withUsername("business-" + role).password("unused").roles(role).build());
+    }
+
+    /** Supply only application dependencies; the scrape manager must stay private to its filter. */
+    @Configuration(proxyBeanMethods = false)
+    @EnableWebSecurity
+    @org.springframework.web.servlet.config.annotation.EnableWebMvc
+    @Import({SecurityConfiguration.class, PrometheusScrapeSecurity.class, TenantFilter.class,
+            JwtAuthenticationFilter.class, RequestLogFilter.class})
+    static class TestConfiguration {
+        /** Provide the existing application's user lookup boundary. */
+        @Bean AccountService accountService() { return mock(AccountService.class); }
+        /** Use the application's existing password encoder type for global logins. */
+        @Bean PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(4); }
+        /** Support the real JSON login filter without changing its implementation. */
+        @Bean ObjectMapper objectMapper() { return new ObjectMapper(); }
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
@@ -150,6 +150,7 @@ class PrometheusScrapeSecurityTest {
         assertEquals(1, filters.stream().filter(BasicAuthenticationFilter.class::isInstance).count());
         assertTrue(filters.indexOf(filters.stream().filter(BasicAuthenticationFilter.class::isInstance).findFirst().orElseThrow())
                 < filters.indexOf(context.getBean(JwtAuthenticationFilter.class)));
+        assertExistingFilterOrder();
     }
 
     /** Treat every caller tenant hint as irrelevant only on the authenticated machine route. */
@@ -247,6 +248,9 @@ class PrometheusScrapeSecurityTest {
     @Test
     void disabledFeatureKeepsExistingAuthorization() throws Exception {
         start(false, "not-a-hash");
+        assertExistingFilterOrder();
+        assertEquals(0, context.getBean(FilterChainProxy.class).getFilterChains().getFirst().getFilters().stream()
+                .filter(BasicAuthenticationFilter.class::isInstance).count());
         assertEquals(400, perform(request("GET", "/actuator/prometheus", basic(USER, PASSWORD))).getStatus());
         MockHttpServletRequest request = request("GET", "/actuator/prometheus", basic(USER, PASSWORD));
         request.addHeader("X-Tenant-ID", "42");
@@ -256,6 +260,20 @@ class PrometheusScrapeSecurityTest {
         request.addHeader("X-Tenant-ID", "42");
         assertEquals(200, perform(request).getStatus());
         assertThrows(IllegalStateException.class, () -> context.getBean(PrometheusScrapeSecurity.class).createFilter());
+    }
+
+    /** Preserve the original custom JWT, request-log and login order without duplicate registration. */
+    private void assertExistingFilterOrder() {
+        var filters = context.getBean(FilterChainProxy.class).getFilterChains().getFirst().getFilters();
+        assertEquals(1, filters.stream().filter(JwtAuthenticationFilter.class::isInstance).count());
+        assertEquals(1, filters.stream().filter(RequestLogFilter.class::isInstance).count());
+        assertEquals(1, filters.stream().filter(cn.flying.filter.JsonUsernamePasswordAuthenticationFilter.class::isInstance).count());
+        int jwt = filters.indexOf(context.getBean(JwtAuthenticationFilter.class));
+        int requestLog = filters.indexOf(context.getBean(RequestLogFilter.class));
+        int login = filters.indexOf(filters.stream()
+                .filter(cn.flying.filter.JsonUsernamePasswordAuthenticationFilter.class::isInstance).findFirst().orElseThrow());
+        assertTrue(jwt < requestLog);
+        assertTrue(requestLog < login);
     }
 
     /** Prove the global manager continues to call AccountService for JSON and form logins. */

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -60,6 +59,32 @@ class PrometheusScrapeSecurityTest {
     private static final String HASH = new BCryptPasswordEncoder(4).encode(PASSWORD);
     private static final String CONTEXT = "/record-platform";
     private AnnotationConfigWebApplicationContext context;
+
+    /** Scan with the real integration application's exclusions without creating infrastructure beans. */
+    @Test
+    void integrationComponentScanExcludesIsolatedSecurityConfiguration() {
+        var scan = cn.flying.test.TestApplication.class
+                .getAnnotation(org.springframework.context.annotation.ComponentScan.class);
+        var scanner = new org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider(true);
+        for (var filter : scan.excludeFilters()) {
+            for (Class<?> type : filter.classes()) {
+                switch (filter.type()) {
+                    case ANNOTATION -> scanner.addExcludeFilter(new org.springframework.core.type.filter.AnnotationTypeFilter(
+                            type.asSubclass(java.lang.annotation.Annotation.class)));
+                    case ASSIGNABLE_TYPE -> scanner.addExcludeFilter(new org.springframework.core.type.filter.AssignableTypeFilter(type));
+                    default -> fail("Update this regression to apply the integration application's new filter type");
+                }
+            }
+        }
+        var candidates = java.util.Arrays.stream(scan.basePackages())
+                .flatMap(basePackage -> scanner.findCandidateComponents(basePackage).stream())
+                .map(org.springframework.beans.factory.config.BeanDefinition::getBeanClassName)
+                .collect(java.util.stream.Collectors.toSet());
+        assertTrue(candidates.contains(SecurityConfiguration.class.getName()));
+        assertTrue(candidates.contains(PrometheusScrapeSecurity.class.getName()));
+        assertFalse(candidates.contains(TestConfiguration.class.getName()),
+                "Isolated test beans must not enter the integration component scan");
+    }
 
     /** Dispose each isolated credential context and detect leaked request authority. */
     @AfterEach
@@ -440,7 +465,7 @@ class PrometheusScrapeSecurityTest {
     }
 
     /** Supply only application dependencies; the scrape manager must stay private to its filter. */
-    @Configuration(proxyBeanMethods = false)
+    @org.springframework.boot.test.context.TestConfiguration(proxyBeanMethods = false)
     @EnableWebSecurity
     @org.springframework.web.servlet.config.annotation.EnableWebMvc
     @Import({SecurityConfiguration.class, PrometheusScrapeSecurity.class, TenantFilter.class,

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SysAuditControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SysAuditControllerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 
 @WebMvcTest(SysAuditController.class)
-// @Import(cn.flying.config.WebConfiguration.class) // Import config to pick up any web settings if needed
+@Import(cn.flying.config.PrometheusScrapeSecurity.class)
 @ActiveProfiles("test")
 public class SysAuditControllerTest {
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/JwtAuthenticationFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/JwtAuthenticationFilterTest.java
@@ -173,7 +173,7 @@ class JwtAuthenticationFilterTest {
                 return null;
             }).when(filterChain).doFilter(request, response);
 
-            new TenantFilter().doFilterInternal(
+            new TenantFilter(new cn.flying.config.PrometheusScrapeSecurity(false, "", "")).doFilterInternal(
                     request,
                     response,
                     (filteredRequest, filteredResponse) ->

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/TenantFilterTest.java
@@ -36,7 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 @DisplayName("TenantFilter Tests")
 class TenantFilterTest {
 
-    private final TenantFilter filter = new TenantFilter();
+    private final TenantFilter filter = new TenantFilter(new cn.flying.config.PrometheusScrapeSecurity(false, "", ""));
 
     @Mock
     private FilterChain filterChain;

--- a/tools/docs/tests/test_check_consistency.py
+++ b/tools/docs/tests/test_check_consistency.py
@@ -40,6 +40,23 @@ class DocumentationEvidenceConsistencyTest(unittest.TestCase):
         result = check_consistency.check_evidence(REPO_ROOT)
         self.assertEqual([], result.issues)
 
+    def test_prometheus_machine_identity_docs_keep_password_file_and_verified_tls(self) -> None:
+        """Require bilingual least-privilege setup without anonymous or insecure scrape examples."""
+        for language in ("en", "zh"):
+            content = (REPO_ROOT / "docs" / language / "deployment/monitoring.md").read_text(encoding="utf-8")
+            for token in ("PROMETHEUS_SCRAPE_ENABLED", "PROMETHEUS_SCRAPE_USERNAME",
+                          "PROMETHEUS_SCRAPE_PASSWORD_HASH", "security.prometheus-scrape.password-hash",
+                          "PROMETHEUS_SCRAPE", "password_file:", "scheme: https", "ca_file:",
+                          "--cacert", "--user collector", "promtool check config", "SIGHUP", "401", "400"):
+                with self.subTest(language=language, token=token):
+                    self.assertIn(token, content)
+            self.assertNotIn("insecure_skip_verify", content)
+            self.assertNotRegex(content, r"curl[^\n]*\s-k\b")
+            self.assertNotIn("targets: ['backend:8000']", content)
+        environment = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+        self.assertIn("PROMETHEUS_SCRAPE_ENABLED=false", environment)
+        self.assertIn("PROMETHEUS_SCRAPE_PASSWORD_HASH=''", environment)
+
     def test_flyway_bootstrap_permissions_remain_narrow_and_version_scoped(self) -> None:
         """Keep bootstrap permission guidance separate from historical repair commands."""
         content = (REPO_ROOT / "docs/operations/flyway-release-compatibility.md").read_text(encoding="utf-8")

--- a/tools/docs/tests/test_check_consistency.py
+++ b/tools/docs/tests/test_check_consistency.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import tempfile
 import unittest
@@ -38,6 +39,54 @@ class DocumentationEvidenceConsistencyTest(unittest.TestCase):
         """Require the checked-in documentation and evidence to remain self-consistent."""
         result = check_consistency.check_evidence(REPO_ROOT)
         self.assertEqual([], result.issues)
+
+    def test_flyway_bootstrap_permissions_remain_narrow_and_version_scoped(self) -> None:
+        """Keep bootstrap permission guidance separate from historical repair commands."""
+        content = (REPO_ROOT / "docs/operations/flyway-release-compatibility.md").read_text(encoding="utf-8")
+        section = content.split("## MySQL bootstrap permissions\n", 1)[1].split("\n## 1. Scope", 1)[0]
+        required = (
+            "Flyway 11.7.2", "Druid 1.2.28", "MySQL 8.4",
+            "SELECT variable_name FROM performance_schema.user_variables_by_thread WHERE variable_value IS NOT NULL;",
+            "SELECT @@foreign_key_checks;", "connection disabled",
+            "not a universal grant requirement", "session user-variable names and values",
+            "separate migration/runtime credentials", "CURRENT_USER()", "CURRENT_ROLE()",
+            "SHOW GRANTS;", "no failed rows", "next restart even when no migrations are pending",
+            "do not edit history or run automatic repair",
+            "https://github.com/flyway/flyway/issues/3202",
+            "https://github.com/alibaba/druid/issues/3626",
+            "https://dev.mysql.com/doc/refman/8.4/en/performance-schema-user-variable-tables.html",
+        )
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, section)
+
+        sql_blocks = "\n".join(re.findall(r"```sql\n(.*?)\n```", section, re.DOTALL))
+        grants = re.findall(r"\bGRANT\s+[^;]+;", sql_blocks, re.IGNORECASE)
+        revokes = re.findall(r"\bREVOKE\s+[^;]+;", sql_blocks, re.IGNORECASE)
+        self.assertEqual(
+            ["GRANT SELECT ON performance_schema.user_variables_by_thread TO '<migration-user>'@'<migration-host>';"],
+            grants,
+        )
+        self.assertEqual(
+            ["REVOKE SELECT ON performance_schema.user_variables_by_thread FROM '<migration-user>'@'<migration-host>';"],
+            revokes,
+        )
+        self.assertIn("SHOW GRANTS FOR '<migration-user>'@'<migration-host>';", sql_blocks)
+        self.assertNotRegex(sql_blocks, r"(?i)\b(?:UPDATE|DELETE|INSERT|REPAIR|DROP|ALTER)\b")
+        self.assertNotIn("flyway:repair", section)
+
+    def test_bilingual_bootstrap_and_troubleshooting_link_canonical_permissions(self) -> None:
+        """Keep all deployment entrypoints connected to the same permission procedure."""
+        canonical_link = "../../operations/flyway-release-compatibility.md#mysql-bootstrap-permissions"
+        for language in ("en", "zh"):
+            for relative_path in ("deployment/environment-setup.md", "troubleshooting/common-issues.md"):
+                path = REPO_ROOT / "docs" / language / relative_path
+                with self.subTest(path=path):
+                    content = path.read_text(encoding="utf-8")
+                    self.assertIn(canonical_link, content)
+                    for token in ("11.7.2", "1.2.28", "MySQL 8.4", "performance_schema.user_variables_by_thread"):
+                        self.assertIn(token, content)
+                    self.assertTrue((path.parent / canonical_link.split("#", 1)[0]).resolve().is_file())
 
     def test_tampered_load_smoke_summary_is_rejected(self) -> None:
         """Reject a derived metric that no longer matches the retained artifact."""

--- a/tools/k6/README.md
+++ b/tools/k6/README.md
@@ -37,13 +37,21 @@ tools/k6/
 ## 前置条件
 
 - 后端服务可访问（默认：`http://localhost:8000/record-platform/api/v1`）
-- 本地 `k6`（macOS）：
+- 本地使用已校验的 k6 **0.57.0** 发布二进制（不是最新版/长期维护承诺）；或显式使用 Docker 固定镜像：
 
 ```bash
-brew install k6
+source tools/k6/runtime.env
+export K6_DOCKER_IMAGE="$K6_TESTED_IMAGE"
+bash tools/k6/check-runtime.sh docker
 ```
 
 - 如需 Docker 执行，必须显式使用 `--engine docker`，并通过 `K6_DOCKER_IMAGE` 提供 digest 固定镜像，例如 `grafana/k6@sha256:<digest>`。
+
+固定基线是 `grafana/k6@sha256:70af91f86cd8e142e0544a4edaf79835a80033f71974b92edd5ac36fd4442a7b`（0.57.0）。原 0.49.0 默认/base 模式都无法初始化现有导入图；不是只改一个对象展开表达式就能修复。完整无网络门禁初始化七个入口及受支持场景，并执行真实 ArrayBuffer/hash fixture 断言；本地等效命令为 `K6_BINARY=/path/to/k6-v0.57.0/k6 bash tools/k6/check-runtime.sh local`，版本不符会失败。
+
+两条上传路径现在使用真正 ASCII 文本 `.txt` / `text/plain`，保留精确分片大小、每个 run/VU/iteration/part 的内容隔离、SHA-256 检查和原始预签名请求边界。不修改生产上传白名单；每次使用新 `RUN_ID`。
+
+私有 HTTPS：原生 k6 使用系统信任；Docker 使用 `K6_CA_CERT_FILE=/private/path/public-trust-bundle.pem`，包装脚本将公共证书只读挂载并设置 `SSL_CERT_FILE`。禁止提交证书/私钥或关闭 TLS 验证。完整用户自行验收步骤见 [中文性能指南](../../docs/zh/perf/k6-loadtest.md#私有-https-与用户自行验收)。初始化不访问服务，不能当作真实业务验收。
 
 > 注意：`X-Tenant-ID` 对 `/api/v1/auth/login` 也必填。
 
@@ -198,7 +206,7 @@ GitHub Actions Secrets（与统一变量同名）：
 - `USERNAME`
 - `PASSWORD`
 
-手工工作流默认执行 `direct-path/smoke`，也可选择 load 和其他场景。镜像固定为 `grafana/k6:0.49.0` 对应的 multi-arch digest；报告 artifact 使用 `if: always()` 上传。外部环境 secret 只服务手工工作流，不属于 PR 强制门禁；PR 内真实 MinIO/Redis/Toxiproxy 门禁由 `platform-storage -Pit` 提供。
+手工工作流默认执行 `direct-path/smoke`，也可选择 load 和其他场景（`core-mixed` 仅支持 smoke）。镜像固定为 `grafana/k6:0.57.0` 对应的 multi-arch digest；报告 artifact 使用 `if: always()` 上传。外部环境 secret 只服务手工工作流，不属于 PR 强制门禁；PR 内真实 MinIO/Redis/Toxiproxy 门禁由 `platform-storage -Pit` 提供，`Required CI` 另执行不联网的运行器/fixture 门禁。
 
 ## 常见问题
 

--- a/tools/k6/check-runtime.sh
+++ b/tools/k6/check-runtime.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inspect every public entrypoint without setup/VU/teardown or target credentials.
+main() {
+  local root engine version entry scenario scenarios
+  root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  cd "$root"
+  source tools/k6/runtime.env
+  engine="${1:-docker}"
+  local -a runner
+  case "$engine" in
+    docker)
+      docker pull "$K6_TESTED_IMAGE"
+      runner=(docker run --rm --network none --read-only --cap-drop ALL
+        --security-opt no-new-privileges -v "$root:/workspace:ro" -w /workspace
+        "$K6_TESTED_IMAGE")
+      ;;
+    local) runner=("${K6_BINARY:-k6}") ;;
+    *) echo 'Usage: check-runtime.sh [docker|local]' >&2; return 2 ;;
+  esac
+  version="$("${runner[@]}" version)"
+  if [[ "$version" != "k6 v${K6_TESTED_VERSION} "* ]]; then
+    echo "Expected the tested k6 v${K6_TESTED_VERSION}; use the pinned container or matching binary" >&2
+    return 1
+  fi
+  for entry in tools/k6/file-query.js tools/k6/chunk-upload.js tools/k6/direct-path.js \
+    tools/k6/scenarios/core-mixed.js tools/k6/suites/ci-smoke.js \
+    tools/k6/suites/local-smoke.js tools/k6/suites/local-load.js; do
+    scenarios='all file-query chunk-upload core-mixed direct-path'
+    if [[ "$entry" == tools/k6/suites/local-load.js ]]; then
+      scenarios='all file-query chunk-upload direct-path'
+    fi
+    for scenario in $scenarios; do
+      "${runner[@]}" inspect --execution-requirements \
+        -e BASE_URL=http://127.0.0.1:1/api/v1 -e TENANT_ID=1 \
+        -e USERNAME=synthetic-fixture -e PASSWORD=synthetic-fixture \
+        -e RUN_ID=runtime-check -e K6_SCENARIO="$scenario" -e CI_INCLUDE_CHUNK=true \
+        "$entry" >/dev/null
+    done
+    echo "Initialized: $entry ($scenarios)"
+  done
+  # This script has only local fixture assertions: no HTTP imports or application calls.
+  "${runner[@]}" run --no-usage-report tools/k6/tests/fixture-runtime.js
+}
+
+main "$@"

--- a/tools/k6/chunk-upload.js
+++ b/tools/k6/chunk-upload.js
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import { sleep } from 'k6';
-import { randomBytes } from 'k6/crypto';
+import { buildTextFixture, FIXTURE_CONTENT_TYPE } from './lib/fixture.js';
 import {
   createConstantVusOptions,
   ensureRequiredConfig,
@@ -39,7 +39,7 @@ export const options = createConstantVusOptions(
  */
 export function runChunkUploadFlow(context, scenarioName = 'chunk-upload') {
   const headers = buildAuthHeaders(context.config.tenantId, context.token);
-  const fileName = `k6-${context.config.runId}-${__VU}-${__ITER}.bin`;
+  const fileName = `k6-${context.config.runId}-${__VU}-${__ITER}.txt`;
   const fileSize = uploadConfig.totalChunks * uploadConfig.chunkSize;
   const startedAt = Date.now();
 
@@ -49,7 +49,7 @@ export function runChunkUploadFlow(context, scenarioName = 'chunk-upload') {
     {
       fileName,
       fileSize: String(fileSize),
-      contentType: 'application/octet-stream',
+      contentType: FIXTURE_CONTENT_TYPE,
       chunkSize: String(uploadConfig.chunkSize),
       totalChunks: String(uploadConfig.totalChunks),
     },
@@ -72,9 +72,9 @@ export function runChunkUploadFlow(context, scenarioName = 'chunk-upload') {
   let chunksOk = true;
   for (let chunkIndex = 0; chunkIndex < uploadConfig.totalChunks; chunkIndex += 1) {
     const chunkTags = buildRequestTags(scenarioName, 'upload_chunk', 'PUT');
-    const bytes = randomBytes(uploadConfig.chunkSize);
+    const bytes = buildTextFixture(uploadConfig.chunkSize, `${fileName}:${chunkIndex}`);
     const payload = {
-      file: http.file(bytes, `chunk-${chunkIndex}.bin`, 'application/octet-stream'),
+      file: http.file(bytes, `chunk-${chunkIndex}.txt`, FIXTURE_CONTENT_TYPE),
     };
 
     const chunkRes = put(

--- a/tools/k6/direct-path.js
+++ b/tools/k6/direct-path.js
@@ -1,6 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { randomBytes, sha256 } from 'k6/crypto';
+import { sha256 } from 'k6/crypto';
+import { buildTextFixture, FIXTURE_CONTENT_TYPE } from './lib/fixture.js';
 import {
   buildRequestTags,
   createConstantVusOptions,
@@ -65,10 +66,10 @@ function buildClientId(runId) {
  *
  * @returns {{index:number, bytes:ArrayBuffer, size:number, hash:string}[]} 分片计划
  */
-function buildPartPlan() {
+function buildPartPlan(fileName) {
   const parts = [];
   for (let index = 0; index < directConfig.totalChunks; index += 1) {
-    const bytes = randomBytes(directConfig.chunkSize);
+    const bytes = buildTextFixture(directConfig.chunkSize, `${fileName}:${index}`);
     parts.push({
       index,
       bytes,
@@ -217,8 +218,8 @@ export function runDirectPathFlow(context, scenarioName = 'direct-path') {
     'Content-Type': 'application/json',
   });
   const clientId = buildClientId(context.config.runId);
-  const fileName = `k6-${context.config.runId}-${__VU}-${__ITER}-direct.bin`;
-  const partPlan = buildPartPlan();
+  const fileName = `k6-${context.config.runId}-${__VU}-${__ITER}-direct.txt`;
+  const partPlan = buildPartPlan(fileName);
   const fileSize = partPlan.reduce((total, part) => total + part.size, 0);
   let uploadedBytes = 0;
   let downloadedBytes = 0;
@@ -230,7 +231,7 @@ export function runDirectPathFlow(context, scenarioName = 'direct-path') {
       clientId,
       fileName,
       fileSize,
-      contentType: 'application/octet-stream',
+      contentType: FIXTURE_CONTENT_TYPE,
       chunkSize: directConfig.chunkSize,
       totalChunks: partPlan.length,
       parts: partPlan.map((part) => ({

--- a/tools/k6/lib/fixture.js
+++ b/tools/k6/lib/fixture.js
@@ -1,0 +1,20 @@
+import { sha256 } from 'k6/crypto';
+
+export const FIXTURE_CONTENT_TYPE = 'text/plain';
+
+/** Build exact-size UTF-8 text with deterministic, per-run/VU/iteration/part identity. */
+export function buildTextFixture(size, identity) {
+  if (!Number.isSafeInteger(size) || size < 1) {
+    throw new Error('Fixture size must be a positive safe integer');
+  }
+  if (typeof identity !== 'string' || identity.length === 0) {
+    throw new Error('Fixture identity is required');
+  }
+  // Start with identity entropy so even small parts do not share a fixed prefix.
+  const line = `${sha256(identity, 'hex')} RecordPlatform load-test text fixture.\n`;
+  const bytes = new Uint8Array(size);
+  for (let index = 0; index < size; index += 1) {
+    bytes[index] = line.charCodeAt(index % line.length);
+  }
+  return bytes.buffer;
+}

--- a/tools/k6/run-ci.sh
+++ b/tools/k6/run-ci.sh
@@ -22,6 +22,7 @@ Environment (required):
   USERNAME
   PASSWORD
   K6_DOCKER_IMAGE               Docker 引擎必填，且必须使用 digest 固定镜像
+  K6_CA_CERT_FILE               Docker 可选：本地可信 PEM CA/自签公共证书文件
   ENVIRONMENT_FINGERPRINT       同环境 baseline 比较标识（默认按目标掩码/引擎/OS 生成）
 USAGE
 }
@@ -288,6 +289,18 @@ run_with_docker_k6() {
     -v "$PWD:/workspace:ro"
     -w /workspace
   )
+
+  # Mount only the public trust bundle; keep TLS verification enabled.
+  if [[ -n "${K6_CA_CERT_FILE:-}" ]]; then
+    if [[ ! -f "$K6_CA_CERT_FILE" || ! -r "$K6_CA_CERT_FILE" ]]; then
+      echo '[ERROR] K6_CA_CERT_FILE must be a readable public PEM certificate file' >&2
+      return 1
+    fi
+    local ca_file
+    ca_file="$(cd "$(dirname "$K6_CA_CERT_FILE")" && pwd)/$(basename "$K6_CA_CERT_FILE")"
+    docker_args+=(-v "$ca_file:/etc/ssl/certs/record-platform-ca.pem:ro"
+      -e SSL_CERT_FILE=/etc/ssl/certs/record-platform-ca.pem)
+  fi
 
   if should_add_docker_host_gateway_alias; then
     docker_args+=(--add-host "host.docker.internal:host-gateway")

--- a/tools/k6/run-local.sh
+++ b/tools/k6/run-local.sh
@@ -17,6 +17,7 @@ Options:
 
 Environment:
   K6_DOCKER_IMAGE               Docker 引擎必填，且必须使用 digest 固定镜像
+  K6_CA_CERT_FILE               Docker 可选：本地可信 PEM CA/自签公共证书文件
   ENVIRONMENT_FINGERPRINT       同环境 baseline 比较标识（默认按目标掩码/引擎/OS 生成）
   DIRECT_RESOURCE_SNAPSHOT_PATH 可选的同源资源快照相对路径
   DIRECT_LIFECYCLE_SNAPSHOT_PATH 可选的同源存储生命周期快照相对路径
@@ -285,6 +286,18 @@ run_with_docker_k6() {
     -v "$PWD:/workspace:ro"
     -w /workspace
   )
+
+  # Mount only the public trust bundle; keep TLS verification enabled.
+  if [[ -n "${K6_CA_CERT_FILE:-}" ]]; then
+    if [[ ! -f "$K6_CA_CERT_FILE" || ! -r "$K6_CA_CERT_FILE" ]]; then
+      echo '[ERROR] K6_CA_CERT_FILE must be a readable public PEM certificate file' >&2
+      return 1
+    fi
+    local ca_file
+    ca_file="$(cd "$(dirname "$K6_CA_CERT_FILE")" && pwd)/$(basename "$K6_CA_CERT_FILE")"
+    docker_args+=(-v "$ca_file:/etc/ssl/certs/record-platform-ca.pem:ro"
+      -e SSL_CERT_FILE=/etc/ssl/certs/record-platform-ca.pem)
+  fi
 
   if should_add_docker_host_gateway_alias; then
     docker_args+=(--add-host "host.docker.internal:host-gateway")

--- a/tools/k6/runtime.env
+++ b/tools/k6/runtime.env
@@ -1,0 +1,3 @@
+# Canonical tested runtime; changes require the no-network runtime gate.
+K6_TESTED_VERSION=0.57.0
+K6_TESTED_IMAGE=grafana/k6@sha256:70af91f86cd8e142e0544a4edaf79835a80033f71974b92edd5ac36fd4442a7b

--- a/tools/k6/tests/contracts.test.mjs
+++ b/tools/k6/tests/contracts.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import { spawnSync } from 'node:child_process';
+import vm from 'node:vm';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** Load the real k6 consumer graph against an isolated in-memory HTTP boundary. */
+async function loadFlow(entry, calls) {
+  const context = vm.createContext({
+    __ENV: { USERNAME: 'fixture', PASSWORD: 'fixture', RUN_ID: 'fixture-run',
+      CHUNK_SIZE: '65536', TOTAL_CHUNKS: '2', DIRECT_CHUNK_SIZE: '65536', DIRECT_TOTAL_CHUNKS: '2' },
+    __VU: 2, __ITER: 3, console, ArrayBuffer, Uint8Array,
+  });
+  const digest = (input) => createHash('sha256').update(typeof input === 'string' ? input : Buffer.from(input)).digest('hex');
+  const response = { status: 200, json: (path) => ({ code: 200, 'data.clientId': 'fixture-client' })[path] };
+  /** Capture calls without connecting to any endpoint. */
+  function request(method, ...args) {
+    calls.push({ method, args });
+    return response;
+  }
+  const http = {
+    file: (data, filename, contentType) => ({ data, filename, contentType }),
+    get: (...args) => request('GET', ...args), post: (...args) => request('POST', ...args),
+    put: (...args) => request('PUT', ...args), del: (...args) => request('DELETE', ...args),
+  };
+  class Metric { add() {} }
+  const builtins = {
+    'k6/http': { default: http }, 'k6/crypto': { sha256: digest },
+    k6: { sleep: () => {}, check: (value, checks) => Object.values(checks).every((fn) => fn(value)), fail: (message) => { throw new Error(message); } },
+    'k6/metrics': { Counter: Metric, Rate: Metric, Trend: Metric },
+  };
+  const modules = new Map();
+  /** Cache modules before linking to support shared transitive dependencies. */
+  function moduleFor(name) {
+    if (modules.has(name)) return modules.get(name);
+    let module;
+    if (builtins[name]) {
+      module = new vm.SyntheticModule(Object.keys(builtins[name]), function () {
+        for (const [key, value] of Object.entries(builtins[name])) this.setExport(key, value);
+      }, { context, identifier: name });
+    } else {
+      module = new vm.SourceTextModule(readFileSync(name, 'utf8'), { context, identifier: name });
+    }
+    modules.set(name, module);
+    return module;
+  }
+  const module = moduleFor(resolve(root, entry));
+  await module.link((name, referrer) => moduleFor(name.startsWith('.') ? resolve(dirname(referrer.identifier), name) : name));
+  await module.evaluate();
+  return module.namespace;
+}
+
+test('traditional consumer sends genuine exact-size text with correct extension and MIME', async () => {
+  const calls = [];
+  const module = await loadFlow('tools/k6/chunk-upload.js', calls);
+  module.runChunkUploadFlow({ config: { runId: 'run-A', tenantId: '1', baseUrl: 'http://fixture.invalid' }, token: 'synthetic' });
+  const start = calls.find((call) => call.method === 'POST').args[1];
+  assert.equal(start.fileName, 'k6-run-A-2-3.txt');
+  assert.equal(start.contentType, 'text/plain');
+  const chunks = calls.filter((call) => call.method === 'PUT');
+  assert.equal(chunks.length, 2);
+  const hashes = chunks.map(({ args }) => {
+    const file = args[1].file;
+    assert.match(file.filename, /\.txt$/);
+    assert.equal(file.contentType, 'text/plain');
+    assert.equal(file.data.byteLength, 65536);
+    assert.match(Buffer.from(file.data).toString('ascii'), /^[\x20-\x7e\n]+$/);
+    return createHash('sha256').update(Buffer.from(file.data)).digest('hex');
+  });
+  assert.notEqual(hashes[0], hashes[1]);
+});
+
+test('direct create uses the exact text size and independently reconstructed SHA-256 plan', async () => {
+  const calls = [];
+  const module = await loadFlow('tools/k6/direct-path.js', calls);
+  module.runDirectPathFlow({ config: { runId: 'run-A', tenantId: '1', baseUrl: 'http://fixture.invalid' }, token: 'synthetic' });
+  const create = JSON.parse(calls.find((call) => call.method === 'POST').args[1]);
+  assert.equal(create.fileName, 'k6-run-A-2-3-direct.txt');
+  assert.equal(create.contentType, 'text/plain');
+  assert.equal(create.fileSize, 131072);
+  for (const part of create.parts) {
+    const seed = createHash('sha256').update(`${create.fileName}:${part.index}`).digest('hex');
+    const line = `${seed} RecordPlatform load-test text fixture.\n`;
+    const expected = Buffer.from(line.repeat(Math.ceil(part.size / line.length)).slice(0, part.size));
+    assert.equal(part.size, 65536);
+    assert.equal(part.plainHash, `sha256:${createHash('sha256').update(expected).digest('hex')}`);
+    assert.equal(part.cipherHash, part.plainHash);
+  }
+});
+
+test('canonical runtime, workflow and bilingual docs share one immutable pin', () => {
+  const pin = readFileSync(resolve(root, 'tools/k6/runtime.env'), 'utf8').match(/^K6_TESTED_IMAGE=(.+)$/m)[1];
+  assert.match(pin, /^grafana\/k6@sha256:[a-f0-9]{64}$/);
+  for (const path of ['.github/workflows/perf-smoke.yml', 'tools/k6/README.md', 'docs/en/perf/k6-loadtest.md', 'docs/zh/perf/k6-loadtest.md']) {
+    assert.ok(readFileSync(resolve(root, path), 'utf8').includes(pin), path);
+  }
+  const workflow = readFileSync(resolve(root, '.github/workflows/test.yml'), 'utf8').split('  required-ci:')[1];
+  assert.ok(workflow.includes('if: always()'));
+  assert.ok(workflow.includes('bash tools/k6/check-runtime.sh docker'));
+  const gate = readFileSync(resolve(root, 'tools/k6/check-runtime.sh'), 'utf8');
+  assert.ok(gate.includes('--network none'));
+  assert.ok(gate.includes('inspect --execution-requirements'));
+  assert.ok(gate.includes('tests/fixture-runtime.js'));
+});
+
+test('both Docker wrappers mount an explicit public trust file read-only without disabling TLS', () => {
+  for (const wrapper of ['run-local.sh', 'run-ci.sh']) {
+    const source = readFileSync(resolve(root, `tools/k6/${wrapper}`), 'utf8').replace(/main "\$@"\s*$/, '');
+    // This is an argv-only fake Docker test, not a certificate/TLS acceptance test.
+    const probe = `${source}\ndocker() { printf '%s\\n' "$@"; }\nrun_with_docker_k6 tools/k6/direct-path.js\n`;
+    const publicFixture = resolve(root, 'tools/k6/tests/fixture-runtime.js');
+    const env = { PATH: process.env.PATH, K6_DOCKER_IMAGE: 'grafana/k6@sha256:synthetic', K6_CA_CERT_FILE: publicFixture };
+    const result = spawnSync('bash', { input: probe, cwd: root, env, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(result.stdout.includes(`${publicFixture}:/etc/ssl/certs/record-platform-ca.pem:ro`));
+    assert.ok(result.stdout.includes('SSL_CERT_FILE=/etc/ssl/certs/record-platform-ca.pem'));
+    assert.doesNotMatch(result.stdout, /insecure|skip.*[Tt][Ll][Ss]/);
+    const rejected = spawnSync('bash', { input: probe, cwd: root,
+      env: { ...env, K6_CA_CERT_FILE: `${publicFixture}.missing` }, encoding: 'utf8' });
+    assert.notEqual(rejected.status, 0);
+    assert.equal(rejected.stdout, '');
+    assert.ok(rejected.stderr.includes('must be a readable public PEM certificate'));
+    const defaults = spawnSync('bash', { input: probe, cwd: root,
+      env: { PATH: process.env.PATH, K6_DOCKER_IMAGE: env.K6_DOCKER_IMAGE }, encoding: 'utf8' });
+    assert.equal(defaults.status, 0, defaults.stderr);
+    assert.ok(!defaults.stdout.includes('SSL_CERT_FILE'));
+  }
+});

--- a/tools/k6/tests/fixture-runtime.js
+++ b/tools/k6/tests/fixture-runtime.js
@@ -1,0 +1,32 @@
+import { sha256 } from 'k6/crypto';
+import { check } from 'k6';
+import { buildTextFixture, FIXTURE_CONTENT_TYPE } from '../lib/fixture.js';
+
+export const options = { vus: 1, iterations: 1, thresholds: { checks: ['rate==1'] } };
+
+/** Fail the actual k6 process on any fixture contract violation. */
+function assert(condition, description) {
+  if (!check(condition, { [description]: (value) => value })) throw new Error(description);
+}
+
+/** Exercise real ArrayBuffer/hash behavior without touching any application endpoint. */
+export default function () {
+  assert(FIXTURE_CONTENT_TYPE === 'text/plain', 'Fixture MIME must match txt');
+  for (const size of [1, 65, 65536, 1048576]) {
+    const buffer = buildTextFixture(size, 'run-one:vu-1:iter-1:part-0');
+    const bytes = new Uint8Array(buffer);
+    assert(buffer instanceof ArrayBuffer && buffer.byteLength === size, 'Exact byte length');
+    assert(bytes.every((byte) => byte === 10 || (byte >= 32 && byte <= 126)), 'Genuine ASCII text');
+    assert(sha256(buffer, 'hex') === sha256(buildTextFixture(size, 'run-one:vu-1:iter-1:part-0'), 'hex'),
+      'Repeatable hash');
+  }
+  const identities = ['run-one:vu-1:iter-1:part-0', 'run-two:vu-1:iter-1:part-0',
+    'run-one:vu-2:iter-1:part-0', 'run-one:vu-1:iter-2:part-0', 'run-one:vu-1:iter-1:part-1'];
+  const hashes = identities.map((identity) => sha256(buildTextFixture(65536, identity), 'hex'));
+  assert(new Set(hashes).size === identities.length, 'Run/VU/iteration/part isolation');
+  for (const size of [0, -1, 1.5, NaN, Infinity]) {
+    let rejected = false;
+    try { buildTextFixture(size, 'fixture'); } catch (_) { rejected = true; }
+    assert(rejected, 'Invalid sizes rejected');
+  }
+}


### PR DESCRIPTION
## Scope

Combine the three remaining deployment-source fixes in one PR, as requested:

- F-013: document the version-scoped Flyway/MySQL bootstrap probe, exact single-table SELECT grant, verification, account/role boundaries and safe revocation guidance. Link both language deployment and troubleshooting entrypoints.
- F-014: pin k6 0.57.0 by immutable image digest, replace unsupported binary fixtures with exact-size text payloads, add an unconditional no-network real-runtime Required CI gate, and support explicit read-only public CA bundles without disabling TLS.
- F-015: add disabled-by-default, endpoint-only Prometheus Basic authentication with a private provider and dedicated authority. Preserve application login, existing admin/monitor Bearer access and business tenant isolation. Document private password-file provisioning, verified TLS and rotation.

## Verification

- Full affected Maven `test` reactor passes; the new Spring security-chain suite now has 31 passing cases, with existing Tenant/JWT and masking regressions passing. Application infrastructure boundaries are isolated test doubles. Existing Docker-dependent skips are not claimed as integration passes.
- Official checksum-verified k6 0.57.0 binary: seven entrypoints / 34 supported initialization combinations and 19 fixture checks pass, with zero network bytes.
- Node real-consumer/hash/pin/TLS-argv regressions: 4/4. CI policy regressions: 39/39.
- Documentation regressions: 11/11; routes/env/roadmap/versions/evidence consistency: 5/5; frozen pnpm 10.26.1 VitePress build passes.
- Shell syntax, workflow actionlint and diff whitespace checks pass.
- The fixed Linux image and full integration/coverage gates must pass PR CI before merge.

## CI follow-ups

- Restored the original fluent security-chain construction and asserted enabled/disabled filter ordering; no CSRF policy change or added scan suppression. The subsequent CodeQL result passed with no new alerts.
- Docker-enabled CI exposed an isolated test configuration entering the integration application's component scan and colliding with its ObjectMapper. Changed the nested harness to Boot TestConfiguration, with a real no-Docker candidate-scan regression: red before the annotation fix, green after. Related focused suite: 78 tests, zero failures/errors/skips. No bean overriding or scan exclusion relaxation.

## Boundaries

- No real credentials, private host configuration, certificates or local task artifacts are included.
- This is a source/configuration handoff, not a deployment or a claim of live application acceptance. The user owns subsequent software testing. The running backend needs the new artifact and private scrape settings before the new scrape path takes effect.
- Independent dependency-upgrade PRs are outside these three fixes. No upload allowlist, coverage threshold or tenant/authentication policy is weakened.
