### PR TITLE
fix: 修复审计仪表盘与证据契约

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,29 @@ jobs:
                   )
           PY
 
+      - name: Require Audit High-Frequency Tenant Isolation IT Execution
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report = Path(
+              "platform-backend/backend-web/target/failsafe-reports/"
+              "TEST-cn.flying.service.AuditHighFrequencyTenantIsolationIT.xml"
+          )
+          if not report.is_file():
+              sys.exit(f"Missing required Failsafe report: {report}")
+
+          suite = ET.parse(report).getroot()
+          for name, expected in {"tests": 1, "skipped": 0, "failures": 0, "errors": 0}.items():
+              actual = int(suite.attrib.get(name, "-1"))
+              if actual != expected:
+                  sys.exit(
+                      f"AuditHighFrequencyTenantIsolationIT {name}={actual}; expected {expected}"
+                  )
+          PY
+
       - name: Require Vault Transit Key Wrapping IT Execution
         run: |
           python3 - <<'PY'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 212 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 217 | `platform-backend/**/src/test/java` |
+| 后端测试文件 | 218 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 38（V1.0.0 ~ V1.20.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,19 +2,19 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（332 files）
+## 当前测试文件快照（336 files）
 
-> 2026-08-31 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
+> 2026-09-02 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
 | Component | Test files |
 | --- | ---: |
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
 | `platform-backend/backend-service` | 96 |
-| `platform-backend/backend-web` | 107 |
-| `platform-backend` | 217 |
+| `platform-backend/backend-web` | 108 |
+| `platform-backend` | 218 |
 | `platform-storage` | 28 |
-| `platform-frontend` | 43 |
+| `platform-frontend` | 46 |
 | `platform-verifier` | 15 |
 | `platform-fisco` | 14 |
 | `platform-api` | 3 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 12 |
-| `total` | 332 |
+| `total` | 336 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 
@@ -147,6 +147,7 @@
 | BaseIntegrationTest | 集成测试基类 |
 | BaseControllerIntegrationTest | 控制器集成测试基类 |
 | OpenApiContractExportTest | OpenAPI 契约导出与稳定性校验 |
+| AuditHighFrequencyTenantIsolationIT | 高频告警列表、KPI 与异常检测的租户/阈值一致性 |
 
 ### 前端测试（platform-frontend，代表性测试文件）
 
@@ -201,6 +202,9 @@
 |----------|----------|
 | route-loaders.test.ts | 路由数据加载器 |
 | app-layout-load.test.ts | 应用布局加载逻辑 |
+| AuditDashboard.render.test.ts | 高频告警聚焦与精确身份、IP、时间窗钻取 |
+| chartLifecycle.test.ts | ECharts 同步初始化、单次重试、resize 与销毁 |
+| charts.render.test.ts | 三类审计图表挂载后生成 canvas |
 
 ### 测试工具类
 

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/SensitiveDataMasker.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/SensitiveDataMasker.java
@@ -60,6 +60,8 @@ public final class SensitiveDataMasker {
             "passwd",
             "pwd",
             "secret",
+            "secrettoken",
+            "secret_token",
             "token",
             "accesstoken",
             "access_token",

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/SensitiveDataMaskerTest.java
@@ -25,6 +25,16 @@ class SensitiveDataMaskerTest {
         }
     }
 
