### PR TITLE
fix: 修复全局权限的租户可见性

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,29 @@ jobs:
                   raise SystemExit(f"CrossTenantHealthIndicatorIT {name}={actual}; expected {expected}")
           PY
 
+      - name: Require Permission Tenant Isolation IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.service.PermissionTenantIsolationIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          for name, expected in {"tests": 2, "skipped": 0, "failures": 0, "errors": 0}.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"PermissionTenantIsolationIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Require Vault Transit Key Wrapping IT Execution
         run: |
           python3 - <<'PY'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 212 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 216 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 217 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 38（V1.0.0 ~ V1.20.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（331 files）
+## 当前测试文件快照（332 files）
 
 > 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -11,8 +11,8 @@
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
 | `platform-backend/backend-service` | 96 |
-| `platform-backend/backend-web` | 106 |
-| `platform-backend` | 216 |
+| `platform-backend/backend-web` | 107 |
+| `platform-backend` | 217 |
 | `platform-storage` | 28 |
 | `platform-frontend` | 43 |
 | `platform-verifier` | 15 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 12 |
-| `total` | 331 |
+| `total` | 332 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/SysPermissionMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/SysPermissionMapper.java
@@ -3,6 +3,8 @@ package cn.flying.dao.mapper;
 import cn.flying.dao.entity.SysPermission;
 import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
