### PR TITLE
fix: 修正真实指标导出与链统计监控

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 212 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 215 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 216 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 38（V1.0.0 ~ V1.20.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（325 files）
+## 当前测试文件快照（326 files）
 
 > 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -11,8 +11,8 @@
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
 | `platform-backend/backend-service` | 96 |
-| `platform-backend/backend-web` | 105 |
-| `platform-backend` | 215 |
+| `platform-backend/backend-web` | 106 |
+| `platform-backend` | 216 |
 | `platform-storage` | 28 |
 | `platform-frontend` | 41 |
 | `platform-verifier` | 15 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 11 |
-| `total` | 325 |
+| `total` | 326 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（326 files）
+## 当前测试文件快照（328 files）
 
 > 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -16,13 +16,13 @@
 | `platform-storage` | 28 |
 | `platform-frontend` | 41 |
 | `platform-verifier` | 15 |
-| `platform-fisco` | 12 |
+| `platform-fisco` | 14 |
 | `platform-api` | 3 |
 | `tools/ci` | 6 |
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 11 |
-| `total` | 326 |
+| `total` | 328 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/config/grafana/slo-dashboard.json
+++ b/config/grafana/slo-dashboard.json
@@ -84,6 +84,7 @@
         }
       ],
       "title": "Upload Success Rate",