+    /** Treat compound secret-token field names as sensitive structured audit data. */
+    @Test
+    void shouldMaskSecretTokenAliases() {
+        String sentinel = "synthetic-secret-token";
+        for (String field : List.of("secretToken", "secret_token", "secret-token", "SECRET_TOKEN")) {
+            assertTrue(SensitiveDataMasker.isSensitiveField(field));
+            assertFalse(SensitiveDataMasker.maskAndSerialize(Map.of(field, sentinel)).contains(sentinel));
+        }
+    }
+
     /** Exercise collection, serialization and Throwable limits through public log-copy entrypoints. */
     @Test
     void shouldOmitOverBudgetLogCopiesWithoutPublishingPrefixes() {

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/SysOperationLogMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/SysOperationLogMapper.java
@@ -20,19 +20,23 @@ import java.util.Map;
 public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
 
     /**
-     * 查询高频操作记录 (v_high_frequency_operations)
+     * Select high-frequency operation groups above the threshold for one tenant and time window.
      */
-    List<HighFrequencyOperationVO> selectHighFrequencyOperations();
+    List<HighFrequencyOperationVO> selectHighFrequencyOperations(
+            @Param("tenantId") Long tenantId,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("threshold") int threshold
+    );
 
     /**
-     * 查询指定租户在时间窗口内超过阈值的高频用户数。
+     * Count high-frequency operation groups above the threshold for one tenant and time window.
      *
-     * @param tenantId 租户ID
-     * @param startTime 起始时间
-     * @param threshold 高频阈值
-     * @return 高频用户数
+     * @param tenantId tenant ID
+     * @param startTime inclusive window start
+     * @param threshold high-frequency threshold
+     * @return high-frequency alert count
      */
-    Integer countHighFrequencyUsers(
+    Integer countHighFrequencyAlerts(
             @Param("tenantId") Long tenantId,
             @Param("startTime") LocalDateTime startTime,
             @Param("threshold") int threshold
@@ -159,11 +163,6 @@ public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
      * 查询指定时间范围内的活跃用户数 (sys_operation_log)
      */
     Long selectActiveUsersBetween(@Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
-
-    /**
-     * 查询高频操作告警数量 (v_high_frequency_operations)
-     */
-    Long selectHighFrequencyAlertCount();
 
     /**
      * 查询过去N天的每日操作统计 (sys_operation_log)

--- a/platform-backend/backend-dao/src/main/resources/mapper/SysOperationLogMapper.xml
+++ b/platform-backend/backend-dao/src/main/resources/mapper/SysOperationLogMapper.xml
@@ -1,32 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="cn.flying.dao.mapper.SysOperationLogMapper">
-    <!-- 查询高频操作记录 -->
+    <!-- Select current-tenant high-frequency groups using the shared window and threshold contract. -->
     <select id="selectHighFrequencyOperations" resultType="cn.flying.dao.vo.audit.HighFrequencyOperationVO">
         SELECT
             user_id as userId,
             username,
             request_ip as requestIp,
-            operation_count as operationCount,
-            start_time as startTime,
-            end_time as endTime,
-            time_span_seconds as timeSpanSeconds
-        FROM v_high_frequency_operations
-        ORDER BY operation_count DESC
-        LIMIT 100 -- Limit results for performance
+            COUNT(*) as operationCount,
+            MIN(operation_time) as startTime,
+            MAX(operation_time) as endTime,
+            TIMESTAMPDIFF(SECOND, MIN(operation_time), MAX(operation_time)) as timeSpanSeconds
+        FROM sys_operation_log
+        WHERE tenant_id = #{tenantId}
+          AND operation_time &gt;= #{startTime}
+          AND user_id IS NOT NULL AND user_id != '' AND user_id != 'system'
+        GROUP BY user_id, username, request_ip
+        HAVING COUNT(*) &gt; #{threshold}
+        ORDER BY operationCount DESC
+        LIMIT 100
     </select>
 
-    <select id="countHighFrequencyUsers" resultType="java.lang.Integer">
+    <select id="countHighFrequencyAlerts" resultType="java.lang.Integer">
         SELECT COUNT(*)
         FROM (
-            SELECT user_id
+            SELECT user_id, username, request_ip
             FROM sys_operation_log
             WHERE tenant_id = #{tenantId}
               AND operation_time >= #{startTime}
               AND user_id IS NOT NULL AND user_id != '' AND user_id != 'system'
-            GROUP BY user_id
+            GROUP BY user_id, username, request_ip
             HAVING COUNT(*) > #{threshold}
-        ) AS high_freq_users
+        ) AS high_freq_alerts
     </select>
 
     <select id="countFailedLoginUsers" resultType="java.lang.Integer">
@@ -198,10 +203,6 @@
         SELECT COUNT(DISTINCT user_id) FROM sys_operation_log
         WHERE operation_time >= #{startTime} AND operation_time &lt; #{endTime}
           AND user_id IS NOT NULL AND user_id != '' AND user_id != 'system'
-    </select>
-
-    <select id="selectHighFrequencyAlertCount" resultType="java.lang.Long">
-        SELECT COUNT(*) FROM v_high_frequency_operations
     </select>
 
     <select id="selectDailyStats" resultType="java.util.Map">

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/SysAuditServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/SysAuditServiceImpl.java
@@ -57,8 +57,13 @@ public class SysAuditServiceImpl implements SysAuditService {
     
     @Override
     public List<HighFrequencyOperationVO> getHighFrequencyOperations() {
-        // 直接使用Mapper查询视图
-        return operationLogMapper.selectHighFrequencyOperations();
+        Long tenantId = requireTenantIdForAudit();
+        int threshold = getPositiveAuditConfig("HIGH_FREQ_THRESHOLD", DEFAULT_HIGH_FREQ_THRESHOLD);
+        return operationLogMapper.selectHighFrequencyOperations(
+                tenantId,
+                LocalDateTime.now().minusMinutes(5),
+                threshold
+        );
     }
     
     @Override
@@ -145,6 +150,7 @@ public class SysAuditServiceImpl implements SysAuditService {
     @Override
     public Map<String, Object> getAuditOverview() {
         Map<String, Object> overview = new HashMap<>();
+        Long tenantId = requireTenantIdForAudit();
         LocalDate today = LocalDate.now();
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.plusDays(1).atStartOfDay(); // Exclusive end
@@ -156,7 +162,15 @@ public class SysAuditServiceImpl implements SysAuditService {
             overview.put("todayErrorOperations", operationLogMapper.selectErrorOperationsBetween(startOfDay, endOfDay));
             overview.put("todaySensitiveOperations", operationLogMapper.selectSensitiveOperationsCountBetween(startOfDay, endOfDay));
             overview.put("todayActiveUsers", operationLogMapper.selectActiveUsersBetween(startOfDay, endOfDay));
-            overview.put("highFrequencyAlerts", operationLogMapper.selectHighFrequencyAlertCount());
+            int highFrequencyThreshold = getPositiveAuditConfig(
+                    "HIGH_FREQ_THRESHOLD",
+                    DEFAULT_HIGH_FREQ_THRESHOLD
+            );
+            overview.put("highFrequencyAlerts", operationLogMapper.countHighFrequencyAlerts(
+                    tenantId,
+                    LocalDateTime.now().minusMinutes(5),
+                    highFrequencyThreshold
+            ));
 
             // 获取过去7天的每日统计数据
             int daysForStats = 7;
@@ -296,7 +310,7 @@ public class SysAuditServiceImpl implements SysAuditService {
             LocalDateTime highFrequencyStartTime = now.minusMinutes(5);
             LocalDateTime failedLoginStartTime = now.minusHours(1);
 
-            int highFreqCount = nvl(operationLogMapper.countHighFrequencyUsers(
+            int highFreqCount = nvl(operationLogMapper.countHighFrequencyAlerts(
                     tenantId,
                     highFrequencyStartTime,
                     highFreqThreshold

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/SysAuditServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/SysAuditServiceImplTest.java
@@ -117,22 +117,38 @@ class SysAuditServiceImplTest {
             HighFrequencyOperationVO operation = new HighFrequencyOperationVO();
             operation.setUserId("user1");
             operation.setUsername("testuser");
-            operation.setOperationCount(100);
-            when(operationLogMapper.selectHighFrequencyOperations()).thenReturn(List.of(operation));
+            operation.setOperationCount(101);
+            when(operationLogMapper.selectAuditConfigByKey("HIGH_FREQ_THRESHOLD"))
+                    .thenReturn(auditConfig("100"));
+            when(operationLogMapper.selectHighFrequencyOperations(
+                    eq(7L), any(LocalDateTime.class), eq(100)))
+                    .thenReturn(List.of(operation));
 
-            List<HighFrequencyOperationVO> result = sysAuditService.getHighFrequencyOperations();
+            List<HighFrequencyOperationVO> result;
+            try (MockedStatic<TenantContext> tenantContextMock = mockStatic(TenantContext.class)) {
+                tenantContextMock.when(TenantContext::requireTenantId).thenReturn(7L);
+                result = sysAuditService.getHighFrequencyOperations();
+            }
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).getUserId()).isEqualTo("user1");
-            assertThat(result.get(0).getOperationCount()).isEqualTo(100);
+            assertThat(result.get(0).getOperationCount()).isEqualTo(101);
+            verify(operationLogMapper).selectHighFrequencyOperations(
+                    eq(7L), any(LocalDateTime.class), eq(100));
         }
 
         @Test
         @DisplayName("should return empty list when no high frequency operations")
         void shouldReturnEmptyListWhenNoOperations() {
-            when(operationLogMapper.selectHighFrequencyOperations()).thenReturn(List.of());
+            when(operationLogMapper.selectHighFrequencyOperations(
+                    eq(7L), any(LocalDateTime.class), eq(100)))
+                    .thenReturn(List.of());
 
-            List<HighFrequencyOperationVO> result = sysAuditService.getHighFrequencyOperations();
+            List<HighFrequencyOperationVO> result;
+            try (MockedStatic<TenantContext> tenantContextMock = mockStatic(TenantContext.class)) {
+                tenantContextMock.when(TenantContext::requireTenantId).thenReturn(7L);
+                result = sysAuditService.getHighFrequencyOperations();
+            }
 
             assertThat(result).isEmpty();
         }
@@ -308,8 +324,11 @@ class SysAuditServiceImplTest {
             when(operationLogMapper.selectErrorOperationsBetween(any(), any())).thenReturn(2L);
             when(operationLogMapper.selectSensitiveOperationsCountBetween(any(), any())).thenReturn(5L);
             when(operationLogMapper.selectActiveUsersBetween(any(), any())).thenReturn(20L);
-            when(operationLogMapper.selectHighFrequencyAlertCount()).thenReturn(3L);
+            when(operationLogMapper.countHighFrequencyAlerts(
+                    eq(7L), any(LocalDateTime.class), eq(100))).thenReturn(3);
             when(operationLogMapper.selectDailyStats(anyInt())).thenReturn(List.of());
+            when(operationLogMapper.selectAuditConfigByKey("HIGH_FREQ_THRESHOLD"))
+                    .thenReturn(auditConfig("100"));
             AuditConfigVO auditEnabledConfig = new AuditConfigVO();
             auditEnabledConfig.setConfigValue("true");
             when(operationLogMapper.selectAuditConfigByKey("AUDIT_ENABLED")).thenReturn(auditEnabledConfig);
@@ -317,11 +336,16 @@ class SysAuditServiceImplTest {
             retentionConfig.setConfigValue("180");
             when(operationLogMapper.selectAuditConfigByKey("LOG_RETENTION_DAYS")).thenReturn(retentionConfig);
 
-            Map<String, Object> result = sysAuditService.getAuditOverview();
+            Map<String, Object> result;
+            try (MockedStatic<TenantContext> tenantContextMock = mockStatic(TenantContext.class)) {
+                tenantContextMock.when(TenantContext::requireTenantId).thenReturn(7L);
+                result = sysAuditService.getAuditOverview();
+            }
 
             assertThat(result).containsKey("totalOperations");
             assertThat(result.get("totalOperations")).isEqualTo(1000L);
             assertThat(result).containsKey("todayOperations");
+            assertThat(result.get("highFrequencyAlerts")).isEqualTo(3);
             assertThat(result).containsKey("auditEnabled");
         }
 
@@ -330,7 +354,11 @@ class SysAuditServiceImplTest {
         void shouldHandleOverviewErrorsGracefully() {
             when(operationLogMapper.selectTotalOperations()).thenThrow(new RuntimeException("DB error"));
 
-            Map<String, Object> result = sysAuditService.getAuditOverview();
+            Map<String, Object> result;
+            try (MockedStatic<TenantContext> tenantContextMock = mockStatic(TenantContext.class)) {
+                tenantContextMock.when(TenantContext::requireTenantId).thenReturn(7L);
+                result = sysAuditService.getAuditOverview();
+            }
 
             assertThat(result).containsKey("error");
         }
@@ -343,7 +371,7 @@ class SysAuditServiceImplTest {
         @Test
         @DisplayName("should return tenant scoped anomaly check results")
         void shouldReturnTenantScopedAnomalyCheckResults() {
-            when(operationLogMapper.countHighFrequencyUsers(eq(7L), any(LocalDateTime.class), eq(100))).thenReturn(1);
+            when(operationLogMapper.countHighFrequencyAlerts(eq(7L), any(LocalDateTime.class), eq(100))).thenReturn(1);
             when(operationLogMapper.countFailedLoginUsers(eq(7L), any(LocalDateTime.class), eq(5))).thenReturn(0);
             when(operationLogMapper.selectErrorRatePercent(eq(7L), any(LocalDateTime.class))).thenReturn(12.5D);
 
@@ -358,7 +386,7 @@ class SysAuditServiceImplTest {
             assertThat(result).containsKey("success");
             assertThat(result.get("success")).isEqualTo(true);
             assertThat(result.get("anomalyDetails").toString()).contains("\"tenantId\":7");
-            verify(operationLogMapper).countHighFrequencyUsers(eq(7L), any(LocalDateTime.class), eq(100));
+            verify(operationLogMapper).countHighFrequencyAlerts(eq(7L), any(LocalDateTime.class), eq(100));
             verify(operationLogMapper).countFailedLoginUsers(eq(7L), any(LocalDateTime.class), eq(5));
             verify(operationLogMapper).selectErrorRatePercent(eq(7L), any(LocalDateTime.class));
         }
@@ -366,7 +394,7 @@ class SysAuditServiceImplTest {
         @Test
         @DisplayName("should handle anomaly check failure")
         void shouldHandleAnomalyCheckFailure() {
-            when(operationLogMapper.countHighFrequencyUsers(eq(7L), any(LocalDateTime.class), anyInt()))
+            when(operationLogMapper.countHighFrequencyAlerts(eq(7L), any(LocalDateTime.class), anyInt()))
                     .thenThrow(new RuntimeException("Query error"));
 
             Map<String, Object> result;
@@ -455,5 +483,14 @@ class SysAuditServiceImplTest {
         log.setStatus(1);
         log.setOperationTime(LocalDateTime.now());
         return log;
+    }
+
+    /**
+     * Build an audit configuration fixture.
+     */
+    private AuditConfigVO auditConfig(String value) {
+        AuditConfigVO config = new AuditConfigVO();
+        config.setConfigValue(value);
+        return config;
     }
 }

--- a/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/aspect/OperationLogAspect.java
@@ -1,6 +1,7 @@
 package cn.flying.aspect;
 
 import cn.flying.common.annotation.OperationLog;
+import cn.flying.common.exception.GeneralException;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.IdUtils;
 import cn.flying.common.util.JsonConverter;
@@ -291,8 +292,32 @@ public class OperationLogAspect {
      * @return 失败原因；成功时返回 null
      */
     private String resolveFailureMessage(Object result, Exception exception) {
+        if (exception instanceof GeneralException generalException) {
+            if (generalException.getMessage() != null && !generalException.getMessage().isBlank()) {
+                return generalException.getMessage();
+            }
+            if (generalException.getData() != null) {
+                Object data = generalException.getData();
+                if (data instanceof CharSequence || data instanceof Number || data instanceof Enum<?>) {
+                    String text = data.toString();
+                    if (!text.isBlank()) {
+                        return text;
+                    }
+                } else {
+                    String serialized = SensitiveDataMasker.maskAndSerialize(data);
+                    if (serialized != null && !serialized.isBlank()) {
+                        return serialized;
+                    }
+                }
+            }
+            if (generalException.getResultEnum() != null
+                    && generalException.getResultEnum().getMessage() != null
+                    && !generalException.getResultEnum().getMessage().isBlank()) {
+                return generalException.getResultEnum().getMessage();
+            }
+        }
         if (exception != null) {
-            return exception.getMessage() != null
+            return exception.getMessage() != null && !exception.getMessage().isBlank()
                     ? exception.getMessage()
                     : exception.getClass().getSimpleName();
         }

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -413,6 +413,30 @@ class OperationLogAspectTest {
                 null,
                 new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED)
         );
+        String blankExplicit = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException(" ")
+        );
+        String numericData = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException(ResultEnum.PARAM_IS_INVALID, 42)
+        );
+        String enumData = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException(ResultEnum.PARAM_IS_INVALID, Thread.State.RUNNABLE)
+        );
+        String blankData = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException(ResultEnum.PARAM_IS_INVALID, " ")
+        );
         String structuredData = ReflectionTestUtils.invokeMethod(
                 aspect,
                 "resolveFailureMessage",
@@ -434,14 +458,25 @@ class OperationLogAspectTest {
                 null,
                 new IllegalStateException()
         );
+        String blankPlainClass = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new IllegalStateException(" ")
+        );
 
         assertThat(explicit).isEqualTo("explicit business reason");
         assertThat(resultEnum).isEqualTo(ResultEnum.PERMISSION_UNAUTHORIZED.getMessage());
