### PR TITLE
fix: 修复文件状态恢复与文本预览

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（329 files）
+## 当前测试文件快照（331 files）
 
 > 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -14,7 +14,7 @@
 | `platform-backend/backend-web` | 106 |
 | `platform-backend` | 216 |
 | `platform-storage` | 28 |
-| `platform-frontend` | 41 |
+| `platform-frontend` | 43 |
 | `platform-verifier` | 15 |
 | `platform-fisco` | 14 |
 | `platform-api` | 3 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 12 |
-| `total` | 329 |
+| `total` | 331 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/FileMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/FileMapper.java
@@ -49,6 +49,25 @@ public interface FileMapper extends BaseMapper<File> {
     int physicalDeleteById(@Param("id") Long id, @Param("tenantId") Long tenantId);
 
     /**
+     * Atomically changes a file between the administrator-visible completed and deleted states.
+     *
+     * @param id file ID
+     * @param tenantId tenant ID
+     * @param expectedStatus status observed before the update
+     * @param targetStatus requested target status
+     * @return number of updated rows
+     */
+    @InterceptorIgnore(tenantLine = "true")
+    @Update("UPDATE file SET status = #{targetStatus} " +
+            "WHERE id = #{id} AND tenant_id = #{tenantId} " +
+            "AND status = #{expectedStatus} AND deleted = 0")
+    int updateStatusByAdminWithCas(
+            @Param("id") Long id,
+            @Param("tenantId") Long tenantId,
+            @Param("expectedStatus") int expectedStatus,
+            @Param("targetStatus") int targetStatus);
+
+    /**
      * 统计用户文件数量
      *
      * @param userId 用户ID

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileAdminServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileAdminServiceImpl.java
@@ -208,6 +208,7 @@ public class FileAdminServiceImpl implements FileAdminService {
     @Transactional
     public void updateFileStatus(String fileId, Integer status, String reason) {
         Long id = IdUtils.fromExternalId(fileId);
+        Long tenantId = TenantContext.requireTenantId();
         File file = fileMapper.selectById(id);
         if (file == null) {
             throw new GeneralException(ResultEnum.PARAM_ERROR, "文件不存在");
@@ -218,20 +219,35 @@ public class FileAdminServiceImpl implements FileAdminService {
         if (targetStatus == FileUploadStatus.NOOP) {
             throw new GeneralException(ResultEnum.PARAM_ERROR, "文件状态不合法");
         }
-        if (targetStatus == FileUploadStatus.SUCCESS
-                && !Objects.equals(file.getStatus(), FileUploadStatus.SUCCESS.getCode())) {
+        FileUploadStatus currentStatus = file.getStatus() == null
+                ? FileUploadStatus.NOOP
+                : FileUploadStatus.getByCode(file.getStatus());
+        if (!isAllowedAdminStatusTransition(currentStatus, targetStatus)) {
             throw new GeneralException(
                     ResultEnum.PARAM_ERROR,
-                    "管理员状态接口不能绕过上传校验将文件提升为成功状态");
+                    "管理员仅允许在已完成与已删除状态之间转换");
         }
 
-        LambdaUpdateWrapper<File> wrapper = new LambdaUpdateWrapper<File>()
-                .eq(File::getId, id)
-                .set(File::getStatus, status);
-
-        fileMapper.update(null, wrapper);
+        int updated = fileMapper.updateStatusByAdminWithCas(
+                id,
+                tenantId,
+                currentStatus.getCode(),
+                targetStatus.getCode());
+        if (updated != 1) {
+            throw new GeneralException(ResultEnum.PARAM_ERROR, "文件状态已发生变化，请刷新后重试");
+        }
         LOGGER.info("管理员更新文件状态: fileId={}, oldStatus={}, newStatus={}, reason={}",
                 fileId, file.getStatus(), status, reason);
+    }
+
+    /**
+     * Checks the closed administrator file-status transition matrix.
+     */
+    private boolean isAllowedAdminStatusTransition(
+            FileUploadStatus currentStatus,
+            FileUploadStatus targetStatus) {
+        return (currentStatus == FileUploadStatus.SUCCESS && targetStatus == FileUploadStatus.DELETE)
+                || (currentStatus == FileUploadStatus.DELETE && targetStatus == FileUploadStatus.SUCCESS);
     }
 
     @Override

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileAdminServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileAdminServiceImplTest.java
@@ -1,5 +1,6 @@
 package cn.flying.service.impl;
 
+import cn.flying.common.constant.FileUploadStatus;
 import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.exception.GeneralException;
 import cn.flying.common.tenant.TenantContext;
@@ -20,14 +21,20 @@ import cn.flying.dao.vo.admin.AdminFileVO;
 import cn.flying.dao.vo.admin.AdminShareQueryParam;
 import cn.flying.dao.vo.admin.AdminShareVO;
 import cn.flying.service.key.FileKeyEnvelopeService;
+import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.apache.ibatis.annotations.Update;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -37,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -628,16 +636,64 @@ class FileAdminServiceImplTest {
             assertEquals(ResultEnum.PARAM_ERROR, ex.getResultEnum());
         }
 
-        @Test
-        @DisplayName("should update file status successfully")
-        void updateFileStatus_success() {
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"99", "-2"})
+        @DisplayName("should reject missing and unknown target statuses")
+        void updateFileStatus_invalidTarget_rejected(String rawStatus) {
             File file = createFile();
             when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+            Integer targetStatus = rawStatus == null || rawStatus.isEmpty()
+                    ? null
+                    : Integer.valueOf(rawStatus);
+
+            GeneralException exception = assertThrows(
+                    GeneralException.class,
+                    () -> fileAdminService.updateFileStatus("ext_" + FILE_ID, targetStatus, "invalid target"));
+
+            assertEquals(ResultEnum.PARAM_ERROR, exception.getResultEnum());
+            verify(fileMapper, never()).updateStatusByAdminWithCas(anyLong(), anyLong(), anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("should mark a completed file as deleted with tenant-scoped CAS")
+        void updateFileStatus_successToDelete_updatesWithCas() {
+            File file = createFile();
+            when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+            when(fileMapper.updateStatusByAdminWithCas(
+                    FILE_ID,
+                    TENANT_ID,
+                    FileUploadStatus.SUCCESS.getCode(),
+                    FileUploadStatus.DELETE.getCode())).thenReturn(1);
 
             assertDoesNotThrow(() -> fileAdminService.updateFileStatus("ext_" + FILE_ID, 2, "admin update"));
 
             verify(fileMapper).selectById(FILE_ID);
-            verify(fileMapper).update(isNull(), any());
+            verify(fileMapper).updateStatusByAdminWithCas(
+                    FILE_ID,
+                    TENANT_ID,
+                    FileUploadStatus.SUCCESS.getCode(),
+                    FileUploadStatus.DELETE.getCode());
+        }
+
+        @Test
+        @DisplayName("should restore a deleted file with tenant-scoped CAS")
+        void updateFileStatus_deleteToSuccess_updatesWithCas() {
+            File file = createFile().setStatus(FileUploadStatus.DELETE.getCode());
+            when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+            when(fileMapper.updateStatusByAdminWithCas(
+                    FILE_ID,
+                    TENANT_ID,
+                    FileUploadStatus.DELETE.getCode(),
+                    FileUploadStatus.SUCCESS.getCode())).thenReturn(1);
+
+            assertDoesNotThrow(() -> fileAdminService.updateFileStatus("ext_" + FILE_ID, 1, "restore"));
+
+            verify(fileMapper).updateStatusByAdminWithCas(
+                    FILE_ID,
+                    TENANT_ID,
+                    FileUploadStatus.DELETE.getCode(),
+                    FileUploadStatus.SUCCESS.getCode());
         }
 
         /**
@@ -654,7 +710,72 @@ class FileAdminServiceImplTest {
                     () -> fileAdminService.updateFileStatus("ext_" + FILE_ID, 1, "manual promotion"));
 
             assertEquals(ResultEnum.PARAM_ERROR, exception.getResultEnum());
-            verify(fileMapper, never()).update(isNull(), any());
+            verify(fileMapper, never()).updateStatusByAdminWithCas(anyLong(), anyLong(), anyInt(), anyInt());
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 1",
+                "2, 2",
+                "1, 0",
+                "1, -1",
+                "2, 0",
+                "2, -1",
+                "0, 2",
+                "-1, 2"
+        })
+        @DisplayName("should reject every transition outside completed and deleted pair")
+        void updateFileStatus_otherTransitions_rejected(int currentStatus, int targetStatus) {
+            File file = createFile().setStatus(currentStatus);
+            when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+
+            GeneralException exception = assertThrows(
+                    GeneralException.class,
+                    () -> fileAdminService.updateFileStatus("ext_" + FILE_ID, targetStatus, "invalid transition"));
+
+            assertEquals(ResultEnum.PARAM_ERROR, exception.getResultEnum());
+            verify(fileMapper, never()).updateStatusByAdminWithCas(anyLong(), anyLong(), anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("should fail closed when the file status changes concurrently")
+        void updateFileStatus_concurrentChange_rejected() {
+            File file = createFile();
+            when(fileMapper.selectById(FILE_ID)).thenReturn(file);
+            when(fileMapper.updateStatusByAdminWithCas(
+                    FILE_ID,
+                    TENANT_ID,
+                    FileUploadStatus.SUCCESS.getCode(),
+                    FileUploadStatus.DELETE.getCode())).thenReturn(0);
+
+            GeneralException exception = assertThrows(
+                    GeneralException.class,
+                    () -> fileAdminService.updateFileStatus("ext_" + FILE_ID, 2, "stale update"));
+
+            assertEquals(ResultEnum.PARAM_ERROR, exception.getResultEnum());
+        }
+
+        @Test
+        @DisplayName("should bind the mapper update to tenant, id, expected status and active rows")
+        void updateFileStatus_mapperContractIsTenantScopedCas() throws NoSuchMethodException {
+            var method = FileMapper.class.getMethod(
+                    "updateStatusByAdminWithCas",
+                    Long.class,
+                    Long.class,
+                    int.class,
+                    int.class);
+            String sql = String.join(" ", method.getAnnotation(Update.class).value())
+                    .replaceAll("\\s+", " ")
+                    .toLowerCase(Locale.ROOT);
+            InterceptorIgnore interceptorIgnore = method.getAnnotation(InterceptorIgnore.class);
+
+            assertAll(
+                    () -> assertTrue(sql.contains("where id = #{id}")),
+                    () -> assertTrue(sql.contains("tenant_id = #{tenantid}")),
+                    () -> assertTrue(sql.contains("status = #{expectedstatus}")),
+                    () -> assertTrue(sql.contains("deleted = 0")),
+                    () -> assertNotNull(interceptorIgnore),
+                    () -> assertEquals("true", interceptorIgnore.tenantLine()));
         }
     }
 

--- a/platform-frontend/src/lib/components/FilePreview.svelte
+++ b/platform-frontend/src/lib/components/FilePreview.svelte
@@ -1,145 +1,189 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { api } from '$api/client';
+  import { onMount } from "svelte";
+  import { api } from "$api/client";
+  import { loadPreviewText } from "$utils/file-preview";
 
-	interface Props {
-		url: string;
-		contentType: string;
-		fileName: string;
-		class?: string;
-	}
+  interface Props {
+    url: string;
+    contentType: string;
+    fileName: string;
+    class?: string;
+  }
 
-	let { url, contentType, fileName, class: className = '' }: Props = $props();
+  let { url, contentType, fileName, class: className = "" }: Props = $props();
 
-	let textContent = $state('');
-	let loadingText = $state(false);
-	let textError = $state<string | null>(null);
+  let textContent = $state("");
+  let loadingText = $state(false);
+  let textError = $state<string | null>(null);
 
-	// 根据 contentType 判断预览类型
-	const previewType = $derived(getPreviewType(contentType));
+  // 根据 contentType 判断预览类型
+  const previewType = $derived(getPreviewType(contentType));
 
-	function getPreviewType(type: string): 'image' | 'video' | 'audio' | 'pdf' | 'text' | 'unsupported' {
-		if (type.startsWith('image/')) return 'image';
-		if (type.startsWith('video/')) return 'video';
-		if (type.startsWith('audio/')) return 'audio';
-		if (type === 'application/pdf') return 'pdf';
-		if (
-			type.startsWith('text/') ||
-			type === 'application/json' ||
-			type === 'application/xml' ||
-			type === 'application/javascript'
-		) {
-			return 'text';
-		}
-		return 'unsupported';
-	}
+  function getPreviewType(
+    type: string,
+  ): "image" | "video" | "audio" | "pdf" | "text" | "unsupported" {
+    if (type.startsWith("image/")) return "image";
+    if (type.startsWith("video/")) return "video";
+    if (type.startsWith("audio/")) return "audio";
+    if (type === "application/pdf") return "pdf";
+    if (
+      type.startsWith("text/") ||
+      type === "application/json" ||
+      type === "application/xml" ||
+      type === "application/javascript"
+    ) {
+      return "text";
+    }
+    return "unsupported";
+  }
 
-	onMount(() => {
-		if (previewType === 'text') {
-			loadTextContent();
-		}
-	});
+  onMount(() => {
+    if (previewType === "text") {
+      loadTextContent();
+    }
+  });
 
-	async function loadTextContent() {
-		loadingText = true;
-		textError = null;
-		try {
-			const text = await api.fetchText(url);
-			// 为提升性能限制文本长度
-			textContent = text.length > 100000 ? text.slice(0, 100000) + '\n\n... (内容过长，已截断)' : text;
-		} catch (err) {
-			textError = err instanceof Error ? err.message : '加载失败';
-		} finally {
-			loadingText = false;
-		}
-	}
+  async function loadTextContent() {
+    loadingText = true;
+    textError = null;
+    try {
+      const text = await loadPreviewText(url, (requestUrl) =>
+        api.fetchText(requestUrl),
+      );
+      // 为提升性能限制文本长度
+      textContent =
+        text.length > 100000
+          ? text.slice(0, 100000) + "\n\n... (内容过长，已截断)"
+          : text;
+    } catch (err) {
+      textError = err instanceof Error ? err.message : "加载失败";
+    } finally {
+      loadingText = false;
+    }
+  }
 
-	function getLanguageClass(type: string): string {
-		if (type === 'application/json') return 'language-json';
-		if (type === 'application/xml' || type === 'text/xml') return 'language-xml';
-		if (type === 'application/javascript' || type === 'text/javascript') return 'language-javascript';
-		if (type === 'text/html') return 'language-html';
-		if (type === 'text/css') return 'language-css';
-		if (type === 'text/markdown') return 'language-markdown';
-		return '';
-	}
+  function getLanguageClass(type: string): string {
+    if (type === "application/json") return "language-json";
+    if (type === "application/xml" || type === "text/xml")
+      return "language-xml";
+    if (type === "application/javascript" || type === "text/javascript")
+      return "language-javascript";
+    if (type === "text/html") return "language-html";
+    if (type === "text/css") return "language-css";
+    if (type === "text/markdown") return "language-markdown";
+    return "";
+  }
 </script>
 
 <div class="file-preview {className}">
-	{#if previewType === 'image'}
-		<div class="flex items-center justify-center bg-muted/30 p-4">
-			<img
-				src={url}
-				alt={fileName}
-				class="max-h-[70vh] max-w-full rounded-lg object-contain shadow-lg"
-			/>
-		</div>
-	{:else if previewType === 'video'}
-		<div class="flex items-center justify-center bg-black p-4">
-			<video
-				src={url}
-				controls
-				class="max-h-[70vh] max-w-full rounded-lg"
-				preload="metadata"
-			>
-				<track kind="captions" />
-				您的浏览器不支持视频播放
-			</video>
-		</div>
-	{:else if previewType === 'audio'}
-		<div class="flex flex-col items-center justify-center gap-4 bg-muted/30 p-8">
-			<div class="flex h-24 w-24 items-center justify-center rounded-full bg-primary/10 text-primary">
-				<svg class="h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
-				</svg>
-			</div>
-			<p class="text-sm font-medium">{fileName}</p>
-			<audio src={url} controls class="w-full max-w-md">
-				您的浏览器不支持音频播放
-			</audio>
-		</div>
-	{:else if previewType === 'pdf'}
-		<div class="h-[70vh] w-full">
-			<iframe
-				src={url}
-				title={fileName}
-				class="h-full w-full rounded-lg border-0"
-			></iframe>
-		</div>
-	{:else if previewType === 'text'}
-		<div class="overflow-hidden rounded-lg border bg-muted/30">
-			{#if loadingText}
-				<div class="flex items-center justify-center p-8">
-					<div class="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
-				</div>
-			{:else if textError}
-				<div class="p-8 text-center text-muted-foreground">
-					<p>{textError}</p>
-				</div>
-			{:else}
-				<pre class="max-h-[70vh] overflow-auto p-4 text-sm {getLanguageClass(contentType)}"><code>{textContent}</code></pre>
-			{/if}
-		</div>
-	{:else}
-		<div class="flex flex-col items-center justify-center gap-4 rounded-lg border bg-muted/30 p-12">
-			<div class="flex h-16 w-16 items-center justify-center rounded-full bg-muted text-muted-foreground">
-				<svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-				</svg>
-			</div>
-			<p class="text-muted-foreground">此文件类型不支持预览</p>
-			<p class="text-sm text-muted-foreground">{contentType}</p>
-		</div>
-	{/if}
+  {#if previewType === "image"}
+    <div class="bg-muted/30 flex items-center justify-center p-4">
+      <img
+        src={url}
+        alt={fileName}
+        class="max-h-[70vh] max-w-full rounded-lg object-contain shadow-lg"
+      />
+    </div>
+  {:else if previewType === "video"}
+    <div class="flex items-center justify-center bg-black p-4">
+      <video
+        src={url}
+        controls
+        class="max-h-[70vh] max-w-full rounded-lg"
+        preload="metadata"
+      >
+        <track kind="captions" />
+        您的浏览器不支持视频播放
+      </video>
+    </div>
+  {:else if previewType === "audio"}
+    <div
+      class="bg-muted/30 flex flex-col items-center justify-center gap-4 p-8"
+    >
+      <div
+        class="bg-primary/10 text-primary flex h-24 w-24 items-center justify-center rounded-full"
+      >
+        <svg
+          class="h-12 w-12"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
+          />
+        </svg>
+      </div>
+      <p class="text-sm font-medium">{fileName}</p>
+      <audio src={url} controls class="w-full max-w-md">
+        您的浏览器不支持音频播放
+      </audio>
+    </div>
+  {:else if previewType === "pdf"}
+    <div class="h-[70vh] w-full">
+      <iframe
+        src={url}
+        title={fileName}
+        class="h-full w-full rounded-lg border-0"
+      ></iframe>
+    </div>
+  {:else if previewType === "text"}
+    <div class="bg-muted/30 overflow-hidden rounded-lg border">
+      {#if loadingText}
+        <div class="flex items-center justify-center p-8">
+          <div
+            class="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent"
+          ></div>
+        </div>
+      {:else if textError}
+        <div class="text-muted-foreground p-8 text-center">
+          <p>{textError}</p>
+        </div>
+      {:else}
+        <pre
+          class="max-h-[70vh] overflow-auto p-4 text-sm {getLanguageClass(
+            contentType,
+          )}"><code>{textContent}</code></pre>
+      {/if}
+    </div>
+  {:else}
+    <div
+      class="bg-muted/30 flex flex-col items-center justify-center gap-4 rounded-lg border p-12"
+    >
+      <div
+        class="bg-muted text-muted-foreground flex h-16 w-16 items-center justify-center rounded-full"
+      >
+        <svg
+          class="h-8 w-8"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </div>
+      <p class="text-muted-foreground">此文件类型不支持预览</p>
+      <p class="text-muted-foreground text-sm">{contentType}</p>
+    </div>
+  {/if}
 </div>
 
 <style>
-	pre {
-		margin: 0;
-		white-space: pre-wrap;
-		word-wrap: break-word;
-	}
-	code {
-		font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
-	}
+  pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  code {
+    font-family:
+      ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
 </style>

--- a/platform-frontend/src/lib/utils/file-preview.test.ts
+++ b/platform-frontend/src/lib/utils/file-preview.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadPreviewText } from "./file-preview";
+
+describe("loadPreviewText", () => {
+  it.each(["blob:https://example.test/file", "data:text/plain,hello"])(
+    "loads same-document URL %s with native fetch",
+    async (url) => {
+      const platformFetchText = vi.fn();
+      const nativeFetch = vi.fn().mockResolvedValue(
+        new Response("decrypted plaintext", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      );
+
+      await expect(
+        loadPreviewText(url, platformFetchText, nativeFetch),
+      ).resolves.toBe("decrypted plaintext");
+      expect(nativeFetch).toHaveBeenCalledWith(url);
+      expect(platformFetchText).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps platform API fetching for API paths", async () => {
+    const platformFetchText = vi.fn().mockResolvedValue("api plaintext");
+    const nativeFetch = vi.fn();
+
+    await expect(
+      loadPreviewText(
+        "/api/v1/files/example/content",
+        platformFetchText,
+        nativeFetch,
+      ),
+    ).resolves.toBe("api plaintext");
+    expect(platformFetchText).toHaveBeenCalledWith(
+      "/api/v1/files/example/content",
+    );
+    expect(nativeFetch).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed native response", async () => {
+    const nativeFetch = vi.fn().mockResolvedValue(
+      new Response("", {
+        status: 400,
+        statusText: "Bad Request",
+      }),
+    );
+
+    await expect(
+      loadPreviewText("blob:https://example.test/file", vi.fn(), nativeFetch),
+    ).rejects.toThrow("请求失败 (400)");
+  });
+});

--- a/platform-frontend/src/lib/utils/file-preview.ts
+++ b/platform-frontend/src/lib/utils/file-preview.ts
@@ -1,0 +1,24 @@
+export type PlatformTextFetcher = (url: string) => Promise<string>;
+
+export type NativePreviewFetcher = (
+  url: string,
+) => Promise<Pick<Response, "ok" | "status" | "text">>;
+
+/**
+ * Loads preview text without routing already-decrypted same-document URLs through the API client.
+ */
+export async function loadPreviewText(
+  url: string,
+  platformFetchText: PlatformTextFetcher,
+  nativeFetch: NativePreviewFetcher = globalThis.fetch,
+): Promise<string> {
+  if (!url.startsWith("blob:") && !url.startsWith("data:")) {
+    return platformFetchText(url);
+  }
+
+  const response = await nativeFetch(url);
+  if (!response.ok) {
+    throw new Error(`请求失败 (${response.status})`);
+  }
+  return response.text();
+}

--- a/platform-frontend/src/lib/utils/file-status-filter.test.ts
+++ b/platform-frontend/src/lib/utils/file-status-filter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { FileStatus } from "$api/types";
+import {
+  FILE_STATUS_FILTER_OPTIONS,
+  toFileStatusQuery,
+} from "./file-status-filter";
+
+describe("file status filter", () => {
+  it("exposes only user-queryable persisted statuses", () => {
+    expect(FILE_STATUS_FILTER_OPTIONS).toEqual([
+      { value: FileStatus.PROCESSING, label: "处理中" },
+      { value: FileStatus.COMPLETED, label: "已完成" },
+      { value: FileStatus.DELETED, label: "已删除" },
+      { value: FileStatus.FAILED, label: "失败" },
+    ]);
+    expect(FILE_STATUS_FILTER_OPTIONS.map(({ label }) => label)).not.toContain(
+      "-",
+    );
+  });
+
+  it("maps only the empty UI sentinel to an omitted API parameter", () => {
+    expect(toFileStatusQuery("")).toBeUndefined();
+    expect(toFileStatusQuery(FileStatus.PROCESSING)).toBe(
+      FileStatus.PROCESSING,
+    );
+    expect(toFileStatusQuery(FileStatus.FAILED)).toBe(FileStatus.FAILED);
+  });
+});

--- a/platform-frontend/src/lib/utils/file-status-filter.ts
+++ b/platform-frontend/src/lib/utils/file-status-filter.ts
@@ -1,0 +1,19 @@
+import { FileStatus } from "$api/types";
+
+export type FileStatusFilter = FileStatus | "";
+
+export const FILE_STATUS_FILTER_OPTIONS = [
+  { value: FileStatus.PROCESSING, label: "处理中" },
+  { value: FileStatus.COMPLETED, label: "已完成" },
+  { value: FileStatus.DELETED, label: "已删除" },
+  { value: FileStatus.FAILED, label: "失败" },
+] as const;
+
+/**
+ * Converts the UI's empty all-status sentinel into an omitted API query value.
+ */
+export function toFileStatusQuery(
+  status: FileStatusFilter,
+): FileStatus | undefined {
+  return status === "" ? undefined : status;
+}

--- a/platform-frontend/src/routes/(app)/files/+page.svelte
+++ b/platform-frontend/src/routes/(app)/files/+page.svelte
@@ -8,6 +8,11 @@
   import { useUpload } from "$stores/upload.svelte";
   import { formatFileSize, formatDateTime } from "$utils/format";
   import {
+    FILE_STATUS_FILTER_OPTIONS,
+    toFileStatusQuery,
+    type FileStatusFilter,
+  } from "$utils/file-status-filter";
+  import {
     getFiles,
     deleteFile,
     createShare,
@@ -42,7 +47,7 @@
   let total = $state(0);
   let pageSize = $state(10);
   let keyword = $state("");
-  let statusFilter = $state<FileStatus | undefined>(undefined);
+  let statusFilter = $state<FileStatusFilter>("");
   let startTime = $state("");
   let endTime = $state("");
   let selectedFileIds = $state<Set<string>>(new Set());
@@ -114,7 +119,7 @@
         pageNum: page,
         pageSize,
         keyword: keyword || undefined,
-        status: statusFilter,
+        status: toFileStatusQuery(statusFilter),
         startTime: toQueryDateTime(startTime),
         endTime: toQueryDateTime(endTime),
       });
@@ -528,9 +533,9 @@
       }}
       class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
     >