@@ -16,6 +18,52 @@ import java.util.Set;
  */
 @Mapper
 public interface SysPermissionMapper extends BaseMapper<SysPermission> {
+
+    /**
+     * Select active permission definitions visible to the current tenant.
+     */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("""
+        SELECT id, tenant_id, code, name, module, action, description, status, create_time, update_time
+        FROM sys_permission
+        WHERE status = 1
+          AND (tenant_id = 0 OR tenant_id = #{tenantId})
+        ORDER BY module, code
+        """)
+    List<SysPermission> selectVisibleActivePermissions(@Param("tenantId") Long tenantId);
+
+    /**
+     * Select a page of permission definitions visible to the current tenant.
+     */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("""
+        <script>
+        SELECT id, tenant_id, code, name, module, action, description, status, create_time, update_time
+        FROM sys_permission
+        WHERE (tenant_id = 0 OR tenant_id = #{tenantId})
+        <if test="module != null and module != ''">
+          AND module = #{module}
+        </if>
+        ORDER BY module, code
+        </script>
+        """)
+    IPage<SysPermission> selectVisiblePermissionPage(
+            Page<SysPermission> page,
+            @Param("tenantId") Long tenantId,
+            @Param("module") String module);
+
+    /**
+     * Select distinct permission modules visible to the current tenant.
+     */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("""
+        SELECT module
+        FROM sys_permission
+        WHERE (tenant_id = 0 OR tenant_id = #{tenantId})
+        GROUP BY module
+        ORDER BY module
+        """)
+    List<String> selectVisibleModules(@Param("tenantId") Long tenantId);
 
     /**
      * 根据角色获取权限码列表

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/PermissionServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/PermissionServiceImpl.java
@@ -207,35 +207,17 @@ public class PermissionServiceImpl implements PermissionService {
 
     @Override
     public List<SysPermission> getPermissionTree(Long tenantId) {
-        LambdaQueryWrapper<SysPermission> wrapper = new LambdaQueryWrapper<>();
-        wrapper.and(w -> w.eq(SysPermission::getTenantId, 0L).or().eq(SysPermission::getTenantId, tenantId));
-        wrapper.eq(SysPermission::getStatus, 1);
-        wrapper.orderByAsc(SysPermission::getModule, SysPermission::getCode);
-        return permissionMapper.selectList(wrapper);
+        return permissionMapper.selectVisibleActivePermissions(tenantId);
     }
 
     @Override
     public IPage<SysPermission> listPermissions(Long tenantId, String module, Page<SysPermission> page) {
-        LambdaQueryWrapper<SysPermission> wrapper = new LambdaQueryWrapper<>();
-        wrapper.and(w -> w.eq(SysPermission::getTenantId, 0L).or().eq(SysPermission::getTenantId, tenantId));
-        if (module != null && !module.isEmpty()) {
-            wrapper.eq(SysPermission::getModule, module);
-        }
-        wrapper.orderByAsc(SysPermission::getModule, SysPermission::getCode);
-        return permissionMapper.selectPage(page, wrapper);
+        return permissionMapper.selectVisiblePermissionPage(page, tenantId, module);
     }
 
     @Override
     public List<String> listModules(Long tenantId) {
-        LambdaQueryWrapper<SysPermission> wrapper = new LambdaQueryWrapper<>();
-        wrapper.and(w -> w.eq(SysPermission::getTenantId, 0L).or().eq(SysPermission::getTenantId, tenantId));
-        wrapper.select(SysPermission::getModule);
-        wrapper.groupBy(SysPermission::getModule);
-
-        List<SysPermission> permissions = permissionMapper.selectList(wrapper);
-        return permissions.stream()
-                .map(SysPermission::getModule)
-                .toList();
+        return permissionMapper.selectVisibleModules(tenantId);
     }
 
     @Override

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/PermissionServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/PermissionServiceImplTest.java
@@ -344,12 +344,13 @@ class PermissionServiceImplTest {
             SysPermission global = createPermission(1L, PERM_FILE_READ, "file");
             global.setTenantId(0L);
             SysPermission tenant = createPermission(2L, PERM_FILE_WRITE, "file");
-            when(permissionMapper.selectList(any())).thenReturn(List.of(global, tenant));
+            when(permissionMapper.selectVisibleActivePermissions(TENANT_ID)).thenReturn(List.of(global, tenant));
 
             List<SysPermission> result = permissionService.getPermissionTree(TENANT_ID);
 
             assertEquals(List.of(global, tenant), result);
-            verify(permissionMapper).selectList(any());
+            verify(permissionMapper).selectVisibleActivePermissions(TENANT_ID);
+            verify(permissionMapper, never()).selectList(any());
         }
 
         /**
@@ -361,12 +362,13 @@ class PermissionServiceImplTest {
             Page<SysPermission> page = new Page<>(1, 10);
             Page<SysPermission> expected = new Page<>(1, 10);
             expected.setRecords(List.of(createPermission(1L, PERM_FILE_READ, "file")));
-            when(permissionMapper.selectPage(eq(page), any())).thenReturn(expected);
+            when(permissionMapper.selectVisiblePermissionPage(page, TENANT_ID, "file")).thenReturn(expected);
 
             IPage<SysPermission> result = permissionService.listPermissions(TENANT_ID, "file", page);
 
             assertSame(expected, result);
-            verify(permissionMapper).selectPage(eq(page), any());
+            verify(permissionMapper).selectVisiblePermissionPage(page, TENANT_ID, "file");
+            verify(permissionMapper, never()).selectPage(any(), any());
         }
 
         /**
@@ -375,13 +377,13 @@ class PermissionServiceImplTest {
         @Test
         @DisplayName("should list distinct permission modules")
         void listModules_mapsPermissionModules() {
-            SysPermission file = createPermission(1L, PERM_FILE_READ, "file");
-            SysPermission admin = createPermission(2L, PERM_ADMIN_ALL, "admin");
-            when(permissionMapper.selectList(any())).thenReturn(List.of(file, admin));
+            when(permissionMapper.selectVisibleModules(TENANT_ID)).thenReturn(List.of("admin", "file"));
 
             List<String> result = permissionService.listModules(TENANT_ID);
 
-            assertEquals(List.of("file", "admin"), result);
+            assertEquals(List.of("admin", "file"), result);
+            verify(permissionMapper).selectVisibleModules(TENANT_ID);
+            verify(permissionMapper, never()).selectList(any());
         }
 
         /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/service/PermissionTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/service/PermissionTenantIsolationIT.java
@@ -13,10 +13,12 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 /**
  * Verifies the explicit global-or-current permission boundary against real MySQL and MyBatis interceptors.
@@ -53,6 +55,10 @@ class PermissionTenantIsolationIT extends BaseIntegrationTest {
         insertPermission(DISABLED_PERMISSION_ID, CURRENT_TENANT, CODE_PREFIX + "disabled", VISIBLE_MODULE, 0);
         insertPermission(OTHER_PERMISSION_ID, OTHER_TENANT, CODE_PREFIX + "other", OTHER_MODULE, 1);
 
+        assertThat(tenantIdForPermissionCode(CODE_PREFIX + "global")).isZero();
+        assertThat(tenantIdForPermissionCode(CODE_PREFIX + "current")).isEqualTo(CURRENT_TENANT);
+        assertThat(tenantIdForPermissionCode(CODE_PREFIX + "disabled")).isEqualTo(CURRENT_TENANT);
+
         List<SysPermission> tree = TenantContext.callWithTenantIsolation(
                         CURRENT_TENANT,
                         () -> permissionService.getPermissionTree(CURRENT_TENANT))
@@ -85,13 +91,21 @@ class PermissionTenantIsolationIT extends BaseIntegrationTest {
                 .containsExactly(CODE_PREFIX + "current", CODE_PREFIX + "disabled");
         assertThat(firstPage.getRecords())
                 .extracting(SysPermission::getTenantId)
-                .containsOnly(0L, CURRENT_TENANT);
+                .containsExactly(CURRENT_TENANT, CURRENT_TENANT);
         assertThat(secondPage.getRecords())
                 .extracting(SysPermission::getCode)
                 .containsExactly(CODE_PREFIX + "global");
         assertThat(secondPage.getRecords())
                 .extracting(SysPermission::getTenantId)
                 .containsOnly(0L);
+        List<SysPermission> pageRecords = new ArrayList<>(firstPage.getRecords());
+        pageRecords.addAll(secondPage.getRecords());
+        assertThat(pageRecords)
+                .extracting(SysPermission::getCode, SysPermission::getTenantId)
+                .containsExactly(
+                        tuple(CODE_PREFIX + "current", CURRENT_TENANT),
+                        tuple(CODE_PREFIX + "disabled", CURRENT_TENANT),
+                        tuple(CODE_PREFIX + "global", 0L));
         assertThat(modules).contains(VISIBLE_MODULE).doesNotContain(OTHER_MODULE);
         assertThat(TenantContext.getTenantId()).isNull();
     }
@@ -185,5 +199,19 @@ class PermissionTenantIsolationIT extends BaseIntegrationTest {
                 Integer.class,
                 permissionId);
         return count != null && count == 1;
+    }
+
+    /**
+     * Read the persisted source tenant directly, bypassing MyBatis result mapping.
+     */
+    private long tenantIdForPermissionCode(String code) {
+        Long tenantId = jdbcTemplate.queryForObject(
+                "SELECT tenant_id FROM sys_permission WHERE code = ?",
+                Long.class,
+                code);
+        if (tenantId == null) {
+            throw new IllegalStateException("Missing permission fixture tenant");
+        }
+        return tenantId;
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/service/PermissionTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/service/PermissionTenantIsolationIT.java
@@ -1,0 +1,189 @@
+package cn.flying.service;
+
+import cn.flying.common.exception.GeneralException;
+import cn.flying.common.tenant.TenantContext;
+import cn.flying.dao.entity.SysPermission;
+import cn.flying.test.BaseIntegrationTest;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the explicit global-or-current permission boundary against real MySQL and MyBatis interceptors.
+ */
+@Transactional
+@Testcontainers(disabledWithoutDocker = false)
+@DisplayName("Permission tenant isolation integration tests")
+class PermissionTenantIsolationIT extends BaseIntegrationTest {
+
+    private static final long CURRENT_TENANT = 918001L;
+    private static final long OTHER_TENANT = 918002L;
+    private static final long GLOBAL_PERMISSION_ID = 91800101L;
+    private static final long CURRENT_PERMISSION_ID = 91800102L;
+    private static final long DISABLED_PERMISSION_ID = 91800103L;
+    private static final long OTHER_PERMISSION_ID = 91800104L;
+    private static final String CODE_PREFIX = "f018:";
+    private static final String VISIBLE_MODULE = "f018-visible";
+    private static final String OTHER_MODULE = "f018-secret";
+
+    @Autowired
+    private PermissionService permissionService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * Proves that tree, page, and module reads include only global and current-tenant definitions.
+     */
+    @Test
+    @DisplayName("should expose global and current permissions while excluding another tenant")
+    void shouldExposeOnlyGlobalAndCurrentPermissionDefinitions() {
+        insertPermission(GLOBAL_PERMISSION_ID, 0L, CODE_PREFIX + "global", VISIBLE_MODULE, 1);
+        insertPermission(CURRENT_PERMISSION_ID, CURRENT_TENANT, CODE_PREFIX + "current", VISIBLE_MODULE, 1);
+        insertPermission(DISABLED_PERMISSION_ID, CURRENT_TENANT, CODE_PREFIX + "disabled", VISIBLE_MODULE, 0);
+        insertPermission(OTHER_PERMISSION_ID, OTHER_TENANT, CODE_PREFIX + "other", OTHER_MODULE, 1);
+
+        List<SysPermission> tree = TenantContext.callWithTenantIsolation(
+                        CURRENT_TENANT,
+                        () -> permissionService.getPermissionTree(CURRENT_TENANT))
+                .stream()
+                .filter(permission -> permission.getCode().startsWith(CODE_PREFIX))
+                .toList();
+        IPage<SysPermission> firstPage = TenantContext.callWithTenantIsolation(
+                CURRENT_TENANT,
+                () -> permissionService.listPermissions(
+                        CURRENT_TENANT,
+                        VISIBLE_MODULE,
+                        new Page<>(1, 2)));
+        IPage<SysPermission> secondPage = TenantContext.callWithTenantIsolation(
+                CURRENT_TENANT,
+                () -> permissionService.listPermissions(
+                        CURRENT_TENANT,
+                        VISIBLE_MODULE,
+                        new Page<>(2, 2)));
+        List<String> modules = TenantContext.callWithTenantIsolation(
+                CURRENT_TENANT,
+                () -> permissionService.listModules(CURRENT_TENANT));
+
+        assertThat(tree)
+                .extracting(SysPermission::getCode)
+                .containsExactly(CODE_PREFIX + "current", CODE_PREFIX + "global");
+        assertThat(firstPage.getTotal()).isEqualTo(3);
+        assertThat(firstPage.getPages()).isEqualTo(2);
+        assertThat(firstPage.getRecords())
+                .extracting(SysPermission::getCode)
+                .containsExactly(CODE_PREFIX + "current", CODE_PREFIX + "disabled");
+        assertThat(firstPage.getRecords())
+                .extracting(SysPermission::getTenantId)
+                .containsOnly(0L, CURRENT_TENANT);
+        assertThat(secondPage.getRecords())
+                .extracting(SysPermission::getCode)
+                .containsExactly(CODE_PREFIX + "global");
+        assertThat(secondPage.getRecords())
+                .extracting(SysPermission::getTenantId)
+                .containsOnly(0L);
+        assertThat(modules).contains(VISIBLE_MODULE).doesNotContain(OTHER_MODULE);
+        assertThat(TenantContext.getTenantId()).isNull();
+    }
+
+    /**
+     * Proves that grant and revoke operations mutate only current-tenant mappings.
+     */
+    @Test
+    @DisplayName("should keep role permission writes tenant protected")
+    void shouldKeepRolePermissionWritesTenantProtected() {
+        insertPermission(GLOBAL_PERMISSION_ID, 0L, CODE_PREFIX + "global", VISIBLE_MODULE, 1);
+        insertPermission(OTHER_PERMISSION_ID, OTHER_TENANT, CODE_PREFIX + "other", OTHER_MODULE, 1);
+        insertRolePermission(91800201L, OTHER_TENANT, "f018role", GLOBAL_PERMISSION_ID);
+
+        TenantContext.runWithTenantIsolation(CURRENT_TENANT, () ->
+                permissionService.assignPermissionToRole("f018role", CODE_PREFIX + "global", CURRENT_TENANT));
+
+        assertThat(countRolePermission(CURRENT_TENANT, "f018role", GLOBAL_PERMISSION_ID)).isOne();
+        assertThat(countRolePermission(OTHER_TENANT, "f018role", GLOBAL_PERMISSION_ID)).isOne();
+
+        TenantContext.runWithTenantIsolation(CURRENT_TENANT, () ->
+                permissionService.revokePermissionFromRole("f018role", CODE_PREFIX + "global", CURRENT_TENANT));
+
+        assertThat(countRolePermission(CURRENT_TENANT, "f018role", GLOBAL_PERMISSION_ID)).isZero();
+        assertThat(countRolePermission(OTHER_TENANT, "f018role", GLOBAL_PERMISSION_ID)).isOne();
+        assertThat(permissionExists(GLOBAL_PERMISSION_ID)).isTrue();
+
+        assertThatThrownBy(() -> TenantContext.runWithTenantIsolation(CURRENT_TENANT, () ->
+                permissionService.assignPermissionToRole("f018role", CODE_PREFIX + "other", CURRENT_TENANT)))
+                .isInstanceOf(GeneralException.class);
+        assertThat(countRolePermission(CURRENT_TENANT, "f018role", OTHER_PERMISSION_ID)).isZero();
+        assertThat(countRolePermission(OTHER_TENANT, "f018role", GLOBAL_PERMISSION_ID)).isOne();
+    }
+
+    /**
+     * Insert a permission fixture without applying the application tenant interceptor.
+     */
+    private void insertPermission(long id, long tenantId, String code, String module, int status) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO sys_permission
+                    (id, tenant_id, code, name, module, action, description, status, create_time, update_time)
+                VALUES (?, ?, ?, ?, ?, 'read', 'F018 integration fixture', ?, NOW(), NOW())
+                """,
+                id,
+                tenantId,
+                code,
+                code,
+                module,
+                status);
+    }
+
+    /**
+     * Insert a role-permission fixture without applying the application tenant interceptor.
+     */
+    private void insertRolePermission(long id, long tenantId, String role, long permissionId) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO sys_role_permission (id, tenant_id, role, permission_id, create_time)
+                VALUES (?, ?, ?, ?, NOW())
+                """,
+                id,
+                tenantId,
+                role,
+                permissionId);
+    }
+
+    /**
+     * Count an exact tenant-scoped role mapping directly in the test database.
+     */
+    private int countRolePermission(long tenantId, String role, long permissionId) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM sys_role_permission
+                WHERE tenant_id = ? AND role = ? AND permission_id = ?
+                """,
+                Integer.class,
+                tenantId,
+                role,
+                permissionId);
+        return count == null ? 0 : count;
+    }
+
+    /**
+     * Check that a permission definition remains present after mapping changes.
+     */
+    private boolean permissionExists(long permissionId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM sys_permission WHERE id = ?",
+                Integer.class,
+                permissionId);
+        return count != null && count == 1;
+    }
+}


### PR DESCRIPTION
## 变更范围

- 权限树、分页和模块列表改用窄范围显式 Mapper 查询
- 三个只读查询绕过自动 tenant line，但 SQL 强制限制 tenant 0 或当前租户
- 树查询仅返回启用定义；管理分页和模块列表保留禁用定义语义
- 创建、更新、删除、角色授权和撤销继续走普通租户拦截写路径
- 新增真实 MySQL/Testcontainers 租户隔离集成测试
- CI 精确要求该 IT 报告为 tests=2、skipped=0、failures=0、errors=0
- 同步 TESTING.md 文件快照

## 安全边界

- 其他租户权限定义在树、分页和模块结果中不可见
- 当前租户授权/撤销不能覆盖或删除其他租户同角色映射
- 仅属于其他租户的权限码不能用于当前租户授权
- 全局权限定义不会因角色映射操作被修改或删除
- 没有为任何写方法增加 InterceptorIgnore

## 本地验证

- PermissionServiceImplTest：36/36
- backend-service 全量：1455 tests，0 failure/error/skip
- backend-web 全部测试源 test-compile 通过
- actionlint 通过
- 文档 evidence 一致性通过
- git diff --check 通过

## 环境边界

本机没有 Docker CLI/socket，定向 Testcontainers IT 按设计失败关闭而非跳过；真实 MySQL 的两项 IT 通过证据必须由本 PR 的 GitHub Docker runner 提供，CI 已增加精确报告门禁。