+        assertThat(blankExplicit).isEqualTo("GeneralException");
+        assertThat(numericData).isEqualTo("42");
+        assertThat(enumData).isEqualTo("RUNNABLE");
+        assertThat(blankData).isEqualTo(ResultEnum.PARAM_IS_INVALID.getMessage());
         assertThat(structuredData)
                 .contains("safe structured reason")
                 .doesNotContain("raw-secret");
         assertThat(plainMessage).isEqualTo("plain failure");
         assertThat(plainClass).isEqualTo("IllegalStateException");
+        assertThat(blankPlainClass).isEqualTo("IllegalStateException");
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -5,6 +5,8 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import cn.flying.common.annotation.OperationLog;
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
 import cn.flying.config.RateLimitClientIpProperties;
 import cn.flying.dao.dto.SysOperationLog;
 import cn.flying.security.TrustedClientIpResolver;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -356,6 +359,66 @@ class OperationLogAspectTest {
     }
 
     /**
+     * Verifies that safe business detail becomes the readable reason while path identifiers stay masked.
+     */
+    @Test
+    @DisplayName("Should preserve safe GeneralException detail in a masked failure audit")
+    void shouldPreserveSafeGeneralExceptionDetailInMaskedFailureAudit() throws Throwable {
+        String rawFileId = "sensitive-file-id";
+        String reason = "管理员状态接口不能绕过上传校验将文件提升为成功状态";
+        SysOperationLogService operationLogService = mock(SysOperationLogService.class);
+        OperationLogAspect aspect = new OperationLogAspect(operationLogService, newResolver(""));
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "PUT",
+                "/api/v1/admin/files/" + rawFileId + "/status"
+        );
+        request.setServletPath("/api/v1/admin/files/" + rawFileId + "/status");
+        request.setRemoteAddr("198.51.100.31");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ProceedingJoinPoint joinPoint = failingAuditedJoinPoint(
+                new GeneralException(ResultEnum.PARAM_IS_INVALID, reason)
+        );
+
+        assertThatThrownBy(() -> aspect.doAround(joinPoint))
+                .isInstanceOf(GeneralException.class);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(SysOperationLog.class);
+        verify(operationLogService).saveOperationLog(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(1);
+        assertThat(captor.getValue().getErrorMsg()).isEqualTo(reason);
+        assertThat(captor.getValue().getErrorMsg()).doesNotContain("GeneralException");
+        assertThat(captor.getValue().getRequestUrl())
+                .isEqualTo("/api/v1/admin/files/***/status")
+                .doesNotContain(rawFileId);
+    }
+
+    /**
+     * Verifies the explicit-message and result-enum fallbacks around the business-detail branch.
+     */
+    @Test
+    @DisplayName("Should resolve GeneralException message sources in priority order")
+    void shouldResolveGeneralExceptionMessageSourcesInPriorityOrder() {
+        OperationLogAspect aspect = newAspect("");
+
+        String explicit = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException("explicit business reason")
+        );
+        String resultEnum = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED)
+        );
+
+        assertThat(explicit).isEqualTo("explicit business reason");
+        assertThat(resultEnum).isEqualTo(ResultEnum.PERMISSION_UNAUTHORIZED.getMessage());
+    }
+
+    /**
      * 验证无 HTTP 请求上下文时仍执行目标方法且不会尝试持久化操作日志。
      */
     @Test