-      <option value={undefined}>全部状态</option>
-      {#each Object.entries(FileStatusLabel) as [value, label]}
-        <option value={Number(value)}>{label}</option>
+      <option value="">全部状态</option>
+      {#each FILE_STATUS_FILTER_OPTIONS as option}
+        <option value={option.value}>{option.label}</option>
       {/each}
     </select>
     <DateTimePicker bind:value={startTime} placeholder="开始时间" />
@@ -546,7 +551,7 @@
       variant="outline"
       onclick={() => {
         keyword = "";
-        statusFilter = undefined;
+        statusFilter = "";
         startTime = "";
         endTime = "";
         page = 1;


### PR DESCRIPTION
## 变更范围

- 将管理员文件状态更新收敛为严格的 SUCCESS 与 DELETE 双向转换
- 使用 file ID、tenant ID、预期原状态和逻辑删除标记执行 CAS 更新
- 拒绝处理中或失败文件被管理员接口提升为成功状态
- 本地 blob/data 文本预览使用浏览器原生 fetch，API 路径继续走平台客户端
- 文件状态筛选使用空字符串表示全部状态，不再展示内部 NOOP 的短横线选项

## 安全边界

- CAS SQL 显式绑定当前 TenantContext 的 tenant ID
- 不允许恢复物理删除对象
- 不允许管理员绕过上传校验创建成功状态
- 未修改或提交 home-server 本地配置及任何凭据

## 验证

- FileAdminServiceImplTest：36 项通过
- backend-service reactor 全量单元测试通过
- 前端全量测试：42 个文件、572 项通过
- pnpm test:coverage 通过，新增工具文件覆盖率 100%
- pnpm lint 通过
- pnpm check：0 error、0 warning
- pnpm build 通过
- 提交钩子处理后再次运行定向前端测试：6 项通过
- git diff --check 通过

## 部署后验收

合并到 main 后，将从 exact main 部署到 home-server，并使用 Codex 内置浏览器验证文本上传/预览/下载、完成态删除与恢复以及筛选器选项。