+      "description": "Uses the backend's actual saga_total counter family. No terminal outcomes means undefined success ratio; missing telemetry is unknown, not healthy.",
       "type": "stat"
     },
     {

--- a/config/prometheus/alerting-rules.yml
+++ b/config/prometheus/alerting-rules.yml
@@ -49,7 +49,7 @@ groups:
         expr: |
           (up{job="recordplatform-backend"} == 1)
           unless on(job, instance)
-          saga_total_total{job="recordplatform-backend",status="started"}
+          saga_total{job="recordplatform-backend",status="started"}
         for: 5m
         labels:
           severity: warning

--- a/config/prometheus/alerting-rules.yml
+++ b/config/prometheus/alerting-rules.yml
@@ -35,6 +35,23 @@ groups:
   # jobs must not page, and absent data must never be replaced with healthy zeroes.
   - name: monitoring:collection
     rules:
+      - alert: RecordPlatformFiscoHistogramBucketsMissing
+        expr: |
+          (
+            (otel_blockchain_operation_duration_seconds_count{job="otel-collector",exported_job="record-platform-fisco",operation="storeFile"} > 0)
+            and on(job, instance)
+            (up{job="otel-collector"} == 1)
+          )
+          unless on(job, instance, exported_job, exported_instance, chain, operation)
+          otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",exported_job="record-platform-fisco",operation="storeFile",le=~"[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?"}
+        for: 2m
+        labels:
+          severity: warning
+          slo: monitoring
+        annotations:
+          summary: "FISCO operation histogram has no finite buckets"
+          description: "An observed storeFile timer has no finite buckets for the same producer and chain; percentile estimates are unavailable."
+
       - alert: RecordPlatformScrapeTargetDown
         expr: up{job=~"recordplatform-backend|otel-collector"} == 0
         for: 2m

--- a/config/prometheus/recording-rules.yml
+++ b/config/prometheus/recording-rules.yml
@@ -18,7 +18,7 @@
 #   or POST /-/reload if --web.enable-lifecycle is set.
 #
 # Metric sources:
-#   saga_total_total{status}         — Micrometer counter (SagaMetrics.java)
+#   saga_total{status}         — Micrometer counter (SagaMetrics.java)
 #                                      status: started | completed | compensated | failed
 #   otel_blockchain_operation_duration_seconds_bucket{operation,le,exported_job}
 #                                    — FISCO metrics exported via OTel Collector Prometheus exporter
@@ -42,67 +42,67 @@ groups:
       # 5-minute window
       - record: sli:upload_success:ratio_rate5m
         expr: |
-          sum(rate(saga_total_total{status="completed"}[5m]))
+          sum(rate(saga_total{status="completed"}[5m]))
           /
           (
-            sum(rate(saga_total_total{status="completed"}[5m]))
-            + sum(rate(saga_total_total{status="failed"}[5m]))
-            + sum(rate(saga_total_total{status="compensated"}[5m]))
+            sum(rate(saga_total{status="completed"}[5m]))
+            + sum(rate(saga_total{status="failed"}[5m]))
+            + sum(rate(saga_total{status="compensated"}[5m]))
           )
 
       # 30-minute window
       - record: sli:upload_success:ratio_rate30m
         expr: |
-          sum(rate(saga_total_total{status="completed"}[30m]))
+          sum(rate(saga_total{status="completed"}[30m]))
           /
           (
-            sum(rate(saga_total_total{status="completed"}[30m]))
-            + sum(rate(saga_total_total{status="failed"}[30m]))
-            + sum(rate(saga_total_total{status="compensated"}[30m]))
+            sum(rate(saga_total{status="completed"}[30m]))
+            + sum(rate(saga_total{status="failed"}[30m]))
+            + sum(rate(saga_total{status="compensated"}[30m]))
           )
 
       # 1-hour window
       - record: sli:upload_success:ratio_rate1h
         expr: |
-          sum(rate(saga_total_total{status="completed"}[1h]))
+          sum(rate(saga_total{status="completed"}[1h]))
           /
           (
-            sum(rate(saga_total_total{status="completed"}[1h]))
-            + sum(rate(saga_total_total{status="failed"}[1h]))
-            + sum(rate(saga_total_total{status="compensated"}[1h]))
+            sum(rate(saga_total{status="completed"}[1h]))
+            + sum(rate(saga_total{status="failed"}[1h]))
+            + sum(rate(saga_total{status="compensated"}[1h]))
           )
 
       # 6-hour window
       - record: sli:upload_success:ratio_rate6h
         expr: |
-          sum(rate(saga_total_total{status="completed"}[6h]))
+          sum(rate(saga_total{status="completed"}[6h]))
           /
           (
-            sum(rate(saga_total_total{status="completed"}[6h]))
-            + sum(rate(saga_total_total{status="failed"}[6h]))
-            + sum(rate(saga_total_total{status="compensated"}[6h]))
+            sum(rate(saga_total{status="completed"}[6h]))
+            + sum(rate(saga_total{status="failed"}[6h]))
+            + sum(rate(saga_total{status="compensated"}[6h]))
           )
 
       # 1-day window
       - record: sli:upload_success:ratio_rate1d
         expr: |
-          sum(rate(saga_total_total{status="completed"}[1d]))
+          sum(rate(saga_total{status="completed"}[1d]))
           /
           (
-            sum(rate(saga_total_total{status="completed"}[1d]))
-            + sum(rate(saga_total_total{status="failed"}[1d]))
-            + sum(rate(saga_total_total{status="compensated"}[1d]))
+            sum(rate(saga_total{status="completed"}[1d]))
+            + sum(rate(saga_total{status="failed"}[1d]))
+            + sum(rate(saga_total{status="compensated"}[1d]))
           )
 
       # 30-day window (rolling SLO compliance)
       - record: sli:upload_success:ratio_rate30d
         expr: |
-          sum(rate(saga_total_total{status="completed"}[30d]))
+          sum(rate(saga_total{status="completed"}[30d]))
           /
           (
-            sum(rate(saga_total_total{status="completed"}[30d]))
-            + sum(rate(saga_total_total{status="failed"}[30d]))
-            + sum(rate(saga_total_total{status="compensated"}[30d]))
+            sum(rate(saga_total{status="completed"}[30d]))
+            + sum(rate(saga_total{status="failed"}[30d]))
+            + sum(rate(saga_total{status="compensated"}[30d]))
           )
 
   # ============================================================================

--- a/config/prometheus/tests/slo-rules.test.yml
+++ b/config/prometheus/tests/slo-rules.test.yml
@@ -11,6 +11,28 @@ group_eval_order:
   - slo:attestation_latency
 
 tests:
+  - name: actual-saga-export-after-success-does-not-fire-missing-metrics
+    interval: 1m
+    input_series:
+      - series: 'up{job="recordplatform-backend",instance="backend"}'
+        values: '1+0x10'
+      - series: 'saga_total{job="recordplatform-backend",instance="backend",status="started"}'
+        values: '0 1+0x9'
+      - series: 'saga_total{job="recordplatform-backend",instance="backend",status="completed"}'
+        values: '0 1+0x9'
+      - series: 'saga_total{job="recordplatform-backend",instance="backend",status="failed"}'
+        values: '0+0x10'
+      - series: 'saga_total{job="recordplatform-backend",instance="backend",status="compensated"}'
+        values: '0+0x10'
+    promql_expr_test:
+      - expr: sli:upload_success:ratio_rate5m
+        eval_time: 2m
+        exp_samples: [{labels: 'sli:upload_success:ratio_rate5m', value: 1}]
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RecordPlatformBackendMetricsMissing
+        exp_alerts: []
+
   - name: successful-api-without-ever-registering-5xx-is-zero-not-absent
     interval: 1m
     input_series:
@@ -36,11 +58,11 @@ tests:
         values: '0+90x65'
       - series: 'http_server_requests_seconds_count{job="recordplatform-backend",status="500"}'
         values: '0+10x65'
-      - series: 'saga_total_total{status="completed"}'
+      - series: 'saga_total{status="completed"}'
         values: '0+90x65'
-      - series: 'saga_total_total{status="failed"}'
+      - series: 'saga_total{status="failed"}'
         values: '0+5x65'
-      - series: 'saga_total_total{status="compensated"}'
+      - series: 'saga_total{status="compensated"}'
         values: '0+5x65'
     promql_expr_test:
       - expr: sli:api_error:ratio_rate5m
@@ -55,11 +77,11 @@ tests:
     input_series:
       - series: 'http_server_requests_seconds_count{job="recordplatform-backend",status="200"}'
         values: '0+0x10'
-      - series: 'saga_total_total{status="completed"}'
+      - series: 'saga_total{status="completed"}'
         values: '0+0x10'
-      - series: 'saga_total_total{status="failed"}'
+      - series: 'saga_total{status="failed"}'
         values: '0+0x10'
-      - series: 'saga_total_total{status="compensated"}'
+      - series: 'saga_total{status="compensated"}'
         values: '0+0x10'
     promql_expr_test:
       - expr: 'sli:api_error:ratio_rate5m == sli:api_error:ratio_rate5m'
@@ -218,7 +240,7 @@ tests:
         values: '1+0x10'
       - series: 'up{job="recordplatform-backend",instance="present"}'
         values: '1+0x10'
-      - series: 'saga_total_total{job="recordplatform-backend",instance="present",status="started"}'
+      - series: 'saga_total{job="recordplatform-backend",instance="present",status="started"}'
         values: '0+0x10'
     alert_rule_test:
       - eval_time: 4m

--- a/config/prometheus/tests/slo-rules.test.yml
+++ b/config/prometheus/tests/slo-rules.test.yml
@@ -11,6 +11,59 @@ group_eval_order:
   - slo:attestation_latency
 
 tests:
+  - name: observed-histogram-with-only-infinity-alerts-without-cross-instance-masking
+    interval: 1m
+    input_series:
+      - series: 'up{job="otel-collector",instance="collector-a"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_count{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-a",chain="local-fisco",operation="storeFile"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-a",chain="local-fisco",operation="storeFile",le="+Inf"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-b",chain="local-fisco",operation="storeFile",le="5"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-b",exported_job="record-platform-fisco",exported_instance="producer-a",chain="local-fisco",operation="storeFile",le="5"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-a",chain="other-chain",operation="storeFile",le="5"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-a",exported_job="record-platform-storage",exported_instance="producer-a",chain="local-fisco",operation="storeFile",le="5"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-a",chain="local-fisco",operation="queryFile",le="5"}'
+        values: '1+0x5'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: RecordPlatformFiscoHistogramBucketsMissing
+        exp_alerts: []
+      - eval_time: 2m
+        alertname: RecordPlatformFiscoHistogramBucketsMissing
+        exp_alerts:
+          - exp_labels: {job: otel-collector, instance: collector-a, exported_job: record-platform-fisco, exported_instance: producer-a, chain: local-fisco, operation: storeFile, severity: warning, slo: monitoring}
+            exp_annotations:
+              summary: 'FISCO operation histogram has no finite buckets'
+              description: 'An observed storeFile timer has no finite buckets for the same producer and chain; percentile estimates are unavailable.'
+
+  - name: finite-buckets-idle-and-down-collectors-do-not-fire-bucket-absence
+    interval: 1m
+    input_series:
+      - series: 'up{job="otel-collector",instance="collector-a"}'
+        values: '1+0x5'
+      - series: 'up{job="otel-collector",instance="collector-down"}'
+        values: '0+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_count{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-a",chain="local-fisco",operation="storeFile"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_bucket{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-a",chain="local-fisco",operation="storeFile",le="5"}'
+        values: '0+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_count{job="otel-collector",instance="collector-a",exported_job="record-platform-fisco",exported_instance="producer-idle",chain="local-fisco",operation="storeFile"}'
+        values: '0+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_count{job="otel-collector",instance="collector-down",exported_job="record-platform-fisco",exported_instance="producer-down",chain="local-fisco",operation="storeFile"}'
+        values: '1+0x5'
+      - series: 'otel_blockchain_operation_duration_seconds_count{job="otel-collector",instance="not-configured",exported_job="record-platform-fisco",exported_instance="producer-optional",chain="local-fisco",operation="storeFile"}'
+        values: '1+0x5'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RecordPlatformFiscoHistogramBucketsMissing
+        exp_alerts: []
+
   - name: actual-saga-export-after-success-does-not-fire-missing-metrics
     interval: 1m
     input_series:

--- a/docs/en/deployment/monitoring.md
+++ b/docs/en/deployment/monitoring.md
@@ -568,11 +568,19 @@ including the 5-second SLO. In the pinned bridge, client percentiles or
 `publishPercentileHistogram(true)` alone do not provide usable finite bucket advice.
 After a genuine operation, verify finite `le` buckets as well as `_count`/`_sum`;
 a lone `+Inf` bucket cannot produce a percentile even with nonzero observations.
+The explicit second-based boundaries are 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 7.5, 10, 30, 60.
 Use a later cumulative increment after the first export baseline for `rate` checks.
 `RecordPlatformFiscoHistogramBucketsMissing` warns after2 minutes only when a
 configured Collector is up and an observed storeFile counter is positive but the
 same producer/chain/operation has no finite buckets. Another service, producer or
 Collector target cannot mask the gap. Never-called or zero-count timers do not fire it.
+
+FISCO chain status quantities are decimal unless the SDK text explicitly starts
+with `0x`/`0X`. A bare `54` means decimal 54, not decimal 84 from a hexadecimal
+reinterpretation. The adapter preserves the
+existing zero fallback for invalid, negative or overflowing values; it does not
+infer hexadecimal merely because the data came from a blockchain SDK. The contract
+test follows a real SDK response DTO through the production service/adapter into gauges.
 
 ### Collection health and no-data behavior
 

--- a/docs/en/deployment/monitoring.md
+++ b/docs/en/deployment/monitoring.md
@@ -77,6 +77,12 @@ the JSON status, not HTTP status alone; `scripts/start.sh` accepts only top-leve
 | `saga_running` | Gauge | Currently running Sagas |
 | `saga_pending_compensation` | Gauge | Sagas awaiting compensation |
 
+The production `SagaMetrics` counter named `saga.total` is exported by the pinned
+Prometheus registry as `saga_total`, with `status=started|completed|failed|compensated`.
+All four states are registered before traffic. The exporter already normalizes the
+counter suffix; do not append a second `_total`. The executable exporter contract
+checks the real registration against both rule files and numerical fixtures.
+
 ### Outbox Metrics
 
 | Metric | Type | Description |
@@ -501,7 +507,7 @@ output {
 
 | SLI | Metric Source | Calculation |
 |-----|--------------|-------------|
-| **Upload Success Rate** | `saga_total_total{status}` | completed / (completed + failed + compensated) |
+| **Upload Success Rate** | `saga_total{status}` | completed / (completed + failed + compensated) |
 | **Attestation P99 Latency** | `otel_blockchain_operation_duration_seconds_bucket` | `histogram_quantile(0.99, sum by (le) (rate(...[window])))` over FISCO observations |
 | **Storage Availability** | `s3_node_online_status` | 30-day rolling average of the deduplicated online-node ratio (`max by (node, fault_domain)`) |
 | **API Error Rate** | `http_server_requests_seconds_count{status}` | 5xx count / total count |
@@ -556,6 +562,13 @@ Import `config/grafana/slo-dashboard.json` into Grafana. The dashboard includes:
 | Resilience4j | Circuit breaker states + retry counts |
 
 > **Note:** Agent 2.26.1's default Micrometer bridge exports timers as histograms in seconds, not client-side quantile series, even if a timer calls `.publishPercentiles()`. Recording rules and dashboard scope `job="otel-collector",exported_job="record-platform-fisco",operation="storeFile"`, apply `rate` before summing by `le`, then estimate quantiles across instances. The existing 5m/30m/1h recording names now represent observations in each interval, not an upper envelope of client summaries. Bucket interpolation is an estimate, not an exact percentile; retain seconds and the 5-second threshold. See [Prometheus histogram functions](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile).
+
+FISCO timers must provide explicit `serviceLevelObjectives(Duration...)` boundaries,
+including the 5-second SLO. In the pinned bridge, client percentiles or
+`publishPercentileHistogram(true)` alone do not provide usable finite bucket advice.
+After a genuine operation, verify finite `le` buckets as well as `_count`/`_sum`;
+a lone `+Inf` bucket cannot produce a percentile even with nonzero observations.
+Use a later cumulative increment after the first export baseline for `rate` checks.
 
 ### Collection health and no-data behavior
 

--- a/docs/en/deployment/monitoring.md
+++ b/docs/en/deployment/monitoring.md
@@ -569,6 +569,10 @@ including the 5-second SLO. In the pinned bridge, client percentiles or
 After a genuine operation, verify finite `le` buckets as well as `_count`/`_sum`;
 a lone `+Inf` bucket cannot produce a percentile even with nonzero observations.
 Use a later cumulative increment after the first export baseline for `rate` checks.
+`RecordPlatformFiscoHistogramBucketsMissing` warns after2 minutes only when a
+configured Collector is up and an observed storeFile counter is positive but the
+same producer/chain/operation has no finite buckets. Another service, producer or
+Collector target cannot mask the gap. Never-called or zero-count timers do not fire it.
 
 ### Collection health and no-data behavior
 

--- a/docs/zh/deployment/monitoring.md
+++ b/docs/zh/deployment/monitoring.md
@@ -540,10 +540,16 @@ FISCO Timer 必须提供显式 `serviceLevelObjectives(Duration...)` 桶边界�
 阈值。固定版本 bridge 中，仅配置客户端 percentiles 或
 `publishPercentileHistogram(true)` 不会提供可用的有限桶建议。真实操作后，除
 `_count`/`_sum` 外还必须确认有限 `le` 桶；只有 `+Inf` 时即使计数非零也无法计算分位数。
+显式秒单位桶边界为0.05、0.1、0.25、0.5、1、2.5、5、7.5、10、30、60。
 验收 `rate` 需在首次导出基线之后再观察一次累计计数增长。
 `RecordPlatformFiscoHistogramBucketsMissing` 仅在已配置 Collector 为 up、storeFile
 计数非零但同一生产者/链/操作缺少有限桶时持续2分钟告警。其他服务、生产者或
 Collector target 的桶不能掩盖缺失；从未调用或计数为零的 Timer 不触发此告警。
+
+FISCO 链状态数量默认按十进制解析，只有 SDK 文本明确以 `0x`/`0X` 开头才按十六进制
+解析；裸 `54` 应为十进制54，不能把它当成 `0x54` 得到84。非法、负值或溢出继续保持既有的零值回退，不能
+仅因数据来自区块链 SDK 就推断进制。契约测试使用真实 SDK 响应 DTO，经生产 service、
+adapter 直达 gauge 验证。
 
 ### 采集健康与无数据语义
 

--- a/docs/zh/deployment/monitoring.md
+++ b/docs/zh/deployment/monitoring.md
@@ -75,6 +75,11 @@ HTTP 兼容性保持不变：`DOWN` 与 `OUT_OF_SERVICE` 返回 503，`DEGRADED`
 | `saga_running` | Gauge | 正在运行的 Saga |
 | `saga_pending_compensation` | Gauge | 待补偿的 Saga |
 
+生产 `SagaMetrics` 中名为 `saga.total` 的 counter，经固定版本 Prometheus registry
+实际导出为 `saga_total`，标签为 `status=started|completed|failed|compensated`，四种
+状态在请求流量到来前即注册。Exporter 已规范化 counter 后缀，不应再追加第二个
+`_total`。可执行 exporter 契约测试会对照生产注册结果检查两份规则和数值 fixture。
+
 ### Outbox 指标
 
 | 指标 | 类型 | 说明 |
@@ -475,7 +480,7 @@ output {
 
 | SLI | 指标来源 | 计算方式 |
 |-----|---------|---------|
-| **上传成功率** | `saga_total_total{status}` | completed / (completed + failed + compensated) |
+| **上传成功率** | `saga_total{status}` | completed / (completed + failed + compensated) |
 | **存证 P99 延迟** | `otel_blockchain_operation_duration_seconds_bucket` | 对 FISCO 观察值计算 `histogram_quantile(0.99, sum by (le) (rate(...[window])))` |
 | **存储可用性** | `s3_node_online_status` | 对按 `(node, fault_domain)` 去重后的瞬时在线节点占比做 30 天滚动平均 |
 | **API 错误率** | `http_server_requests_seconds_count{status}` | 5xx 数量 / 总请求数 |
@@ -530,6 +535,12 @@ rule_files:
 | Resilience4j | 断路器状态 + 重试次数 |
 
 > **注意**：Agent 2.26.1 默认 Micrometer bridge 将 Timer 导出为秒单位的直方图，而非客户端 quantile 序列，即使 Timer 调用了 `.publishPercentiles()`。规则和面板限定 `job="otel-collector",exported_job="record-platform-fisco",operation="storeFile"`，先对每条 counter 计算 `rate`，再按 `le` 求和并跨实例估算分位数。现有 5m/30m/1h recording 名称代表对应区间的观察值，不再是客户端分位数上包络。桶内插值是估算而非精确分位数；保留秒单位和 5 秒阈值。参见 [Prometheus 直方图函数](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile)。
+
+FISCO Timer 必须提供显式 `serviceLevelObjectives(Duration...)` 桶边界，包含5秒 SLO
+阈值。固定版本 bridge 中，仅配置客户端 percentiles 或
+`publishPercentileHistogram(true)` 不会提供可用的有限桶建议。真实操作后，除
+`_count`/`_sum` 外还必须确认有限 `le` 桶；只有 `+Inf` 时即使计数非零也无法计算分位数。
+验收 `rate` 需在首次导出基线之后再观察一次累计计数增长。
 
 ### 采集健康与无数据语义
 

--- a/docs/zh/deployment/monitoring.md
+++ b/docs/zh/deployment/monitoring.md
@@ -541,6 +541,9 @@ FISCO Timer 必须提供显式 `serviceLevelObjectives(Duration...)` 桶边界�
 `publishPercentileHistogram(true)` 不会提供可用的有限桶建议。真实操作后，除
 `_count`/`_sum` 外还必须确认有限 `le` 桶；只有 `+Inf` 时即使计数非零也无法计算分位数。
 验收 `rate` 需在首次导出基线之后再观察一次累计计数增长。
+`RecordPlatformFiscoHistogramBucketsMissing` 仅在已配置 Collector 为 up、storeFile
+计数非零但同一生产者/链/操作缺少有限桶时持续2分钟告警。其他服务、生产者或
+Collector target 的桶不能掩盖缺失；从未调用或计数为零的 Timer 不触发此告警。
 
 ### 采集健康与无数据语义
 

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/SagaPrometheusContractTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/SagaPrometheusContractTest.java
@@ -1,0 +1,94 @@
+package cn.flying.config;
+
+import cn.flying.service.monitor.SagaMetrics;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Bind monitoring consumers to production Saga registration and the actual exporter. */
+class SagaPrometheusContractTest {
+
+    /** Export eagerly registered states before traffic and real counter increments afterward. */
+    @Test
+    void productionCountersExportOneTotalSuffixAndAllFourStates() {
+        var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        try {
+            // Registration/counter methods do not access persistence; no DAO substitute is used.
+            var metrics = new SagaMetrics(registry, null, null);
+            metrics.init();
+            assertEquals(Map.of("started", 0.0, "completed", 0.0, "failed", 0.0, "compensated", 0.0),
+                    counters(registry.scrape()));
+            metrics.recordSagaStarted();
+            metrics.recordSagaStarted();
+            metrics.recordSagaCompleted();
+            metrics.recordSagaFailed();
+            metrics.recordSagaCompensated();
+            String actual = registry.scrape();
+            assertTrue(actual.contains("# TYPE saga_total counter"));
+            assertFalse(actual.contains("saga_total_total"));
+            assertEquals(Map.of("started", 2.0, "completed", 1.0, "failed", 1.0, "compensated", 1.0),
+                    counters(actual));
+        } finally {
+            registry.close();
+        }
+    }
+
+    /** Fail when fixtures and rules agree with each other but disagree with real scrape output. */
+    @Test
+    void checkedInMonitoringConsumersUseTheActuallyExportedFamily() throws IOException {
+        var registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        try {
+            new SagaMetrics(registry, null, null).init();
+            String actual = registry.scrape();
+            Path root = repositoryRoot();
+            for (String relative : new String[]{
+                    "config/prometheus/recording-rules.yml",
+                    "config/prometheus/alerting-rules.yml",
+                    "config/prometheus/tests/slo-rules.test.yml"}) {
+                String consumer = Files.readString(root.resolve(relative));
+                var selectors = Pattern.compile("\\b(saga_[a-z_]+)\\{").matcher(consumer);
+                int checked = 0;
+                while (selectors.find()) {
+                    assertTrue(actual.contains("# TYPE " + selectors.group(1) + " counter"),
+                            relative + " references a Saga counter family absent from production scrape");
+                    checked++;
+                }
+                assertTrue(checked > 0, relative + " must retain the Saga monitoring contract");
+            }
+        } finally {
+            registry.close();
+        }
+    }
+
+    /** Parse real exporter samples without relying on decimal formatting or iteration order. */
+    private static Map<String, Double> counters(String scrape) {
+        var matcher = Pattern.compile("^saga_total\\{status=\"([^\"]+)\"} ([0-9.Ee+-]+)$",
+                Pattern.MULTILINE).matcher(scrape);
+        Map<String, Double> result = new HashMap<>();
+        while (matcher.find()) {
+            result.put(matcher.group(1), Double.parseDouble(matcher.group(2)));
+        }
+        return result;
+    }
+
+    /** Find only this checkout's rule assets whether Maven starts at root or module level. */
+    private static Path repositoryRoot() {
+        for (Path path = Path.of("").toAbsolutePath(); path != null; path = path.getParent()) {
+            if (Files.isRegularFile(path.resolve("config/prometheus/recording-rules.yml"))) {
+                return path;
+            }
+        }
+        throw new IllegalStateException("Monitoring rule assets are required by this contract test");
+    }
+}

--- a/platform-fisco/pom.xml
+++ b/platform-fisco/pom.xml
@@ -33,6 +33,7 @@
         <commons-io.version>2.22.0</commons-io.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <bcprov.version>1.84</bcprov.version>
+        <otel-agent-test.version>2.26.1</otel-agent-test.version>
     </properties>
     <dependencies>
         <dependency>
@@ -81,6 +82,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Exercise the deployed bridge without adding its SDK to application dependencies. -->
+        <dependency>
+            <groupId>io.opentelemetry.javaagent</groupId>
+            <artifactId>opentelemetry-javaagent</artifactId>
+            <version>${otel-agent-test.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -248,6 +256,7 @@
                             测试环境（CI/沙箱）可能限制写入真实用户目录，因此将 user.home 指向模块的 target 目录，确保测试可重复且无外部副作用。
                          -->
                         <user.home>${project.build.directory}</user.home>
+                        <fisco.test.otel-agent>${settings.localRepository}/io/opentelemetry/javaagent/opentelemetry-javaagent/${otel-agent-test.version}/opentelemetry-javaagent-${otel-agent-test.version}.jar</fisco.test.otel-agent>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/AbstractFiscoAdapter.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/adapter/impl/AbstractFiscoAdapter.java
@@ -550,9 +550,9 @@ public abstract class AbstractFiscoAdapter implements BlockChainAdapter {
             if (totalTransactionCount != null) {
                 TotalTransactionCount.TransactionCountInfo info = totalTransactionCount.getTotalTransactionCount();
                 if (info != null) {
-                    builder.blockNumber(parseHexLong(info.getBlockNumber()))
-                            .transactionCount(parseHexLong(info.getTransactionCount()))
-                            .failedTransactionCount(parseHexLong(info.getFailedTransactionCount()));
+                    builder.blockNumber(parseChainQuantity(info.getBlockNumber()))
+                            .transactionCount(parseChainQuantity(info.getTransactionCount()))
+                            .failedTransactionCount(parseChainQuantity(info.getFailedTransactionCount()));
                 }
             }
 
@@ -616,24 +616,24 @@ public abstract class AbstractFiscoAdapter implements BlockChainAdapter {
     // ==================== 私有辅助方法 ====================
 
     /**
-     * 解析十六进制字符串为 long
-     * 支持带或不带 0x/0X 前缀的格式
+     * Parses SDK decimal quantities, or hexadecimal quantities with an explicit 0x/0X prefix.
      *
-     * @param hexValue 十六进制字符串
-     * @return 解析后的 long 值，解析失败返回 0
+     * @param value an SDK block height or transaction count
+     * @return a nonnegative long, preserving the zero fallback for missing or invalid quantities
      */
-    protected long parseHexLong(String hexValue) {
-        if (hexValue == null || hexValue.isEmpty()) return 0L;
+    protected long parseChainQuantity(String value) {
+        if (value == null || value.isEmpty()) return 0L;
         try {
-            String cleanHex = hexValue;
-            // 移除 0x/0X 前缀
-            if (cleanHex.startsWith("0x") || cleanHex.startsWith("0X")) {
-                cleanHex = cleanHex.substring(2);
+            boolean hexadecimal = value.startsWith("0x") || value.startsWith("0X");
+            String digits = hexadecimal ? value.substring(2) : value;
+            if (digits.isEmpty()) return 0L;
+            long parsed = new java.math.BigInteger(digits, hexadecimal ? 16 : 10).longValueExact();
+            if (parsed < 0) {
+                throw new NumberFormatException("Chain quantities must be nonnegative");
             }
-            if (cleanHex.isEmpty()) return 0L;
-            return new java.math.BigInteger(cleanHex, 16).longValue();
-        } catch (NumberFormatException e) {
-            log.warn("[parseHexLong] 解析失败: {}", hexValue);
+            return parsed;
+        } catch (NumberFormatException | ArithmeticException e) {
+            log.warn("[parseChainQuantity] Invalid chain quantity: {}", value);
             return 0L;
         }
     }

--- a/platform-fisco/src/main/java/cn/flying/fisco_bcos/monitor/FiscoMetrics.java
+++ b/platform-fisco/src/main/java/cn/flying/fisco_bcos/monitor/FiscoMetrics.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -26,6 +27,14 @@ import java.util.concurrent.atomic.AtomicLong;
 @Component
 @RequiredArgsConstructor
 public class FiscoMetrics {
+
+    // Explicit SLO boundaries survive the OTel bridge; client-side percentiles do not supply buckets.
+    private static final Duration[] OPERATION_LATENCY_BUCKETS = {
+            Duration.ofMillis(50), Duration.ofMillis(100), Duration.ofMillis(250),
+            Duration.ofMillis(500), Duration.ofSeconds(1), Duration.ofMillis(2500),
+            Duration.ofSeconds(5), Duration.ofMillis(7500), Duration.ofSeconds(10),
+            Duration.ofSeconds(30), Duration.ofSeconds(60)
+    };
 
     private final MeterRegistry registry;
     private final BlockChainAdapter chainAdapter;
@@ -77,6 +86,7 @@ public class FiscoMetrics {
                 .tag("chain", chainTag)
                 .tag("operation", "storeFile")
                 .publishPercentiles(0.5, 0.95, 0.99)
+                .serviceLevelObjectives(OPERATION_LATENCY_BUCKETS)
                 .register(registry);
 
         queryFileTimer = Timer.builder("blockchain.operation.duration")
@@ -84,6 +94,7 @@ public class FiscoMetrics {
                 .tag("chain", chainTag)
                 .tag("operation", "queryFile")
                 .publishPercentiles(0.5, 0.95, 0.99)
+                .serviceLevelObjectives(OPERATION_LATENCY_BUCKETS)
                 .register(registry);
 
         deleteFileTimer = Timer.builder("blockchain.operation.duration")
@@ -91,6 +102,7 @@ public class FiscoMetrics {
                 .tag("chain", chainTag)
                 .tag("operation", "deleteFile")
                 .publishPercentiles(0.5, 0.95, 0.99)
+                .serviceLevelObjectives(OPERATION_LATENCY_BUCKETS)
                 .register(registry);
 
         shareFileTimer = Timer.builder("blockchain.operation.duration")
@@ -98,6 +110,7 @@ public class FiscoMetrics {
                 .tag("chain", chainTag)
                 .tag("operation", "shareFile")
                 .publishPercentiles(0.5, 0.95, 0.99)
+                .serviceLevelObjectives(OPERATION_LATENCY_BUCKETS)
                 .register(registry);
 
         // 区块链状态仪表盘 (按链类型区分)

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/FiscoChainStatusMetricsTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/adapter/impl/FiscoChainStatusMetricsTest.java
@@ -1,0 +1,103 @@
+package cn.flying.fisco_bcos.adapter.impl;
+
+import cn.flying.fisco_bcos.adapter.model.ChainStatus;
+import cn.flying.fisco_bcos.monitor.FiscoMetrics;
+import cn.flying.fisco_bcos.service.SharingService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.fisco.bcos.sdk.v3.client.Client;
+import org.fisco.bcos.sdk.v3.client.protocol.response.TotalTransactionCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/** Verifies real SDK response DTOs through the production service, adapter, and metric gauges. */
+@ExtendWith(MockitoExtension.class)
+class FiscoChainStatusMetricsTest {
+
+    @Mock
+    private Client client;
+
+    private LocalFiscoAdapter adapter;
+
+    /** Replaces only the external SDK boundary; internal service and adapter behavior remain real. */
+    @BeforeEach
+    void setUp() {
+        SharingService sharingService = new SharingService();
+        ReflectionTestUtils.setField(sharingService, "client", client);
+        adapter = new LocalFiscoAdapter();
+        ReflectionTestUtils.setField(adapter, "sharingService", sharingService);
+    }
+
+    /** SDK 3.x decimal quantities must reach gauges unchanged, including the live 54/54/2 case. */
+    @Test
+    void decimalSdkResponseShouldReachGaugesWithoutHexReinterpretation() throws Exception {
+        TotalTransactionCount response = new ObjectMapper().readValue("""
+                {"result":{"blockNumber":54,"transactionCount":54,"failedTransactionCount":2}}
+                """, TotalTransactionCount.class);
+        assertThat(response.getTotalTransactionCount().getBlockNumber()).isEqualTo("54");
+        when(client.getTotalTransactionCount()).thenReturn(response);
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        try {
+            FiscoMetrics metrics = new FiscoMetrics(registry, adapter);
+            metrics.init();
+            metrics.refreshBlockchainStatus();
+
+            assertThat(registry.get("blockchain.block.height").gauge().value()).isEqualTo(54);
+            assertThat(registry.get("blockchain.transactions.total").gauge().value()).isEqualTo(54);
+            assertThat(registry.get("blockchain.transactions.failed").gauge().value()).isEqualTo(2);
+            assertThat(registry.get("blockchain.health").gauge().value()).isEqualTo(1);
+        } finally {
+            registry.close();
+        }
+    }
+
+    /** Only explicit hexadecimal prefixes select radix sixteen; plain strings remain decimal. */
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0", "10, 10", "54, 54", "054, 54", "0x36, 54", "0X36, 54",
+            "0x2a, 42", "0X2A, 42", "9223372036854775807, 9223372036854775807",
+            "0x7fffffffffffffff, 9223372036854775807"
+    })
+    void chainQuantitiesShouldRespectExplicitRadix(String quantity, long expected) {
+        assertQuantities(quantity, expected);
+    }
+
+    /** Malformed, negative, or overflowing values keep the existing zero fallback without wrapping. */
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"0x", "0X", "garbage", "2a", "-1", "0x-1",
+            "9223372036854775808", "0x8000000000000000"})
+    void invalidChainQuantitiesShouldNotPolluteGauges(String quantity) {
+        assertQuantities(quantity, 0);
+    }
+
+    /** Supplies a real SDK DTO and checks all three counters share the same numeric contract. */
+    private void assertQuantities(String quantity, long expected) {
+        TotalTransactionCount.TransactionCountInfo info = new TotalTransactionCount.TransactionCountInfo();
+        info.setBlockNumber(quantity);
+        info.setTransactionCount(quantity);
+        info.setFailedTransactionCount(quantity);
+        TotalTransactionCount response = new TotalTransactionCount();
+        response.setResult(info);
+        when(client.getTotalTransactionCount()).thenReturn(response);
+
+        ChainStatus status = adapter.getChainStatus();
+
+        assertThat(status.isHealthy()).isTrue();
+        assertThat(status.getBlockNumber()).isEqualTo(expected);
+        assertThat(status.getTransactionCount()).isEqualTo(expected);
+        assertThat(status.getFailedTransactionCount()).isEqualTo(expected);
+    }
+}

--- a/platform-fisco/src/test/java/cn/flying/fisco_bcos/monitor/FiscoMetricsOtelExportTest.java
+++ b/platform-fisco/src/test/java/cn/flying/fisco_bcos/monitor/FiscoMetricsOtelExportTest.java
@@ -1,0 +1,162 @@
+package cn.flying.fisco_bcos.monitor;
+
+import cn.flying.fisco_bcos.adapter.BlockChainAdapter;
+import cn.flying.fisco_bcos.adapter.model.ChainType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Metrics;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/** Runs the actual deployed Java agent and inspects its real OTLP JSON exporter, without network I/O. */
+class FiscoMetricsOtelExportTest {
+
+    // Pinned to Maven Central's opentelemetry-javaagent/2.26.1/*.jar.sha256 release checksum.
+    private static final String AGENT_SHA256 =
+            "cc4af5966ab72109cacc962ba3b9f99b3e88caf064c3144a451bcfe0f4950f19";
+    private static final List<String> OPERATIONS = List.of("storeFile", "queryFile", "deleteFile", "shareFile");
+    private static final List<Double> EXPECTED_BOUNDS =
+            List.of(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 7.5, 10.0, 30.0, 60.0);
+
+    @TempDir
+    Path temporaryDirectory;
+
+    /** Finite, second-based buckets must account for samples below, at, and above the five-second SLO. */
+    @Test
+    void productionTimersShouldExportFiniteBucketsThroughPinnedAgent() throws Exception {
+        List<JsonNode> metrics = exportMetrics("record");
+        List<JsonNode> histograms = metrics.stream()
+                .filter(metric -> metric.path("name").asText().equals("blockchain.operation.duration"))
+                .toList();
+        assertThat(histograms).hasSize(1);
+        JsonNode histogram = histograms.getFirst();
+        assertThat(histogram.path("unit").asText()).isEqualTo("s");
+        JsonNode points = histogram.path("histogram").path("dataPoints");
+        assertThat(points.size()).isEqualTo(4);
+        List<String> observedOperations = new ArrayList<>();
+        for (JsonNode point : points) {
+            List<Double> bounds = new ArrayList<>();
+            point.path("explicitBounds").forEach(bound -> bounds.add(bound.asDouble()));
+            assertThat(bounds).hasSize(EXPECTED_BOUNDS.size());
+            for (int index = 0; index < bounds.size(); index++) {
+                // The bridge converts nanoseconds with floating-point multiplication.
+                assertThat(bounds.get(index)).isCloseTo(EXPECTED_BOUNDS.get(index), within(1e-12));
+            }
+            List<Long> counts = new ArrayList<>();
+            point.path("bucketCounts").forEach(count -> counts.add(count.asLong()));
+            assertThat(counts).containsExactly(0L, 0L, 0L, 0L, 1L, 0L, 1L, 0L, 1L, 0L, 0L, 0L);
+            assertThat(point.path("count").asLong()).isEqualTo(3);
+            assertThat(point.path("sum").asDouble()).isEqualTo(16.0);
+            assertThat(attribute(point, "chain")).isEqualTo("local-fisco");
+            observedOperations.add(attribute(point, "operation"));
+        }
+        assertThat(observedOperations).containsExactlyInAnyOrderElementsOf(OPERATIONS);
+    }
+
+    /** Eager gauges prove export works, while unused operation timers must not invent observations. */
+    @Test
+    void idleTimersShouldNotExportSyntheticLatencyObservations() throws Exception {
+        List<JsonNode> metrics = exportMetrics("idle");
+        assertThat(metrics).anyMatch(metric -> metric.path("name").asText().equals("blockchain.health"));
+        assertThat(metrics).noneMatch(metric -> metric.path("name").asText().equals("blockchain.operation.duration"));
+    }
+
+    /** Forks a bounded, credential-free process and collects the agent's shutdown metric export. */
+    private List<JsonNode> exportMetrics(String mode) throws Exception {
+        Path agent = Path.of(System.getProperty("fisco.test.otel-agent"));
+        assertThat(HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+                .digest(Files.readAllBytes(agent)))).isEqualTo(AGENT_SHA256);
+        Path output = temporaryDirectory.resolve(mode + ".log");
+        ProcessBuilder builder = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-Xmx256m", "-XX:ActiveProcessorCount=2", "-javaagent:" + agent,
+                "-Duser.home=" + temporaryDirectory,
+                "-Dotel.instrumentation.common.default-enabled=false",
+                "-Dotel.instrumentation.micrometer.enabled=true",
+                "-Dotel.service.name=fisco-metrics-contract-test",
+                "-Dotel.metrics.exporter=logging-otlp", "-Dotel.traces.exporter=none", "-Dotel.logs.exporter=none",
+                "-Dotel.metric.export.interval=600000",
+                "-cp", System.getProperty("surefire.test.class.path"), Fixture.class.getName(), mode)
+                .redirectErrorStream(true).redirectOutput(output.toFile());
+        builder.environment().clear();
+        Process process = builder.start();
+        try {
+            assertThat(process.waitFor(30, TimeUnit.SECONDS)).as("agent fixture exits within deadline").isTrue();
+            assertThat(Files.size(output)).isLessThan(2 * 1024 * 1024);
+            String text = Files.readString(output);
+            assertThat(process.exitValue()).as(text).isZero();
+            ObjectMapper mapper = new ObjectMapper();
+            List<JsonNode> metrics = new ArrayList<>();
+            for (String line : text.lines().toList()) {
+                int start = line.indexOf("{\"resource\"");
+                if (start < 0) {
+                    continue;
+                }
+                JsonNode resource = mapper.readTree(line.substring(start));
+                for (JsonNode scope : resource.path("scopeMetrics")) {
+                    if (scope.path("scope").path("name").asText().equals("io.opentelemetry.micrometer-1.5")) {
+                        scope.path("metrics").forEach(metrics::add);
+                    }
+                }
+            }
+            assertThat(metrics).as(text).isNotEmpty();
+            return metrics;
+        } finally {
+            if (process.isAlive()) {
+                process.destroyForcibly();
+                process.waitFor(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /** Reads an exported string attribute without assuming the order of the OTLP attribute list. */
+    private String attribute(JsonNode point, String name) {
+        for (JsonNode attribute : point.path("attributes")) {
+            if (attribute.path("key").asText().equals(name)) {
+                return attribute.path("value").path("stringValue").asText();
+            }
+        }
+        throw new AssertionError("Missing metric attribute: " + name);
+    }
+
+    /** Standalone numeric fixture: real metric registration, no application bootstrap or chain call. */
+    public static final class Fixture {
+        private static FiscoMetrics metrics;
+
+        /** Records deterministic durations; JVM shutdown flushes the actual agent exporter once. */
+        public static void main(String[] arguments) {
+            BlockChainAdapter adapter = (BlockChainAdapter) Proxy.newProxyInstance(
+                    Fixture.class.getClassLoader(), new Class<?>[]{BlockChainAdapter.class},
+                    (proxy, method, values) -> {
+                        if (method.getName().equals("getChainType")) {
+                            return ChainType.LOCAL_FISCO;
+                        }
+                        throw new AssertionError("No chain operation is allowed in the metric fixture");
+                    });
+            metrics = new FiscoMetrics(Metrics.globalRegistry, adapter);
+            metrics.init();
+            if (arguments[0].equals("record")) {
+                for (String operation : OPERATIONS) {
+                    var timer = Metrics.globalRegistry.get("blockchain.operation.duration")
+                            .tag("operation", operation).timer();
+                    timer.record(Duration.ofSeconds(1));
+                    timer.record(Duration.ofSeconds(5));
+                    timer.record(Duration.ofSeconds(10));
+                }
+            }
+        }
+    }
+}

--- a/tools/ci/tests/test_monitoring_contract.py
+++ b/tools/ci/tests/test_monitoring_contract.py
@@ -11,6 +11,17 @@ ROOT = Path(__file__).resolve().parents[3]
 class MonitoringContractTest(unittest.TestCase):
     """Assert source consumers remain aligned with real promtool fixtures."""
 
+    def test_saga_selectors_retain_the_native_exporter_contract(self) -> None:
+        """Keep config-only changes bound to the family exercised by the Java exporter test."""
+        for relative in ('config/prometheus/recording-rules.yml',
+                         'config/prometheus/alerting-rules.yml',
+                         'config/prometheus/tests/slo-rules.test.yml'):
+            content = (ROOT / relative).read_text()
+            self.assertNotIn('saga_total_total', content)
+            self.assertIn('saga_total{', content)
+        contract = ROOT / 'platform-backend/backend-web/src/test/java/cn/flying/config/SagaPrometheusContractTest.java'
+        self.assertIn('new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)', contract.read_text())
+
     def test_dashboard_latency_queries_have_numerical_fixtures(self) -> None:
         """Every actual latency panel query must be exercised by the rule engine."""
         dashboard = json.loads((ROOT / 'config/grafana/slo-dashboard.json').read_text())


### PR DESCRIPTION
## 问题与修复

部署后的真实采集发现三处监控契约错误，本 PR 聚焦修复生产者与消费者的实际边界：

- Saga 的实际 Prometheus counter 为 `saga_total`，规则却查询不存在的双 `_total` 名称，导致上传 SLI 缺失和业务指标缺失误报。纠正规则、数值 fixture 和文档，并增加生产 `SagaMetrics` → 实际 `PrometheusMeterRegistry` → 规则/fixture 的契约测试。
- FISCO Timer 虽有非零计数，但 OTel bridge 仅导出 `+Inf` 桶。为四种操作设置含 5 秒阈值的显式 SLO 桶，通过实际固定版本 Java agent 导出 OTLP JSON 验证秒单位、有限边界和观察值。Agent 仅为 test 依赖，不进入应用运行时或两个打包 JAR。
- SDK 的裸十进制数量曾被当成十六进制，例如 `54` 错报为 `84`。现在仅显式 `0x`/`0X` 才选择十六进制，并保护负数/溢出，保留已有无效输入零值回退。

新增有限桶缺失告警仅对已配置且正常采集的 Collector、真实 `storeFile` 计数大于零、同一 producer/chain/operation 缺少有限桶时触发。其他实例、服务、链或操作不能遮蔽缺失；从未调用或 idle 不伪造业务值。

## 验证

- 新 Saga 实际 exporter 契约先在旧规则上复现失败，修复后 2 项通过。
- 全后端单元测试：2274 项，0 failures/errors，21 项既有 skipped；本地结果不替代 CI 集成测试。
- 完整 FISCO package：201 项，0 failures/errors/skipped；整合后新增 23 项真实 bridge/SDK DTO 契约重跑通过。
- `tools/ci/tests`：59 项通过；文档测试 11 项与 evidence consistency 通过。
- 固定镜像真实 `promtool`：19 recording rules、20 alerting rules 校验通过，17 组数值 fixture 通过。无网络、只读 fixture 挂载。
- actionlint 与 `git diff --check` 通过。

## 范围与部署

不更改 Saga 生产业务逻辑、接口、数据库、合约或存储数据。应用源码变更仅涉及 FISCO 指标桶和链状态数量解析。真实文件业务测试已经提供错误导出证据；线上规则未热修改，新 FISCO JAR 与最终规则须在 PR 检查、合并后部署。当前源测试不宣称已完成最终线上有限桶/P99 验收。