@@ -423,6 +486,22 @@ class OperationLogAspectTest {
         when(joinPoint.getSignature()).thenReturn(signature);
         when(joinPoint.getArgs()).thenReturn(new Object[]{token});
         when(joinPoint.proceed()).thenReturn(response);
+        when(signature.getMethod()).thenReturn(method);
+        when(signature.getDeclaringTypeName()).thenReturn(AuditedFixture.class.getName());
+        when(signature.getName()).thenReturn(method.getName());
+        return joinPoint;
+    }
+
+    /**
+     * Build an audited join point that throws the supplied business exception.
+     */
+    private ProceedingJoinPoint failingAuditedJoinPoint(Exception exception) throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        Method method = AuditedFixture.class.getDeclaredMethod("execute");
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(joinPoint.getArgs()).thenReturn(new Object[0]);
+        when(joinPoint.proceed()).thenThrow(exception);
         when(signature.getMethod()).thenReturn(method);
         when(signature.getDeclaringTypeName()).thenReturn(AuditedFixture.class.getName());
         when(signature.getName()).thenReturn(method.getName());

--- a/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/aspect/OperationLogAspectTest.java
@@ -394,7 +394,7 @@ class OperationLogAspectTest {
     }
 
     /**
-     * Verifies the explicit-message and result-enum fallbacks around the business-detail branch.
+     * Verifies every safe message source and fallback around the business-detail branch.
      */
     @Test
     @DisplayName("Should resolve GeneralException message sources in priority order")
@@ -413,9 +413,35 @@ class OperationLogAspectTest {
                 null,
                 new GeneralException(ResultEnum.PERMISSION_UNAUTHORIZED)
         );
+        String structuredData = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new GeneralException(
+                        ResultEnum.PARAM_IS_INVALID,
+                        java.util.Map.of("reason", "safe structured reason", "secretToken", "raw-secret")
+                )
+        );
+        String plainMessage = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new IllegalStateException("plain failure")
+        );
+        String plainClass = ReflectionTestUtils.invokeMethod(
+                aspect,
+                "resolveFailureMessage",
+                null,
+                new IllegalStateException()
+        );
 
         assertThat(explicit).isEqualTo("explicit business reason");
         assertThat(resultEnum).isEqualTo(ResultEnum.PERMISSION_UNAUTHORIZED.getMessage());
+        assertThat(structuredData)
+                .contains("safe structured reason")
+                .doesNotContain("raw-secret");
+        assertThat(plainMessage).isEqualTo("plain failure");
+        assertThat(plainClass).isEqualTo("IllegalStateException");
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/service/AuditHighFrequencyTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/service/AuditHighFrequencyTenantIsolationIT.java
@@ -1,0 +1,93 @@
+package cn.flying.service;
+
+import cn.flying.common.tenant.TenantContext;
+import cn.flying.dao.vo.audit.HighFrequencyOperationVO;
+import cn.flying.test.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the tenant, window, and threshold contract for audit high-frequency alerts.
+ */
+@Transactional
+@Testcontainers(disabledWithoutDocker = false)
+@DisplayName("Audit high-frequency tenant isolation integration tests")
+class AuditHighFrequencyTenantIsolationIT extends BaseIntegrationTest {
+
+    private static final long CURRENT_TENANT = 919001L;
+    private static final long OTHER_TENANT = 919002L;
+
+    @Autowired
+    private SysAuditService sysAuditService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * Proves list, overview count, and anomaly detection share one tenant-scoped threshold contract.
+     */
+    @Test
+    @DisplayName("should count only current-tenant groups that cross the configured threshold")
+    void shouldCountOnlyCurrentTenantGroupsThatCrossConfiguredThreshold() {
+        jdbcTemplate.update(
+                "UPDATE sys_audit_config SET config_value = '3' WHERE config_key = 'HIGH_FREQ_THRESHOLD'"
+        );
+        insertOperations(CURRENT_TENANT, "f019-crossing", "f019-user", "198.51.100.19", 4);
+        insertOperations(CURRENT_TENANT, "f019-boundary", "f019-boundary", "198.51.100.20", 3);
+        insertOperations(OTHER_TENANT, "f019-other", "f019-other", "203.0.113.19", 4);
+
+        List<HighFrequencyOperationVO> alerts = TenantContext.callWithTenantIsolation(
+                CURRENT_TENANT,
+                sysAuditService::getHighFrequencyOperations
+        );
+        Map<String, Object> overview = TenantContext.callWithTenantIsolation(
+                CURRENT_TENANT,
+                sysAuditService::getAuditOverview
+        );
+        Map<String, Object> anomalies = TenantContext.callWithTenantIsolation(
+                CURRENT_TENANT,
+                sysAuditService::checkAnomalies
+        );
+
+        assertThat(alerts)
+                .extracting(HighFrequencyOperationVO::getUserId)
+                .containsExactly("f019-crossing");
+        assertThat(alerts.getFirst().getOperationCount()).isEqualTo(4);
+        assertThat(overview.get("highFrequencyAlerts")).isEqualTo(1);
+        assertThat(anomalies.get("hasAnomalies")).isEqualTo(true);
+        assertThat(anomalies.get("anomalyDetails").toString())
+                .contains("\"tenantId\":" + CURRENT_TENANT)
+                .contains("\"highFrequencyUsers\":1")
+                .contains("\"highFrequency\":3")
+                .doesNotContain(String.valueOf(OTHER_TENANT));
+        assertThat(TenantContext.getTenantId()).isNull();
+    }
+
+    /**
+     * Inserts a bounded operation-log fixture inside the active five-minute window.
+     */
+    private void insertOperations(long tenantId, String userId, String username, String requestIp, int count) {
+        for (int index = 0; index < count; index++) {
+            jdbcTemplate.update(
+                    """
+                    INSERT INTO sys_operation_log
+                        (tenant_id, module, operation_type, request_ip, status, user_id, username, operation_time)
+                    VALUES (?, 'f019-audit', 'QUERY', ?, 0, ?, ?, NOW())
+                    """,
+                    tenantId,
+                    requestIp,
+                    userId,
+                    username
+            );
+        }
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/service/AuditHighFrequencyTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/service/AuditHighFrequencyTenantIsolationIT.java
@@ -1,6 +1,7 @@
 package cn.flying.service;
 
 import cn.flying.common.tenant.TenantContext;
+import cn.flying.common.util.SnowflakeIdGenerator;
 import cn.flying.dao.vo.audit.HighFrequencyOperationVO;
 import cn.flying.test.BaseIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +32,9 @@ class AuditHighFrequencyTenantIsolationIT extends BaseIntegrationTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private SnowflakeIdGenerator snowflakeIdGenerator;
 
     /**
      * Proves list, overview count, and anomaly detection share one tenant-scoped threshold contract.
@@ -80,9 +84,10 @@ class AuditHighFrequencyTenantIsolationIT extends BaseIntegrationTest {
             jdbcTemplate.update(
                     """
                     INSERT INTO sys_operation_log
-                        (tenant_id, module, operation_type, request_ip, status, user_id, username, operation_time)
-                    VALUES (?, 'f019-audit', 'QUERY', ?, 0, ?, ?, NOW())
+                        (id, tenant_id, module, operation_type, request_ip, status, user_id, username, operation_time)
+                    VALUES (?, ?, 'f019-audit', 'QUERY', ?, 0, ?, ?, NOW())
                     """,
+                    snowflakeIdGenerator.nextId(),
                     tenantId,
                     requestIp,
                     userId,

--- a/platform-frontend/src/lib/api/types/system.ts
+++ b/platform-frontend/src/lib/api/types/system.ts
@@ -72,6 +72,7 @@ export interface OperationLogVO {
  * 审计日志查询参数
  */
 export interface AuditLogQueryParams {
+  userId?: string;
   username?: string;
   operationType?: string;
   module?: string;

--- a/platform-frontend/src/routes/(app)/admin/audit/components/AuditDashboard.render.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/AuditDashboard.render.test.ts
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getAuditOverview: vi.fn(),
+  getHighFrequencyOperations: vi.fn(),
+  getErrorOperationStats: vi.fn(),
+  getUserTimeDistribution: vi.fn(),
+  getAuditLogs: vi.fn(),
+  getAuditLog: vi.fn(),
+}));
+
+vi.mock("$api/endpoints/system", () => apiMocks);
+
+import AuditDashboard from "./AuditDashboard.svelte";
+import AuditLogList from "./AuditLogList.svelte";
+
+describe("AuditDashboard high-frequency drill", () => {
+  const alert = {
+    userId: "audit-user-id",
+    username: "audit-user",
+    requestIp: "198.51.100.19",
+    operationCount: 101,
+    startTime: "2026-09-02 10:00:00",
+    endTime: "2026-09-02 10:04:59",
+    timeSpanSeconds: 299,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.getAuditOverview.mockResolvedValue({
+      highFrequencyAlerts: 1,
+      dailyStats: [],
+    });
+    apiMocks.getHighFrequencyOperations.mockResolvedValue([alert]);
+    apiMocks.getErrorOperationStats.mockResolvedValue([]);
+    apiMocks.getUserTimeDistribution.mockResolvedValue([]);
+    apiMocks.getAuditLogs.mockResolvedValue({ records: [], total: 0 });
+    vi.stubGlobal("scrollTo", vi.fn());
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("focuses the actual alert table and drills a row with its exact group window", async () => {
+    const onDrillDown = vi.fn();
+    const view = render(AuditDashboard, { onDrillDown });
+
+    await waitFor(() => expect(view.getByText("audit-user")).toBeTruthy());
+
+    const alertCard = view.getByText("高频告警").closest("button");
+    expect(alertCard).not.toBeNull();
+    await fireEvent.click(alertCard!);
+
+    const alertSection = view.container.querySelector("#high-frequency-alerts");
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+    expect(document.activeElement).toBe(alertSection);
+    expect(onDrillDown).not.toHaveBeenCalled();
+
+    const alertRow = view.getByText("audit-user").closest("tr");
+    expect(alertRow).not.toBeNull();
+    await fireEvent.click(alertRow!);
+
+    expect(onDrillDown).toHaveBeenCalledWith({
+      userId: alert.userId,
+      username: alert.username,
+      requestIp: alert.requestIp,
+      startTime: alert.startTime,
+      endTime: alert.endTime,
+    });
+  });
+
+  it("propagates the alert IP and exact window into the log query", async () => {
+    const view = render(AuditLogList, {
+      externalFilters: {
+        userId: alert.userId,
+        username: alert.username,
+        requestIp: alert.requestIp,
+        startTime: alert.startTime,
+        endTime: alert.endTime,
+        _counter: 1,
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiMocks.getAuditLogs).toHaveBeenCalledWith({
+        pageNum: 1,
+        pageSize: 20,
+        userId: alert.userId,
+        username: alert.username,
+        requestIp: alert.requestIp,
+        startTime: alert.startTime,
+        endTime: alert.endTime,
+      });
+    });
+
+    expect(
+      (view.getByPlaceholderText("用户 ID") as HTMLInputElement).value,
+    ).toBe(alert.userId);
+    expect(
+      (view.getByPlaceholderText("请求 IP") as HTMLInputElement).value,
+    ).toBe(alert.requestIp);
+  });
+});

--- a/platform-frontend/src/routes/(app)/admin/audit/components/AuditDashboard.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/AuditDashboard.svelte
@@ -21,10 +21,12 @@
 
   /** 钻取筛选参数 */
   export type DrillDownFilter = {
+    userId?: string;
     username?: string;
     module?: string;
     operationType?: string;
     status?: string;
+    requestIp?: string;
     startTime?: string;
     endTime?: string;
     onlySensitive?: boolean;
@@ -43,6 +45,7 @@
   let timeDistribution = $state<UserTimeDistributionVO[]>([]);
   let refreshInterval: ReturnType<typeof setInterval> | null = null;
   let lastRefresh = $state<Date | null>(null);
+  let highFrequencySection: HTMLElement | null = null;
 
   function asNumber(value: unknown): number | null {
     if (typeof value === "number" && Number.isFinite(value)) return value;
@@ -120,7 +123,12 @@
   }
 
   function drillHighFrequencyAlerts() {
-    onDrillDown?.({ ...getTodayRange() });
+    if (highFreq.length === 0) return;
+    highFrequencySection?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+    highFrequencySection?.focus({ preventScroll: true });
   }
 
   function drillActiveUsers() {
@@ -144,7 +152,13 @@
   // --- 表格钻取 ---
 
   function handleHighFreqRowClick(item: HighFrequencyOperationVO) {
-    onDrillDown?.({ username: item.username, ...getTodayRange() });
+    onDrillDown?.({
+      userId: item.userId,
+      username: item.username,
+      requestIp: item.requestIp,
+      startTime: item.startTime,
+      endTime: item.endTime,
+    });
   }
 
   function handleErrorRowClick(row: ErrorOperationStatsVO) {
@@ -286,7 +300,12 @@
   <!-- 表格区域 -->
   <div class="grid gap-4 lg:grid-cols-2">
     <!-- 高频告警 -->
-    <div class="bg-card/50 rounded-xl border p-4">
+    <section
+      id="high-frequency-alerts"
+      bind:this={highFrequencySection}
+      tabindex="-1"
+      class="bg-card/50 rounded-xl border p-4 outline-none focus-visible:ring-2"
+    >
       <div class="mb-3 flex items-center justify-between">
         <p class="text-sm font-medium">高频操作告警</p>
         {#if highFreq.length > 0}
@@ -336,7 +355,7 @@
           </Table.Root>
         </div>
       {/if}
-    </div>
+    </section>
 
     <!-- 错误统计 -->
     <div class="bg-card/50 rounded-xl border p-4">

--- a/platform-frontend/src/routes/(app)/admin/audit/components/AuditLogList.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/AuditLogList.svelte
@@ -27,10 +27,12 @@
   /** 外部传入的筛选条件（从仪表盘钻取） */
   interface Props {
     externalFilters?: {
+      userId?: string;
       username?: string;
       module?: string;
       operationType?: string;
       status?: string;
+      requestIp?: string;
       startTime?: string;
       endTime?: string;
       onlySensitive?: boolean;
@@ -47,9 +49,11 @@
   let total = $state(0);
 
   let filterUsername = $state("");
+  let filterUserId = $state("");
   let filterModule = $state("");
   let filterOperationType = $state("");
   let filterStatus = $state("");
+  let filterRequestIp = $state("");
   let filterStartTime = $state("");
   let filterEndTime = $state("");
   let onlySensitive = $state(false);
@@ -69,10 +73,12 @@
   /** 应用外部筛选并加载 */
   function applyExternalFilters() {
     if (!externalFilters) return;
+    filterUserId = externalFilters.userId ?? "";
     filterUsername = externalFilters.username ?? "";
     filterModule = externalFilters.module ?? "";
     filterOperationType = externalFilters.operationType ?? "";
     filterStatus = externalFilters.status ?? "";
+    filterRequestIp = externalFilters.requestIp ?? "";
     filterStartTime = externalFilters.startTime ?? "";
     filterEndTime = externalFilters.endTime ?? "";
     onlySensitive = externalFilters.onlySensitive ?? false;
@@ -102,10 +108,12 @@
         pageNum: page,
         pageSize,
       };
+      if (filterUserId) params.userId = filterUserId;
       if (filterUsername) params.username = filterUsername;
       if (filterModule) params.module = filterModule;
       if (filterOperationType) params.operationType = filterOperationType;
       if (filterStatus !== "") params.status = Number(filterStatus);
+      if (filterRequestIp) params.requestIp = filterRequestIp;
       if (filterStartTime) params.startTime = filterStartTime;
       if (filterEndTime) params.endTime = filterEndTime;
 
@@ -128,10 +136,12 @@
   }
 
   function clearFilters() {
+    filterUserId = "";
     filterUsername = "";
     filterModule = "";
     filterOperationType = "";
     filterStatus = "";
+    filterRequestIp = "";
     filterStartTime = "";
     filterEndTime = "";
     onlySensitive = false;
@@ -153,7 +163,7 @@
     try {
       selectedLogDetail = await getAuditLog(String(log.id));
     } catch (err) {
-      console.error('getAuditLog detail failed:', err);
+      console.error("getAuditLog detail failed:", err);
       selectedLogDetail = null;
     } finally {
       loadingLogDetail = false;
@@ -194,10 +204,24 @@
 <Card.Root>
   <Card.Header class="pb-4">
     <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      <!-- 用户 ID -->
+      <Input
+        placeholder="用户 ID"
+        bind:value={filterUserId}
+        onkeydown={(e) => e.key === "Enter" && handleSearch()}
+      />
+
       <!-- 用户名 -->
       <Input
         placeholder="用户名"
         bind:value={filterUsername}
+        onkeydown={(e) => e.key === "Enter" && handleSearch()}
+      />
+
+      <!-- 请求 IP -->
+      <Input
+        placeholder="请求 IP"
+        bind:value={filterRequestIp}
         onkeydown={(e) => e.key === "Enter" && handleSearch()}
       />
 

--- a/platform-frontend/src/routes/(app)/admin/audit/components/charts/ErrorPieChart.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/charts/ErrorPieChart.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
   import * as echarts from "echarts";
   import type { ErrorOperationStatsVO } from "$api/types";
+  import { chartLifecycle } from "./chartLifecycle";
 
   interface Props {
     data: ErrorOperationStatsVO[];
@@ -17,9 +17,6 @@
     onItemClick,
   }: Props = $props();
 
-  let chart: echarts.ECharts | null = null;
-  let resizeObserver: ResizeObserver | null = null;
-
   const colors = [
     "#ef4444",
     "#f97316",
@@ -29,15 +26,21 @@
     "#8b5cf6",
   ];
 
-  function updateChart() {
-    if (!chart) return;
+  type ChartState = {
+    data: ErrorOperationStatsVO[];
+    onItemClick?: (item: ErrorOperationStatsVO) => void;
+  };
 
-    if (!data.length) {
+  function updateChart(
+    chart: echarts.ECharts,
+    chartData: ErrorOperationStatsVO[],
+  ) {
+    if (!chartData.length) {
       chart.clear();
       return;
     }
 
-    const pieData = data.slice(0, 6).map((item, idx) => ({
+    const pieData = chartData.slice(0, 6).map((item, idx) => ({
       name: item.module + " - " + item.operationType,
       value: item.errorCount,
       itemStyle: { color: colors[idx % colors.length] },
@@ -89,49 +92,22 @@
     });
   }
 
-  function initAction(node: HTMLDivElement) {
-    resizeObserver = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      const { width, height } = entry.contentRect;
-      if (width === 0 || height === 0) return;
-
-      if (!chart) {
-        chart = echarts.init(node, undefined, { renderer: "canvas" });
+  function initAction(node: HTMLDivElement, state: ChartState) {
+    return chartLifecycle(
+      node,
+      state,
+      (chart, current) => updateChart(chart, current.data),
+      (chart, getState) => {
         chart.on("click", (params) => {
-          if (params.dataIndex !== undefined && onItemClick) {
-            onItemClick(data[params.dataIndex]);
+          const current = getState();
+          if (params.dataIndex !== undefined && current.onItemClick) {
+            const item = current.data[params.dataIndex];
+            if (item) current.onItemClick(item);
           }
         });
-        updateChart();
-      } else {
-        chart.resize();
-      }
-    });
-    resizeObserver.observe(node);
-
-    return {
-      destroy() {
-        resizeObserver?.disconnect();
-        resizeObserver = null;
-        chart?.dispose();
-        chart = null;
       },
-    };
+    );
   }
-
-  $effect(() => {
-    if (data && chart) {
-      updateChart();
-    }
-  });
-
-  onDestroy(() => {
-    resizeObserver?.disconnect();
-    resizeObserver = null;
-    chart?.dispose();
-    chart = null;
-  });
 </script>
 
 <div class="bg-card/50 rounded-xl border p-4">
@@ -149,6 +125,9 @@
       暂无错误数据
     </div>
   {:else}
-    <div use:initAction class="mt-2 h-[200px] w-full"></div>
+    <div
+      use:initAction={{ data, onItemClick }}
+      class="mt-2 h-[200px] w-full"
+    ></div>
   {/if}
 </div>

--- a/platform-frontend/src/routes/(app)/admin/audit/components/charts/HeatmapChart.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/charts/HeatmapChart.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
   import * as echarts from "echarts";
   import type { UserTimeDistributionVO } from "$api/types";
+  import { chartLifecycle } from "./chartLifecycle";
 
   interface Props {
     data: UserTimeDistributionVO[];
@@ -11,29 +11,27 @@
 
   let { data, title = "操作时间热力图", loading = false }: Props = $props();
 
-  let chart: echarts.ECharts | null = null;
-  let resizeObserver: ResizeObserver | null = null;
-
   const days = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"];
   const hours = Array.from({ length: 24 }, (_, i) => `${i}:00`);
 
-  function updateChart() {
-    if (!chart) return;
-
-    if (!data.length) {
+  function updateChart(
+    chart: echarts.ECharts,
+    chartData: UserTimeDistributionVO[],
+  ) {
+    if (!chartData.length) {
       chart.clear();
       return;
     }
 
     const heatmapData: Array<[number, number, number]> = [];
-    const maxValue = data.reduce(
+    const maxValue = chartData.reduce(
       (max, item) => Math.max(max, item.operationCount),
       0,
     );
 
     for (let day = 0; day < 7; day++) {
       for (let hour = 0; hour < 24; hour++) {
-        const item = data.find(
+        const item = chartData.find(
           (d) => d.dayOfWeek === day && d.hourOfDay === hour,
         );
         heatmapData.push([hour, day, item?.operationCount ?? 0]);
@@ -122,44 +120,12 @@
     });
   }
 
-  function initAction(node: HTMLDivElement) {
-    resizeObserver = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      const { width, height } = entry.contentRect;
-      if (width === 0 || height === 0) return;
-
-      if (!chart) {
-        chart = echarts.init(node, undefined, { renderer: "canvas" });
-        updateChart();
-      } else {
-        chart.resize();
-      }
-    });
-    resizeObserver.observe(node);
-
-    return {
-      destroy() {
-        resizeObserver?.disconnect();
-        resizeObserver = null;
-        chart?.dispose();
-        chart = null;
-      },
-    };
+  function initAction(
+    node: HTMLDivElement,
+    chartData: UserTimeDistributionVO[],
+  ) {
+    return chartLifecycle(node, chartData, updateChart);
   }
-
-  $effect(() => {
-    if (data && chart) {
-      updateChart();
-    }
-  });
-
-  onDestroy(() => {
-    resizeObserver?.disconnect();
-    resizeObserver = null;
-    chart?.dispose();
-    chart = null;
-  });
 </script>
 
 <div class="bg-card/50 rounded-xl border p-4">
@@ -177,6 +143,6 @@
       暂无时间分布数据
     </div>
   {:else}
-    <div use:initAction class="mt-2 h-[260px] w-full"></div>
+    <div use:initAction={data} class="mt-2 h-[260px] w-full"></div>
   {/if}
 </div>

--- a/platform-frontend/src/routes/(app)/admin/audit/components/charts/TrendChart.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/charts/TrendChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
   import * as echarts from "echarts";
+  import { chartLifecycle } from "./chartLifecycle";
 
   interface Props {
     data: Array<{ date: string; count: number }>;
@@ -16,14 +16,14 @@
     onDateClick,
   }: Props = $props();
 
-  let chart: echarts.ECharts | null = null;
-  let resizeObserver: ResizeObserver | null = null;
+  type ChartState = {
+    data: Array<{ date: string; count: number }>;
+    onDateClick?: (date: string) => void;
+  };
 
-  function updateChart() {
-    if (!chart || !data.length) return;
-
-    const dates = data.map((d) => d.date);
-    const counts = data.map((d) => d.count);
+  function updateChart(chart: echarts.ECharts, chartData: ChartState["data"]) {
+    const dates = chartData.map((d) => d.date);
+    const counts = chartData.map((d) => d.count);
 
     chart.setOption({
       tooltip: {
@@ -87,49 +87,21 @@
     });
   }
 
-  function initAction(node: HTMLDivElement) {
-    resizeObserver = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      const { width, height } = entry.contentRect;
-      if (width === 0 || height === 0) return;
-
-      if (!chart) {
-        chart = echarts.init(node, undefined, { renderer: "canvas" });
+  function initAction(node: HTMLDivElement, state: ChartState) {
+    return chartLifecycle(
+      node,
+      state,
+      (chart, current) => updateChart(chart, current.data),
+      (chart, getState) => {
         chart.on("click", (params) => {
-          if (params.name && onDateClick) {
-            onDateClick(params.name as string);
+          const current = getState();
+          if (params.name && current.onDateClick) {
+            current.onDateClick(params.name as string);
           }
         });
-        updateChart();
-      } else {
-        chart.resize();
-      }
-    });
-    resizeObserver.observe(node);
-
-    return {
-      destroy() {
-        resizeObserver?.disconnect();
-        resizeObserver = null;
-        chart?.dispose();
-        chart = null;
       },
-    };
+    );
   }
-
-  $effect(() => {
-    if (data && chart) {
-      updateChart();
-    }
-  });
-
-  onDestroy(() => {
-    resizeObserver?.disconnect();
-    resizeObserver = null;
-    chart?.dispose();
-    chart = null;
-  });
 </script>
 
 <div class="bg-card/50 rounded-xl border p-4">
@@ -147,6 +119,9 @@
       暂无趋势数据
     </div>
   {:else}
-    <div use:initAction class="mt-2 h-[200px] w-full"></div>
+    <div
+      use:initAction={{ data, onDateClick }}
+      class="mt-2 h-[200px] w-full"
+    ></div>
   {/if}
 </div>

--- a/platform-frontend/src/routes/(app)/admin/audit/components/charts/chartLifecycle.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/charts/chartLifecycle.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const echartsMocks = vi.hoisted(() => ({
+  init: vi.fn(),
+}));
+
+vi.mock("echarts", () => ({
+  init: echartsMocks.init,
+}));
+
+import { chartLifecycle } from "./chartLifecycle";
+
+describe("chartLifecycle", () => {
+  let resizeCallback: ResizeObserverCallback;
+  let disconnect: ReturnType<typeof vi.fn>;
+  let observe: ReturnType<typeof vi.fn>;
+  let chart: {
+    resize: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    disconnect = vi.fn();
+    observe = vi.fn();
+    chart = { resize: vi.fn(), dispose: vi.fn() };
+    echartsMocks.init.mockReturnValue(chart);
+
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback;
+        }
+        observe = observe;
+        disconnect = disconnect;
+      },
+    );
+  });
+
+  function sizedNode(width = 640, height = 240) {
+    const node = document.createElement("div");
+    vi.spyOn(node, "getBoundingClientRect").mockReturnValue({
+      width,
+      height,
+      x: 0,
+      y: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      left: 0,
+      toJSON: () => ({}),
+    });
+    return node;
+  }
+
+  it("initializes synchronously without waiting for ResizeObserver", () => {
+    const render = vi.fn();
+    const node = sizedNode();
+
+    const lifecycle = chartLifecycle(node, [1], render);
+
+    expect(echartsMocks.init).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledWith(chart, [1]);
+    expect(observe).toHaveBeenCalledWith(node);
+
+    lifecycle.update([2]);
+    expect(render).toHaveBeenLastCalledWith(chart, [2]);
+
+    resizeCallback([], {} as ResizeObserver);
+    expect(chart.resize).toHaveBeenCalledOnce();
+
+    lifecycle.destroy();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(chart.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("uses one bounded animation-frame retry and can initialize on a later resize", () => {
+    const callbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const node = sizedNode(0, 0);
+    const render = vi.fn();
+
+    const lifecycle = chartLifecycle(node, [1], render);
+
+    expect(echartsMocks.init).not.toHaveBeenCalled();
+    expect(callbacks).toHaveLength(1);
+    callbacks[0](0);
+    expect(echartsMocks.init).not.toHaveBeenCalled();
+    expect(callbacks).toHaveLength(1);
+
+    vi.mocked(node.getBoundingClientRect).mockReturnValue({
+      width: 640,
+      height: 240,
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 640,
+      bottom: 240,
+      left: 0,
+      toJSON: () => ({}),
+    });
+    resizeCallback([], {} as ResizeObserver);
+
+    expect(echartsMocks.init).toHaveBeenCalledOnce();
+    expect(render).toHaveBeenCalledWith(chart, [1]);
+    lifecycle.destroy();
+  });
+
+  it("cancels a pending retry when the action is destroyed before layout", () => {
+    const requestFrame = vi.fn(() => 17);
+    const cancelFrame = vi.fn();
+    vi.stubGlobal("requestAnimationFrame", requestFrame);
+    vi.stubGlobal("cancelAnimationFrame", cancelFrame);
+
+    const lifecycle = chartLifecycle(sizedNode(0, 0), [1], vi.fn());
+    lifecycle.destroy();
+
+    expect(requestFrame).toHaveBeenCalledOnce();
+    expect(cancelFrame).toHaveBeenCalledWith(17);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(echartsMocks.init).not.toHaveBeenCalled();
+  });
+});

--- a/platform-frontend/src/routes/(app)/admin/audit/components/charts/chartLifecycle.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/charts/chartLifecycle.ts
@@ -1,0 +1,70 @@
+import * as echarts from "echarts";
+
+/**
+ * Mounts an ECharts instance immediately when the container has layout, then
+ * keeps resize observation and disposal behind one shared lifecycle boundary.
+ */
+export function chartLifecycle<T>(
+  node: HTMLDivElement,
+  initialValue: T,
+  render: (chart: echarts.ECharts, value: T) => void,
+  connect?: (chart: echarts.ECharts, getValue: () => T) => void,
+) {
+  let value = initialValue;
+  let chart: echarts.ECharts | null = null;
+  let retryFrame: number | null = null;
+
+  const hasLayout = () => {
+    const rect = node.getBoundingClientRect();
+    return (
+      (node.clientWidth > 0 || rect.width > 0) &&
+      (node.clientHeight > 0 || rect.height > 0)
+    );
+  };
+
+  const initialize = () => {
+    if (chart || !hasLayout()) return false;
+
+    chart = echarts.init(node, undefined, { renderer: "canvas" });
+    connect?.(chart, () => value);
+    render(chart, value);
+    return true;
+  };
+
+  initialize();
+  if (!chart) {
+    retryFrame = requestAnimationFrame(() => {
+      retryFrame = null;
+      initialize();
+    });
+  }
+
+  const resizeObserver = new ResizeObserver(() => {
+    if (!chart) {
+      initialize();
+      return;
+    }
+    chart.resize();
+  });
+  resizeObserver.observe(node);
+
+  return {
+    update(nextValue: T) {
+      value = nextValue;
+      if (chart) {
+        render(chart, value);
+      } else {
+        initialize();
+      }
+    },
+    destroy() {
+      resizeObserver.disconnect();
+      if (retryFrame !== null) {
+        cancelAnimationFrame(retryFrame);
+        retryFrame = null;
+      }
+      chart?.dispose();
+      chart = null;
+    },
+  };
+}

--- a/platform-frontend/src/routes/(app)/admin/audit/components/charts/charts.render.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/charts/charts.render.test.ts
@@ -1,0 +1,88 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const echartsMocks = vi.hoisted(() => ({
+  init: vi.fn(),
+}));
+
+vi.mock("echarts", () => ({
+  init: echartsMocks.init,
+  graphic: {
+    LinearGradient: class {},
+  },
+}));
+
+import ErrorPieChart from "./ErrorPieChart.svelte";
+import HeatmapChart from "./HeatmapChart.svelte";
+import TrendChart from "./TrendChart.svelte";
+
+describe("audit charts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    echartsMocks.init.mockImplementation((node: HTMLElement) => {
+      node.appendChild(document.createElement("canvas"));
+      return {
+        on: vi.fn(),
+        setOption: vi.fn(),
+        clear: vi.fn(),
+        resize: vi.fn(),
+        dispose: vi.fn(),
+      };
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: 640,
+      height: 260,
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 640,
+      bottom: 260,
+      left: 0,
+      toJSON: () => ({}),
+    });
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("creates a canvas immediately and updates without recreating the chart", async () => {
+    const trend = render(TrendChart, {
+      data: [{ date: "2026-09-02", count: 12 }],
+    });
+    const errors = render(ErrorPieChart, {
+      data: [
+        {
+          module: "file",
+          operationType: "UPDATE",
+          errorMsg: "failure",
+          errorCount: 2,
+          firstOccurrence: "2026-09-02 10:00:00",
+          lastOccurrence: "2026-09-02 10:01:00",
+        },
+      ],
+    });
+    const heatmap = render(HeatmapChart, {
+      data: [{ dayOfWeek: 2, hourOfDay: 10, operationCount: 8 }],
+    });
+
+    expect(echartsMocks.init).toHaveBeenCalledTimes(3);
+    expect(trend.container.querySelector("canvas")).not.toBeNull();
+    expect(errors.container.querySelector("canvas")).not.toBeNull();
+    expect(heatmap.container.querySelector("canvas")).not.toBeNull();
+
+    await trend.rerender({ data: [{ date: "2026-09-03", count: 18 }] });
+    expect(echartsMocks.init).toHaveBeenCalledTimes(3);
+    expect(
+      echartsMocks.init.mock.results[0]?.value.setOption,
+    ).toHaveBeenCalledTimes(2);
+  });
+});

--- a/platform-frontend/vitest.config.ts
+++ b/platform-frontend/vitest.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "vitest/config";
 import { resolve } from "path";
+import { svelteTesting } from "@testing-library/svelte/vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
+  plugins: [svelte(), svelteTesting()],
   test: {
     include: ["src/**/*.{test,spec}.{ts,js}"],
     globals: true,


### PR DESCRIPTION
## 变更范围

- 修复三张 ECharts 图表仅依赖 ResizeObserver 导致首次不初始化的问题，并统一挂载、重试、resize、更新和销毁生命周期
- 统一高频列表、KPI 与异常检测的当前租户、最近五分钟及动态阈值语义
- 高频告警钻取携带精确 userId、username、requestIp 与实际时间窗口
- 优先提取 GeneralException 的安全业务详情，并保持字段与路径脱敏
- 增加真实 MySQL 租户隔离 IT、渲染回归及 CI 零跳过门禁
- 同步测试证据文档

## 验证

- `pnpm format:check`
- `pnpm lint`
- `pnpm check`（0 errors / 0 warnings）
- `pnpm test:coverage`（45 files / 578 tests）
- `pnpm build`
- backend-service 全量单测（1455 passed）
- backend-web 单元测试（563 passed）
- `mvn -pl backend-web -am -DskipTests test-compile`
- `python3 tools/docs/check_consistency.py --check-evidence`
- `actionlint .github/workflows/test.yml`
- `git diff --check`

真实 MySQL `AuditHighFrequencyTenantIsolationIT` 在本机因无 Docker socket 按 fail-closed 失败，PR CI 必须执行且要求 tests=1、skipped/failures/errors=0。

## 运行时边界

- 源码默认可信代理列表保持为空
- home-server 的 `127.0.0.1/32` 仅在 PR 合并后的服务器本地配置，不进入仓库
- 不包含任何服务器凭据或本地机密配置