### PR TITLE
feat: 扩展常用文件类型与安全预览

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -608,6 +608,8 @@ This module exposes two upload paths:
 - Backend-proxied chunk upload with pause/resume support.
 - Direct multipart upload where the frontend uploads chunk bytes to object storage through presigned URLs and the backend only validates metadata, registers the file, persists the chunk manifest, and records attestation.
 
+Clients should first read `GET /api/v1/upload-sessions/policy`. The response is the authoritative list of allowed filename extensions, compatible MIME aliases, preview modes, capability groups, and the maximum file size. Empty MIME values and `application/octet-stream` fall back to the extension; concrete MIME values must match the extension.
+
 ### Upload Flow
 
 1. Call `POST /api/v1/upload-sessions` to initialize upload session
@@ -643,7 +645,7 @@ POST /api/v1/upload-sessions
 | ----------- | ------ | -------- | ------------------------------------------------------------- |
 | fileName    | string | Yes      | File name                                                     |
 | fileSize    | long   | Yes      | File size in bytes                                            |
-| contentType | string | Yes      | MIME type                                                     |
+| contentType | string | No       | MIME type; empty browser values fall back to the extension    |
 | clientId    | string | No       | Client-provided ID (optional, auto-generated if not provided) |
 | chunkSize   | int    | Yes      | Size of each chunk                                            |
 | totalChunks | int    | Yes      | Total number of chunks                                        |
@@ -4031,6 +4033,7 @@ Operational defaults: backfill worker enabled, apply disabled, run lease 300 sec
 - `GET /api/v1/files/shares`
 - `GET /api/v1/files/{id}/provenance`
 - `GET /api/v1/transactions/{transactionHash}`
+- `GET /api/v1/upload-sessions/policy`
 - `POST /api/v1/upload-sessions`
 - `POST /api/v1/upload-sessions/direct`
 - `PUT /api/v1/upload-sessions/{clientId}/chunks/{chunkNumber}`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,8 +27,8 @@
 | 指标 | 当前值 | 自动校验来源 |
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
-| 后端服务类 | 212 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 218 | `platform-backend/**/src/test/java` |
+| 后端服务类 | 213 | `platform-backend/backend-service/src/main/java` |
+| 后端测试文件 | 219 | `platform-backend/**/src/test/java` |
 | 数据库迁移 | 38（V1.0.0 ~ V1.20.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（336 files）
+## 当前测试文件快照（340 files）
 
 > 2026-09-02 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -10,11 +10,11 @@
 | --- | ---: |
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
-| `platform-backend/backend-service` | 96 |
+| `platform-backend/backend-service` | 97 |
 | `platform-backend/backend-web` | 108 |
-| `platform-backend` | 218 |
+| `platform-backend` | 219 |
 | `platform-storage` | 28 |
-| `platform-frontend` | 46 |
+| `platform-frontend` | 49 |
 | `platform-verifier` | 15 |
 | `platform-fisco` | 14 |
 | `platform-api` | 3 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 12 |
-| `total` | 336 |
+| `total` | 340 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 
@@ -44,6 +44,7 @@
 | 测试类 | 覆盖范围 |
 |--------|----------|
 | FileUploadServiceTest | 分块上传、暂停/恢复、状态管理、所有权验证 |
+| FileUploadPolicyRegistryTest | 上传扩展名/MIME 矩阵、空 MIME 降级与主动内容预览策略 |
 | FileUploadServiceConcurrencyTest | 上传并发安全 |
 | FileServiceTest | 分享生成（公开/私密）、取消/更新分享、访问计数 |
 | FileServiceConcurrencyTest | 文件操作并发安全 |
@@ -205,6 +206,7 @@
 | AuditDashboard.render.test.ts | 高频告警聚焦与精确身份、IP、时间窗钻取 |
 | chartLifecycle.test.ts | ECharts 同步初始化、单次重试、resize 与销毁 |
 | charts.render.test.ts | 三类审计图表挂载后生成 canvas |
+| upload-policy.render.test.ts | 上传页策略加载、accept 同步、快速拒绝与加载失败回退 |
 
 ### 测试工具类
 

--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -79,6 +79,7 @@ The anonymous public-share surface is limited to the five exact share-related `G
 
 | Method | Endpoint | Description |
 |------|------|------|
+| GET | `/api/v1/upload-sessions/policy` | Get the server-authoritative extension, MIME, preview, and size policy |
 | POST | `/api/v1/upload-sessions` | Start chunked upload |
 | POST | `/api/v1/upload-sessions/direct` | Start direct multipart upload and return presigned URLs |
 | PUT | `/api/v1/upload-sessions/{clientId}/chunks/{chunkNumber}` | Upload chunk |
@@ -90,6 +91,8 @@ The anonymous public-share surface is limited to the five exact share-related `G
 | DELETE | `/api/v1/upload-sessions/{clientId}/direct` | Abort direct multipart upload |
 | GET | `/api/v1/upload-sessions/{clientId}` | Check upload status |
 | GET | `/api/v1/upload-sessions/{clientId}/progress` | Query upload progress |
+
+Every upload requires an allowlisted filename extension. An empty MIME value or `application/octet-stream` may fall back to the extension; any concrete MIME must be compatible with that extension. HTML, SVG, and source files are rendered only as escaped text. Office/OpenDocument files, archives, and formats without stable browser decoders remain download-only.
 
 ### Files and Sharing (`/api/v1/files`)
 

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -79,6 +79,7 @@ Authorization: Bearer <token>
 
 | 方法 | 端点 | 说明 |
 |------|------|------|
+| GET | `/api/v1/upload-sessions/policy` | 获取服务端权威的扩展名、MIME、预览能力和大小策略 |
 | POST | `/api/v1/upload-sessions` | 开始分片上传 |
 | POST | `/api/v1/upload-sessions/direct` | 开始对象存储直传并返回预签名 URL |
 | PUT | `/api/v1/upload-sessions/{clientId}/chunks/{chunkNumber}` | 上传分片 |
@@ -90,6 +91,8 @@ Authorization: Bearer <token>
 | DELETE | `/api/v1/upload-sessions/{clientId}/direct` | 中止对象存储直传 |
 | GET | `/api/v1/upload-sessions/{clientId}` | 检查上传状态 |
 | GET | `/api/v1/upload-sessions/{clientId}/progress` | 查询上传进度 |
+
+所有上传都必须具有白名单扩展名。浏览器未提供 MIME 或提供 `application/octet-stream` 时可按扩展名降级；任何具体 MIME 都必须与扩展名兼容。HTML、SVG 和源代码只能作为转义文本预览；Office/OpenDocument、压缩包及缺少稳定浏览器解码器的格式只提供下载。
 
 ### 文件与分享（`/api/v1/files`）
 

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/DirectUploadSessionRequest.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/DirectUploadSessionRequest.java
@@ -36,8 +36,8 @@ public class DirectUploadSessionRequest {
     @Schema(description = "文件大小", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long fileSize;
 
-    @NotBlank
-    @Schema(description = "文件类型")
+    @Size(max = 255)
+    @Schema(description = "文件类型；浏览器未提供时可为空")
     private String contentType;
 
     @Pattern(regexp = "^[A-Za-z0-9-]{1,64}$", message = "clientId 格式无效")

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/UploadFileTypePolicyVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/UploadFileTypePolicyVO.java
@@ -1,0 +1,22 @@
+package cn.flying.dao.vo.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Describes one server-authorized upload file extension and its preview capability.
+ */
+@Schema(description = "上传文件类型策略")
+public record UploadFileTypePolicyVO(
+        @Schema(description = "不含点号的小写文件扩展名", example = "pdf", requiredMode = Schema.RequiredMode.REQUIRED)
+        String extension,
+        @Schema(description = "能力分组编码", example = "document", requiredMode = Schema.RequiredMode.REQUIRED)
+        String category,
+        @Schema(description = "能力分组名称", example = "文档", requiredMode = Schema.RequiredMode.REQUIRED)
+        String categoryLabel,
+        @Schema(description = "预览模式", allowableValues = {"image", "video", "audio", "pdf", "text", "unsupported"}, requiredMode = Schema.RequiredMode.REQUIRED)
+        String previewMode,
+        @Schema(description = "与扩展名兼容的具体 MIME 别名", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<String> mimeTypes) {
+}

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/UploadPolicyVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/file/UploadPolicyVO.java
@@ -1,0 +1,16 @@
+package cn.flying.dao.vo.file;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Exposes the current server-authoritative upload policy to authenticated clients.
+ */
+@Schema(description = "上传策略")
+public record UploadPolicyVO(
+        @Schema(description = "单文件最大字节数", example = "4294967296", requiredMode = Schema.RequiredMode.REQUIRED)
+        long maxFileSizeBytes,
+        @Schema(description = "允许的文件类型及预览能力", requiredMode = Schema.RequiredMode.REQUIRED)
+        List<UploadFileTypePolicyVO> fileTypes) {
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/FileUploadService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/FileUploadService.java
@@ -8,6 +8,7 @@ import cn.flying.dao.vo.file.DirectUploadSessionVO;
 import cn.flying.dao.vo.file.ProgressVO;
 import cn.flying.dao.vo.file.ResumeUploadVO;
 import cn.flying.dao.vo.file.StartUploadVO;
+import cn.flying.dao.vo.file.UploadPolicyVO;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -18,6 +19,13 @@ import org.springframework.web.multipart.MultipartFile;
  */
 
 public interface FileUploadService {
+    /**
+     * Returns the current server-authoritative upload and preview policy.
+     *
+     * @return upload policy
+     */
+    UploadPolicyVO getUploadPolicy();
+
     /**
      * 开始上传
      * @param uid 用户ID

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/FileUploadServiceImpl.java
@@ -26,6 +26,7 @@ import cn.flying.service.manifest.ChunkManifestService;
 import cn.flying.service.manifest.ChunkManifestView;
 import cn.flying.service.manifest.FramedManifestFinalizationService;
 import cn.flying.service.remote.FileRemoteClient;
+import cn.flying.service.upload.FileUploadPolicyRegistry;
 import cn.flying.platformapi.request.AbortDirectMultipartUploadRequest;
 import cn.flying.platformapi.request.CompleteDirectMultipartUploadRequest;
 import cn.flying.platformapi.request.CreateDirectMultipartUploadRequest;
@@ -129,21 +130,6 @@ public class FileUploadServiceImpl implements FileUploadService {
     private static final String DIRECT_STAGE_CHAIN_ATTESTED = "CHAIN_ATTESTED";
     private static final String DIRECT_STAGE_FILE_STORED = "FILE_STORED";
     private static final String DIRECT_STAGE_MANIFEST_STORED = "MANIFEST_STORED";
-    // --- 允许的文件类型 ---
-    private static final Set<String> ALLOWED_FILE_EXTENSIONS = Set.of(
-            "jpg", "jpeg", "png", "gif", "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "zip", "rar", "7z"
-    );
-    private static final Map<String, String> ALLOWED_MIME_TYPES = Map.ofEntries(
-            Map.entry("image/jpeg", "jpg"), Map.entry("image/png", "png"), Map.entry("image/gif", "gif"),
-            Map.entry("application/pdf", "pdf"), Map.entry("application/msword", "doc"),
-            Map.entry("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
-            Map.entry("application/vnd.ms-excel", "xls"),
-            Map.entry("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx"),
-            Map.entry("application/vnd.ms-powerpoint", "ppt"),
-            Map.entry("application/vnd.openxmlformats-officedocument.presentationml.presentation", "pptx"),
-            Map.entry("text/plain", "txt"), Map.entry("application/zip", "zip"),
-            Map.entry("application/x-rar-compressed", "rar"), Map.entry("application/x-7z-compressed", "7z")
-    );
     // --- 线程池配置 ---
     @Qualifier("fileProcessTaskExecutor")
     private final Executor fileProcessingExecutor;
@@ -252,6 +238,14 @@ public class FileUploadServiceImpl implements FileUploadService {
     }
 
     // === Service 方法实现 ===
+
+    /**
+     * Returns the stable upload policy consumed by the frontend.
+     */
+    @Override
+    public UploadPolicyVO getUploadPolicy() {
+        return FileUploadPolicyRegistry.toView(MAX_FILE_SIZE_BYTES);
+    }
 
     /**
      * 记录定时扫描时采用的截止时间和暂停分类，供 finalizer 锁内重新判定。
@@ -934,9 +928,8 @@ public class FileUploadServiceImpl implements FileUploadService {
             throw new GeneralException("分片大小必须在 1B 到 " + (MAX_CHUNK_SIZE_BYTES / 1024 / 1024) + "MB 之间");
         }
         validateUploadPlan(fileSize, chunkSize, totalChunks);
-        if (!isFileTypeAllowed(fileName, contentType)) {
-            throw new GeneralException("不支持的文件类型");
-        }
+        FileUploadPolicyRegistry.validate(fileName, contentType);
+        String normalizedContentType = FileUploadPolicyRegistry.normalizeForPersistence(contentType);
         validateUploadTargetFile(userId, fileName, fileSize, targetFileId);
 
         boolean hasProvidedClientId = !CommonUtils.isBlank(clientId);
@@ -1002,12 +995,12 @@ public class FileUploadServiceImpl implements FileUploadService {
         checkQuotaForNewUploadSession(tenantId, userId, fileSize, targetFileId);
 
         log.info("处理上传开始请求: 文件名={}, 文件大小={}, 内容类型={}, 用户SUID={}, 客户端ID={}",
-                fileName, fileSize, contentType, SUID, clientId);
+                fileName, fileSize, normalizedContentType, SUID, clientId);
 
         // --- 创建新会话 ---
         try {
             FileUploadState newState = new FileUploadState(
-                    userId, fileName, fileSize, contentType, clientId, chunkSize, totalChunks, targetFileId
+                    userId, fileName, fileSize, normalizedContentType, clientId, chunkSize, totalChunks, targetFileId
             );
             newState.setTenantId(tenantId);
             newState.setRecoverySchemaVersion(CURRENT_RECOVERY_SCHEMA_VERSION);
@@ -1323,9 +1316,8 @@ public class FileUploadServiceImpl implements FileUploadService {
             throw new GeneralException(ResultEnum.PARAM_ERROR, "分片总数不能为空");
         }
         validateUploadPlan(request.getFileSize(), request.getChunkSize(), request.getTotalChunks());
-        if (!isFileTypeAllowed(request.getFileName(), request.getContentType())) {
-            throw new GeneralException(ResultEnum.FILE_ACCEPT_NOT_SUPPORT);
-        }
+        FileUploadPolicyRegistry.validate(request.getFileName(), request.getContentType());
+        request.setContentType(FileUploadPolicyRegistry.normalizeForPersistence(request.getContentType()));
         if (CommonUtils.isEmpty(request.getParts()) || request.getParts().size() != request.getTotalChunks()) {
             throw new GeneralException(ResultEnum.PARAM_ERROR, "直传分片元数据数量与上传计划不匹配");
         }
@@ -3926,17 +3918,6 @@ public class FileUploadServiceImpl implements FileUploadService {
         return SAFE_FILENAME_PATTERN.matcher(fileName).matches();
     }
 
-    private boolean isFileTypeAllowed(String fileName, String contentType) {
-        String extension = getFileExtension(fileName);
-        if (contentType != null) {
-            String lowerContentType = contentType.toLowerCase();
-            if (ALLOWED_MIME_TYPES.containsKey(lowerContentType)) {
-                return true;
-            }
-        }
-        return extension != null && ALLOWED_FILE_EXTENSIONS.contains(extension);
-    }
-
     // 创建恢复会话响应 DTO
     private StartUploadVO createResumeDto(FileUploadState state) {
         // 恢复时同时返回 uploadedChunks / processedChunks，便于客户端决定跳过上传或仅等待服务端处理
@@ -3967,12 +3948,6 @@ public class FileUploadServiceImpl implements FileUploadService {
         if (fileName.endsWith(".") || fileName.endsWith(" ")) return true;
         String upperName = fileName.toUpperCase();
         return upperName.matches("^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$");
-    }
-
-    private String getFileExtension(String fileName) {
-        if (fileName == null) return null;
-        int dotIndex = fileName.lastIndexOf('.');
-        return (dotIndex > 0 && dotIndex < fileName.length() - 1) ? fileName.substring(dotIndex + 1).toLowerCase() : null;
     }
 
     /**

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/upload/FileUploadPolicyRegistry.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/upload/FileUploadPolicyRegistry.java
@@ -1,0 +1,228 @@
+package cn.flying.service.upload;
+
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.dao.vo.file.UploadFileTypePolicyVO;
+import cn.flying.dao.vo.file.UploadPolicyVO;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Holds the single authoritative extension, MIME compatibility, and preview policy for uploads.
+ */
+public final class FileUploadPolicyRegistry {
+
+    private static final String GENERIC_BINARY_MIME = "application/octet-stream";
+    private static final String CATEGORY_SUMMARY = "文档、文本/代码、图片、音频、视频、压缩包";
+    private static final Pattern CONCRETE_MIME_PATTERN = Pattern.compile(
+            "^[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+$"
+    );
+    private static final Map<String, PolicyEntry> ENTRIES = createEntries();
+
+    private FileUploadPolicyRegistry() {
+    }
+
+    /**
+     * Validates that a filename has an allowed extension and that any concrete MIME matches it.
+     */
+    public static void validate(String fileName, String contentType) {
+        String extension = extensionOf(fileName);
+        if (extension == null) {
+            throw new GeneralException(ResultEnum.FILE_ACCEPT_NOT_SUPPORT,
+                    "文件缺少有效扩展名；可上传类型：" + CATEGORY_SUMMARY);
+        }
+        PolicyEntry entry = ENTRIES.get(extension);
+        if (entry == null) {
+            throw new GeneralException(ResultEnum.FILE_ACCEPT_NOT_SUPPORT,
+                    "不支持的文件扩展名 ." + extension + "；可上传类型：" + CATEGORY_SUMMARY);
+        }
+
+        String normalizedMime = normalizeMimeType(contentType);
+        if (normalizedMime.isEmpty() || GENERIC_BINARY_MIME.equals(normalizedMime)) {
+            return;
+        }
+        if (!CONCRETE_MIME_PATTERN.matcher(normalizedMime).matches()) {
+            throw new GeneralException(ResultEnum.FILE_ACCEPT_NOT_SUPPORT,
+                    "文件内容类型格式无效；可上传类型：" + CATEGORY_SUMMARY);
+        }
+        if (!entry.mimeTypes().contains(normalizedMime)) {
+            throw new GeneralException(ResultEnum.FILE_ACCEPT_NOT_SUPPORT,
+                    "文件扩展名 ." + extension + " 与内容类型 " + normalizedMime
+                            + " 不匹配；可上传类型：" + CATEGORY_SUMMARY);
+        }
+    }
+
+    /**
+     * Returns a safe stable MIME value for persistence after successful validation.
+     */
+    public static String normalizeForPersistence(String contentType) {
+        String normalized = normalizeMimeType(contentType);
+        return normalized.isEmpty() ? GENERIC_BINARY_MIME : normalized;
+    }
+
+    /**
+     * Builds the authenticated policy response in stable extension order.
+     */
+    public static UploadPolicyVO toView(long maxFileSizeBytes) {
+        List<UploadFileTypePolicyVO> fileTypes = ENTRIES.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> new UploadFileTypePolicyVO(
+                        entry.getKey(),
+                        entry.getValue().category(),
+                        entry.getValue().categoryLabel(),
+                        entry.getValue().previewMode(),
+                        List.copyOf(entry.getValue().mimeTypes())))
+                .toList();
+        return new UploadPolicyVO(maxFileSizeBytes, fileTypes);
+    }
+
+    /**
+     * Normalizes MIME aliases by trimming, lowercasing, and removing parameters.
+     */
+    static String normalizeMimeType(String contentType) {
+        if (contentType == null) {
+            return "";
+        }
+        int parameterIndex = contentType.indexOf(';');
+        String baseType = parameterIndex >= 0 ? contentType.substring(0, parameterIndex) : contentType;
+        return baseType.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Extracts a normalized extension from the final filename segment.
+     */
+    static String extensionOf(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex <= 0 || dotIndex == fileName.length() - 1) {
+            return null;
+        }
+        return fileName.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Registers all supported formats without allowing later mutation.
+     */
+    private static Map<String, PolicyEntry> createEntries() {
+        Map<String, PolicyEntry> entries = new LinkedHashMap<>();
+
+        register(entries, "document", "文档", "pdf", mimes("application/pdf"), "pdf");
+        register(entries, "document", "文档", "unsupported", mimes("application/msword"), "doc");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.openxmlformats-officedocument.wordprocessingml.document"), "docx");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.ms-word.document.macroenabled.12"), "docm");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.ms-excel", "application/x-msexcel"), "xls");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"), "xlsx");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.ms-excel.sheet.macroenabled.12"), "xlsm");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.ms-powerpoint"), "ppt");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.openxmlformats-officedocument.presentationml.presentation"), "pptx");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.ms-powerpoint.presentation.macroenabled.12"), "pptm");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.oasis.opendocument.text"), "odt");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.oasis.opendocument.spreadsheet"), "ods");
+        register(entries, "document", "文档", "unsupported", mimes("application/vnd.oasis.opendocument.presentation"), "odp");
+        register(entries, "document", "文档", "unsupported", mimes("application/rtf", "text/rtf"), "rtf");
+
+        register(entries, "text", "文本/代码", "text", mimes("text/plain"), "txt", "log", "ini", "conf", "properties");
+        register(entries, "text", "文本/代码", "text", mimes("text/markdown", "text/plain"), "md");
+        register(entries, "text", "文本/代码", "text", mimes("text/csv", "application/csv", "text/plain"), "csv");
+        register(entries, "text", "文本/代码", "text", mimes("text/tab-separated-values", "text/plain"), "tsv");
+        register(entries, "text", "文本/代码", "text", mimes("application/json", "text/json", "text/plain"), "json");
+        register(entries, "text", "文本/代码", "text", mimes(
+                "application/json", "application/jsonl", "application/ndjson", "application/x-ndjson", "text/plain"), "jsonl");
+        register(entries, "text", "文本/代码", "text", mimes("application/xml", "text/xml", "text/plain"), "xml");
+        register(entries, "text", "文本/代码", "text", mimes("application/yaml", "text/yaml", "application/x-yaml", "text/plain"), "yaml", "yml");
+        register(entries, "text", "文本/代码", "text", mimes("application/sql", "text/x-sql", "text/plain"), "sql");
+        register(entries, "text", "文本/代码", "text", mimes("text/html", "text/plain"), "html", "htm");
+        register(entries, "text", "文本/代码", "text", mimes("image/svg+xml", "text/plain"), "svg");
+        register(entries, "text", "文本/代码", "text", mimes("text/css", "text/plain"), "css");
+        register(entries, "text", "文本/代码", "text", mimes("application/javascript", "text/javascript", "application/x-javascript", "text/plain"), "js", "mjs", "cjs");
+        register(entries, "text", "文本/代码", "text", mimes(
+                "text/typescript", "application/typescript", "video/mp2t", "text/plain"), "ts", "tsx");
+        register(entries, "text", "文本/代码", "text", mimes("text/jsx", "text/plain"), "jsx");
+        register(entries, "text", "文本/代码", "text", mimes("text/x-java-source", "text/plain"), "java");
+        register(entries, "text", "文本/代码", "text", mimes("text/x-python", "text/plain"), "py");
+        register(entries, "text", "文本/代码", "text", mimes("text/x-go", "text/plain"), "go");
+        register(entries, "text", "文本/代码", "text", mimes("text/x-rust", "text/plain"), "rs");
+        register(entries, "text", "文本/代码", "text", mimes("text/x-c", "text/plain"), "c", "h");
+        register(entries, "text", "文本/代码", "text", mimes("text/x-c++", "text/plain"), "cc", "cpp", "hpp");
+        register(entries, "text", "文本/代码", "text", mimes("application/x-sh", "text/x-shellscript", "text/plain"), "sh", "bash", "zsh");
+        register(entries, "text", "文本/代码", "text", mimes("text/plain", "application/x-powershell"), "ps1");
+
+        register(entries, "image", "图片", "image", mimes("image/jpeg", "image/pjpeg"), "jpg", "jpeg");
+        register(entries, "image", "图片", "image", mimes("image/png"), "png");
+        register(entries, "image", "图片", "image", mimes("image/gif"), "gif");
+        register(entries, "image", "图片", "image", mimes("image/webp"), "webp");
+        register(entries, "image", "图片", "image", mimes("image/avif"), "avif");
+        register(entries, "image", "图片", "image", mimes("image/bmp", "image/x-ms-bmp"), "bmp");
+        register(entries, "image", "图片", "unsupported", mimes("image/tiff"), "tif", "tiff");
+        register(entries, "image", "图片", "unsupported", mimes("image/heic", "image/heic-sequence"), "heic");
+        register(entries, "image", "图片", "unsupported", mimes("image/heif", "image/heif-sequence"), "heif");
+
+        register(entries, "audio", "音频", "audio", mimes("audio/mpeg", "audio/mp3"), "mp3");
+        register(entries, "audio", "音频", "audio", mimes("audio/wav", "audio/x-wav", "audio/wave"), "wav");
+        register(entries, "audio", "音频", "audio", mimes("audio/ogg"), "ogg", "oga", "opus");
+        register(entries, "audio", "音频", "audio", mimes("audio/mp4", "audio/x-m4a"), "m4a");
+        register(entries, "audio", "音频", "audio", mimes("audio/aac", "audio/x-aac"), "aac");
+        register(entries, "audio", "音频", "audio", mimes("audio/flac", "audio/x-flac"), "flac");
+
+        register(entries, "video", "视频", "video", mimes("video/mp4"), "mp4", "m4v");
+        register(entries, "video", "视频", "video", mimes("video/webm"), "webm");
+        register(entries, "video", "视频", "video", mimes("video/quicktime"), "mov");
+        register(entries, "video", "视频", "video", mimes("video/x-msvideo", "video/avi"), "avi");
+        register(entries, "video", "视频", "video", mimes("video/x-matroska"), "mkv");
+
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/zip", "application/x-zip-compressed"), "zip");
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/vnd.rar", "application/x-rar", "application/x-rar-compressed"), "rar");
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/x-7z-compressed"), "7z");
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/x-tar"), "tar");
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/gzip", "application/x-gzip", "application/x-compressed-tar"), "gz", "tgz");
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/x-bzip2"), "bz2");
+        register(entries, "archive", "压缩包", "unsupported", mimes("application/x-xz"), "xz");
+
+        return Collections.unmodifiableMap(entries);
+    }
+
+    /**
+     * Adds one immutable policy entry for each extension and rejects accidental duplicates.
+     */
+    private static void register(
+            Map<String, PolicyEntry> entries,
+            String category,
+            String categoryLabel,
+            String previewMode,
+            Set<String> mimeTypes,
+            String... extensions) {
+        PolicyEntry entry = new PolicyEntry(category, categoryLabel, previewMode, mimeTypes);
+        for (String extension : extensions) {
+            if (entries.put(extension, entry) != null) {
+                throw new IllegalStateException("Duplicate upload extension policy: " + extension);
+            }
+        }
+    }
+
+    /**
+     * Creates an immutable normalized MIME alias set.
+     */
+    private static Set<String> mimes(String... values) {
+        Set<String> result = new LinkedHashSet<>();
+        for (String value : values) {
+            result.add(normalizeMimeType(value));
+        }
+        return Collections.unmodifiableSet(result);
+    }
+
+    private record PolicyEntry(
+            String category,
+            String categoryLabel,
+            String previewMode,
+            Set<String> mimeTypes) {
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/FileUploadServiceTest.java
@@ -534,6 +534,7 @@ class FileUploadServiceTest {
         void shouldCreateDirectUploadSession() {
             TenantContext.setTenantId(77L);
             DirectUploadSessionRequest request = directSessionRequest();
+            request.setContentType("");
             request.getParts().getFirst().setPlainHash("SHA256:" + CHUNK_HASH_0.substring(7));
             request.getParts().getFirst().setCipherHash("SHA256:" + CHUNK_HASH_0.substring(7));
             when(redisStateManager.getState(CLIENT_ID)).thenReturn(null);
@@ -552,6 +553,7 @@ class FileUploadServiceTest {
                     ArgumentCaptor.forClass(CreateDirectMultipartUploadRequest.class);
             verify(fileRemoteClient).createDirectMultipartUpload(storageRequestCaptor.capture());
             assertEquals(CLIENT_ID, storageRequestCaptor.getValue().sessionId());
+            assertEquals("application/octet-stream", storageRequestCaptor.getValue().contentType());
             assertEquals(CHUNK_HASH_0, storageRequestCaptor.getValue().parts().getFirst().objectName());
 
             verify(redisStateManager).saveNewState(
@@ -568,6 +570,23 @@ class FileUploadServiceTest {
             );
             verify(redisStateManager).updateState(argThat(FileUploadState::isDirectUpload));
             verify(quotaService).checkUploadQuota(77L, USER_ID, 1024L);
+        }
+
+        /**
+         * Verifies direct upload rejects a concrete extension and MIME mismatch before storage allocation.
+         */
+        @Test
+        void shouldRejectDirectUploadMimeMismatchBeforeStorage() {
+            DirectUploadSessionRequest request = directSessionRequest();
+            request.setContentType("text/plain");
+
+            GeneralException exception = assertThrows(
+                    GeneralException.class,
+                    () -> fileUploadService.startDirectUpload(USER_ID, request));
+
+            assertEquals(ResultEnum.FILE_ACCEPT_NOT_SUPPORT, exception.getResultEnum());
+            verify(fileRemoteClient, never()).createDirectMultipartUpload(any());
+            verify(redisStateManager, never()).saveNewState(any(), anyString());
         }
 
         /**
@@ -1833,6 +1852,35 @@ class FileUploadServiceTest {
             assertTrue(result.getProcessedChunks().isEmpty());
 
             verify(redisStateManager).saveNewState(any(FileUploadState.class), eq(SUID));
+        }
+
+        /**
+         * Verifies an empty browser MIME falls back to the allowed extension and persists a stable value.
+         */
+        @Test
+        void shouldAcceptEmptyBrowserMimeByExtension() {
+            when(redisStateManager.getSessionIdByFileClientKey(anyLong(), anyString(), anyString()))
+                    .thenReturn(null);
+
+            fileUploadService.startUpload(USER_ID, "notes.md", 1024L, "", null, 1024, 1);
+
+            verify(redisStateManager).saveNewState(
+                    argThat(state -> "application/octet-stream".equals(state.getContentType())),
+                    eq(SUID));
+        }
+
+        /**
+         * Verifies a concrete MIME conflict is rejected before any session is persisted.
+         */
+        @Test
+        void shouldRejectConcreteMimeMismatchBeforeSessionPersistence() {
+            GeneralException exception = assertThrows(
+                    GeneralException.class,
+                    () -> fileUploadService.startUpload(
+                            USER_ID, "report.pdf", 1024L, "text/plain", null, 1024, 1));
+
+            assertEquals(ResultEnum.FILE_ACCEPT_NOT_SUPPORT, exception.getResultEnum());
+            verify(redisStateManager, never()).saveNewState(any(), anyString());
         }
 
         /**

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/upload/FileUploadPolicyRegistryTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/upload/FileUploadPolicyRegistryTest.java
@@ -1,0 +1,111 @@
+package cn.flying.service.upload;
+
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.exception.GeneralException;
+import cn.flying.dao.vo.file.UploadFileTypePolicyVO;
+import cn.flying.dao.vo.file.UploadPolicyVO;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the server-authoritative upload extension and MIME policy matrix.
+ */
+class FileUploadPolicyRegistryTest {
+
+    /**
+     * Verifies every published extension accepts its own aliases and browser fallback MIME values.
+     */
+    @Test
+    void shouldAcceptEveryPublishedExtensionWithCompatibleOrGenericMime() {
+        UploadPolicyVO policy = FileUploadPolicyRegistry.toView(4096L);
+
+        assertEquals(4096L, policy.maxFileSizeBytes());
+        assertTrue(policy.fileTypes().size() >= 70);
+        for (UploadFileTypePolicyVO fileType : policy.fileTypes()) {
+            String fileName = "sample." + fileType.extension().toUpperCase();
+            assertFalse(fileType.mimeTypes().isEmpty());
+            assertDoesNotThrow(() -> FileUploadPolicyRegistry.validate(fileName, fileType.mimeTypes().getFirst()));
+            assertDoesNotThrow(() -> FileUploadPolicyRegistry.validate(fileName, ""));
+            assertDoesNotThrow(() -> FileUploadPolicyRegistry.validate(fileName, null));
+            assertDoesNotThrow(() -> FileUploadPolicyRegistry.validate(fileName, "application/octet-stream"));
+        }
+    }
+
+    /**
+     * Verifies MIME normalization removes case, whitespace, and parameters without widening compatibility.
+     */
+    @Test
+    void shouldNormalizeMimeParametersAndRejectConcreteMismatch() {
+        assertDoesNotThrow(() -> FileUploadPolicyRegistry.validate(
+                "report.JSON", " Application/JSON ; charset=UTF-8"));
+
+        GeneralException mismatch = assertThrows(GeneralException.class,
+                () -> FileUploadPolicyRegistry.validate("report.pdf", "text/plain"));
+        assertEquals(ResultEnum.FILE_ACCEPT_NOT_SUPPORT, mismatch.getResultEnum());
+        assertTrue(String.valueOf(mismatch.getData()).contains(".pdf"));
+        assertTrue(String.valueOf(mismatch.getData()).contains("text/plain"));
+        assertTrue(String.valueOf(mismatch.getData()).contains("可上传类型"));
+    }
+
+    /**
+     * Verifies malformed concrete MIME values fail without reflecting control characters.
+     */
+    @Test
+    void shouldRejectMalformedMimeWithoutReflectingIt() {
+        String malformedMime = "text/plain\nforged-log-line";
+
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> FileUploadPolicyRegistry.validate("notes.txt", malformedMime));
+
+        assertEquals(ResultEnum.FILE_ACCEPT_NOT_SUPPORT, exception.getResultEnum());
+        assertTrue(String.valueOf(exception.getData()).contains("内容类型格式无效"));
+        assertFalse(String.valueOf(exception.getData()).contains(malformedMime));
+    }
+
+    /**
+     * Verifies executable, installer, disk-image, absent, and missing extensions remain fail closed.
+     */
+    @Test
+    void shouldRejectExcludedOrMissingExtensionsEvenWhenMimeLooksAllowed() {
+        for (String fileName : List.of(
+                "payload.exe", "library.dll", "installer.msi", "mobile.apk",
+                "disk.iso", "virtual.qcow2", "archive.jar", "README")) {
+            GeneralException exception = assertThrows(GeneralException.class,
+                    () -> FileUploadPolicyRegistry.validate(fileName, "image/png"));
+            assertEquals(ResultEnum.FILE_ACCEPT_NOT_SUPPORT, exception.getResultEnum());
+            assertTrue(String.valueOf(exception.getData()).contains("可上传类型"));
+        }
+    }
+
+    /**
+     * Verifies active text formats are published only as escaped-text preview modes.
+     */
+    @Test
+    void shouldPublishActiveFormatsAsTextOnly() {
+        UploadPolicyVO policy = FileUploadPolicyRegistry.toView(1L);
+
+        for (String extension : List.of("html", "htm", "svg", "js", "mjs", "cjs")) {
+            UploadFileTypePolicyVO fileType = policy.fileTypes().stream()
+                    .filter(candidate -> extension.equals(candidate.extension()))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals("text", fileType.previewMode());
+        }
+    }
+
+    /**
+     * Verifies empty browser MIME values are persisted as a stable generic binary MIME.
+     */
+    @Test
+    void shouldNormalizeEmptyMimeForPersistence() {
+        assertEquals("application/octet-stream", FileUploadPolicyRegistry.normalizeForPersistence(null));
+        assertEquals("text/plain", FileUploadPolicyRegistry.normalizeForPersistence("Text/Plain; charset=utf-8"));
+    }
+}

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/UploadSessionController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/UploadSessionController.java
@@ -15,6 +15,7 @@ import cn.flying.dao.vo.file.FileUploadStatusVO;
 import cn.flying.dao.vo.file.ProgressVO;
 import cn.flying.dao.vo.file.ResumeUploadVO;
 import cn.flying.dao.vo.file.StartUploadVO;
+import cn.flying.dao.vo.file.UploadPolicyVO;
 import cn.flying.service.FileUploadService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -54,6 +55,18 @@ public class UploadSessionController {
     private final FileUploadService fileUploadService;
 
     /**
+     * Returns the current server-authoritative upload and preview policy.
+     *
+     * @return upload policy
+     */
+    @GetMapping("/policy")
+    @Operation(summary = "获取上传策略")
+    @OperationLog(module = "文件分片上传模块", operationType = "查询", description = "获取上传策略")
+    public Result<UploadPolicyVO> getUploadPolicy() {
+        return Result.success(fileUploadService.getUploadPolicy());
+    }
+
+    /**
      * 创建上传会话。
      *
      * @param userId           用户 ID
@@ -75,7 +88,8 @@ public class UploadSessionController {
             @Pattern(regexp = "^[\\p{IsHan}a-zA-Z0-9\\u4e00-\\u9fa5._\\-\\s,;!@#$%&()+=]+$")
             String fileName,
             @Schema(description = "文件大小") @RequestParam("fileSize") @Min(1) @Max(4294967296L) long fileSize,
-            @Schema(description = "文件类型") @RequestParam(value = "contentType") @NotBlank String contentType,
+            @Schema(description = "文件类型；浏览器未提供时可为空")
+            @RequestParam(value = "contentType", required = false) @Size(max = 255) String contentType,
             @Schema(description = "客户端ID") @RequestParam(value = "clientId", required = false)
             @Pattern(regexp = "^[A-Za-z0-9-]{1,64}$", message = "clientId 格式无效") String providedClientId,
             @Schema(description = "分片大小") @RequestParam(value = "chunkSize") @Min(1) @Max(83886080) int chunkSize,

--- a/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
@@ -515,10 +515,35 @@ class OpenApiContractExportTest {
                 directSessionRequestSchema,
                 "fileName",
                 "fileSize",
-                "contentType",
                 "chunkSize",
                 "totalChunks",
                 "parts");
+        assertThat(directSessionRequestSchema.path("properties").has("contentType")).isTrue();
+        assertThat(directSessionRequestSchema.path("properties").path("contentType")
+                .path("maxLength").asInt()).isEqualTo(255);
+        JsonNode uploadPolicyOperation = rootNode.path("paths")
+                .path("/api/v1/upload-sessions/policy").path("get");
+        assertThat(uploadPolicyOperation.isMissingNode()).isFalse();
+        assertThat(uploadPolicyOperation.path("responses").path("200")
+                .path("content").path("*/*").path("schema").path("$ref").asText())
+                .isEqualTo("#/components/schemas/ResultUploadPolicyVO");
+        assertProtectedOperation(rootNode, "/api/v1/upload-sessions/policy", "get");
+        JsonNode uploadPolicySchema = rootNode.path("components").path("schemas").path("UploadPolicyVO");
+        assertRequiredFields(uploadPolicySchema, "maxFileSizeBytes", "fileTypes");
+        JsonNode uploadFileTypePolicySchema = rootNode.path("components").path("schemas")
+                .path("UploadFileTypePolicyVO");
+        assertRequiredFields(
+                uploadFileTypePolicySchema,
+                "extension",
+                "category",
+                "categoryLabel",
+                "previewMode",
+                "mimeTypes");
+        List<String> previewModes = new ArrayList<>();
+        uploadFileTypePolicySchema.path("properties").path("previewMode").path("enum")
+                .forEach(value -> previewModes.add(value.asText()));
+        assertThat(previewModes)
+                .containsExactlyInAnyOrder("image", "video", "audio", "pdf", "text", "unsupported");
         assertRequiredFields(
                 rootNode.path("components").path("schemas").path("DirectUploadPartUrlVO"),
                 "index",

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/UploadSessionControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/UploadSessionControllerTest.java
@@ -9,6 +9,7 @@ import cn.flying.dao.vo.file.FileUploadStatusVO;
 import cn.flying.dao.vo.file.ProgressVO;
 import cn.flying.dao.vo.file.ResumeUploadVO;
 import cn.flying.dao.vo.file.StartUploadVO;
+import cn.flying.dao.vo.file.UploadPolicyVO;
 import cn.flying.service.FileUploadService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,6 +94,20 @@ class UploadSessionControllerTest {
         verify(fileUploadService).completeUpload(userId, clientId);
         verify(fileUploadService).pauseUpload(userId, clientId);
         verify(fileUploadService).uploadChunk(eq(userId), eq(clientId), eq(1), any());
+    }
+
+    /**
+     * Verifies the authenticated policy endpoint delegates to the upload service.
+     */
+    @Test
+    void shouldReturnUploadPolicy() {
+        UploadPolicyVO policy = new UploadPolicyVO(4096L, List.of());
+        when(fileUploadService.getUploadPolicy()).thenReturn(policy);
+
+        Result<UploadPolicyVO> result = controller.getUploadPolicy();
+
+        assertEquals(policy, result.getData());
+        verify(fileUploadService).getUploadPolicy();
     }
 
     /**

--- a/platform-frontend/src/lib/api/endpoints/upload.test.ts
+++ b/platform-frontend/src/lib/api/endpoints/upload.test.ts
@@ -38,6 +38,14 @@ describe("upload endpoints", () => {
     vi.unstubAllGlobals();
   });
 
+  it("getUploadPolicy 应读取服务器权威上传策略", async () => {
+    const policy = { maxFileSizeBytes: 1024, fileTypes: [] };
+    clientMocks.api.get.mockResolvedValue(policy);
+
+    await expect(uploadApi.getUploadPolicy()).resolves.toEqual(policy);
+    expect(clientMocks.api.get).toHaveBeenCalledWith("/upload-sessions/policy");
+  });
+
   it("startUpload 应使用 URLSearchParams 适配后端 @RequestParam", async () => {
     clientMocks.api.post.mockResolvedValue({
       clientId: "c1",

--- a/platform-frontend/src/lib/api/endpoints/upload.ts
+++ b/platform-frontend/src/lib/api/endpoints/upload.ts
@@ -9,10 +9,18 @@ import type {
   DirectUploadSessionVO,
   DirectUploadCompleteRequest,
   DirectUploadCompleteVO,
+  UploadPolicyVO,
 } from "../types";
 
 const BASE = "/upload-sessions";
 const DIRECT_UPLOAD_ETAG_PATTERN = /^[\x21-\x7e]{1,255}$/;
+
+/**
+ * Loads the current server-authoritative upload and preview policy.
+ */
+export async function getUploadPolicy(): Promise<UploadPolicyVO> {
+  return api.get<UploadPolicyVO>(`${BASE}/policy`);
+}
 
 /**
  * 开始上传（初始化或恢复）。

--- a/platform-frontend/src/lib/api/types/files.ts
+++ b/platform-frontend/src/lib/api/types/files.ts
@@ -8,6 +8,18 @@ type RequiredFields<T, K extends keyof T> = Omit<T, K> & {
 };
 
 /**
+ * Server-authoritative upload file type policy.
+ * @see UploadFileTypePolicyVO.java
+ */
+export type UploadFileTypePolicyVO = OpenApiSchema<"UploadFileTypePolicyVO">;
+
+/**
+ * Server-authoritative upload policy.
+ * @see UploadPolicyVO.java
+ */
+export type UploadPolicyVO = OpenApiSchema<"UploadPolicyVO">;
+
+/**
  * 文件信息
  * @see FileVO.java
  */

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -2809,6 +2809,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/upload-sessions/policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 获取上传策略 */
+        get: operations["getUploadPolicy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/upload-sessions/{clientId}": {
         parameters: {
             query?: never;
@@ -3940,8 +3957,8 @@ export interface components {
             chunkSize: number;
             /** @description 客户端会话 ID */
             clientId?: string;
-            /** @description 文件类型 */
-            contentType: string;
+            /** @description 文件类型；浏览器未提供时可为空 */
+            contentType?: string;
             /** @description 目标文件ID（可选） */
             fileId?: string;
             /** @description 文件名 */
@@ -6497,6 +6514,17 @@ export interface components {
             message?: string;
         };
         /** @description 返回结果封装 */
+        ResultUploadPolicyVO: {
+            /**
+             * Format: int32
+             * @description 操作代码
+             */
+            code?: number;
+            data?: components["schemas"]["UploadPolicyVO"];
+            /** @description 提示信息 */
+            message?: string;
+        };
+        /** @description 返回结果封装 */
         ResultUserFileStatsVO: {
             /**
              * Format: int32
@@ -7186,6 +7214,42 @@ export interface components {
             avatar?: string;
             /** @description 昵称（预留字段） */
             nickname?: string;
+        };
+        /** @description 上传文件类型策略 */
+        UploadFileTypePolicyVO: {
+            /**
+             * @description 能力分组编码
+             * @example document
+             */
+            category: string;
+            /**
+             * @description 能力分组名称
+             * @example 文档
+             */
+            categoryLabel: string;
+            /**
+             * @description 不含点号的小写文件扩展名
+             * @example pdf
+             */
+            extension: string;
+            /** @description 与扩展名兼容的具体 MIME 别名 */
+            mimeTypes: string[];
+            /**
+             * @description 预览模式
+             * @enum {string}
+             */
+            previewMode: "image" | "video" | "audio" | "pdf" | "text" | "unsupported";
+        };
+        /** @description 上传策略 */
+        UploadPolicyVO: {
+            /** @description 允许的文件类型及预览能力 */
+            fileTypes: components["schemas"]["UploadFileTypePolicyVO"][];
+            /**
+             * Format: int64
+             * @description 单文件最大字节数
+             * @example 4294967296
+             */
+            maxFileSizeBytes: number;
         };
         /** @description 用户文件统计信息 */
         UserFileStatsVO: {
@@ -11288,8 +11352,8 @@ export interface operations {
                 chunkSize: string;
                 /** @description 客户端ID */
                 clientId?: string;
-                /** @description 文件类型 */
-                contentType: string;
+                /** @description 文件类型；浏览器未提供时可为空 */
+                contentType?: string;
                 /** @description 目标文件ID（可选） */
                 fileId?: string;
                 /** @description 文件名 */
@@ -11336,6 +11400,26 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["ResultDirectUploadSessionVO"];
+                };
+            };
+        };
+    };
+    getUploadPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ResultUploadPolicyVO"];
                 };
             };
         };

--- a/platform-frontend/src/lib/components/FilePreview.render.test.ts
+++ b/platform-frontend/src/lib/components/FilePreview.render.test.ts
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchText: vi.fn(),
+}));
+
+vi.mock("$api/client", () => ({
+  api: apiMocks,
+}));
+
+import FilePreview from "./FilePreview.svelte";
+
+describe("FilePreview", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [
+      "active.svg",
+      "image/svg+xml",
+      '<svg onload="window.__executed=true"><script>window.__executed=true</script><image href="https://invalid.example/track" /></svg>',
+    ],
+    [
+      "active.html",
+      "text/html",
+      '<script>window.__executed=true</script><img src="https://invalid.example/track" onerror="window.__executed=true">',
+    ],
+  ])(
+    "renders hostile %s bytes only as escaped text",
+    async (fileName, contentType, activePayload) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(new Response(activePayload, { status: 200 })),
+      );
+
+      const view = render(FilePreview, {
+        url: "blob:https://example.test/active",
+        fileName,
+        contentType,
+      });
+
+      await waitFor(() => expect(view.getByText(activePayload)).toBeTruthy());
+      expect(view.container.querySelector("script")).toBeNull();
+      expect(view.container.querySelector("image")).toBeNull();
+      expect(view.container.querySelector("img")).toBeNull();
+      expect(apiMocks.fetchText).not.toHaveBeenCalled();
+    },
+  );
+
+  it("falls back to an explicit download action after native decode failure", async () => {
+    const view = render(FilePreview, {
+      url: "blob:https://example.test/photo",
+      fileName: "photo.webp",
+      contentType: "image/webp",
+    });
+
+    const image = view.getByRole("img", { name: "photo.webp" });
+    await fireEvent.error(image);
+
+    expect(view.getByText("浏览器无法解码此文件")).toBeTruthy();
+    const download = view.getByRole("link", { name: "下载文件" });
+    expect(download.getAttribute("download")).toBe("photo.webp");
+  });
+
+  it("does not advertise metadata-only documents as previewable", () => {
+    const view = render(FilePreview, {
+      url: "blob:https://example.test/document",
+      fileName: "report.docx",
+      contentType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+
+    expect(view.getByText("此文件类型不支持预览")).toBeTruthy();
+    expect(view.getByRole("link", { name: "下载文件" })).toBeTruthy();
+  });
+
+  it("resets a native decode failure and reloads text when the source changes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("next text", { status: 200 })),
+    );
+    const view = render(FilePreview, {
+      url: "blob:https://example.test/photo",
+      fileName: "photo.webp",
+      contentType: "image/webp",
+    });
+
+    await fireEvent.error(view.getByRole("img", { name: "photo.webp" }));
+    expect(view.getByText("浏览器无法解码此文件")).toBeTruthy();
+
+    await view.rerender({
+      url: "blob:https://example.test/next",
+      fileName: "next.txt",
+      contentType: "text/plain",
+    });
+
+    await waitFor(() => expect(view.getByText("next text")).toBeTruthy());
+    expect(view.queryByText("浏览器无法解码此文件")).toBeNull();
+  });
+});

--- a/platform-frontend/src/lib/components/FilePreview.svelte
+++ b/platform-frontend/src/lib/components/FilePreview.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { api } from "$api/client";
-  import { loadPreviewText } from "$utils/file-preview";
+  import { classifyFilePreview, loadPreviewText } from "$utils/file-preview";
 
   interface Props {
     url: string;
@@ -15,50 +14,49 @@
   let textContent = $state("");
   let loadingText = $state(false);
   let textError = $state<string | null>(null);
+  let nativePreviewError = $state(false);
 
-  // 根据 contentType 判断预览类型
-  const previewType = $derived(getPreviewType(contentType));
+  const previewType = $derived(classifyFilePreview(fileName, contentType));
 
-  function getPreviewType(
-    type: string,
-  ): "image" | "video" | "audio" | "pdf" | "text" | "unsupported" {
-    if (type.startsWith("image/")) return "image";
-    if (type.startsWith("video/")) return "video";
-    if (type.startsWith("audio/")) return "audio";
-    if (type === "application/pdf") return "pdf";
-    if (
-      type.startsWith("text/") ||
-      type === "application/json" ||
-      type === "application/xml" ||
-      type === "application/javascript"
-    ) {
-      return "text";
+  $effect(() => {
+    const sourceUrl = url;
+    const sourceFileName = fileName;
+    const sourceContentType = contentType;
+    const sourcePreviewType = previewType;
+    let cancelled = false;
+
+    // Reset state whenever a reused preview component receives another file.
+    void sourceFileName;
+    void sourceContentType;
+    nativePreviewError = false;
+    textContent = "";
+    textError = null;
+    loadingText = sourcePreviewType === "text";
+    if (sourcePreviewType === "text") {
+      void loadTextContent(sourceUrl, () => cancelled);
     }
-    return "unsupported";
-  }
 
-  onMount(() => {
-    if (previewType === "text") {
-      loadTextContent();
-    }
+    return () => {
+      cancelled = true;
+    };
   });
 
-  async function loadTextContent() {
-    loadingText = true;
-    textError = null;
+  /** Loads one captured text source and ignores completion after the source changes. */
+  async function loadTextContent(
+    sourceUrl: string,
+    isCancelled: () => boolean,
+  ): Promise<void> {
     try {
-      const text = await loadPreviewText(url, (requestUrl) =>
+      const text = await loadPreviewText(sourceUrl, (requestUrl) =>
         api.fetchText(requestUrl),
       );
-      // 为提升性能限制文本长度
-      textContent =
-        text.length > 100000
-          ? text.slice(0, 100000) + "\n\n... (内容过长，已截断)"
-          : text;
+      if (!isCancelled()) textContent = text;
     } catch (err) {
-      textError = err instanceof Error ? err.message : "加载失败";
+      if (!isCancelled()) {
+        textError = err instanceof Error ? err.message : "加载失败";
+      }
     } finally {
-      loadingText = false;
+      if (!isCancelled()) loadingText = false;
     }
   }
 
@@ -76,12 +74,23 @@
 </script>
 
 <div class="file-preview {className}">
-  {#if previewType === "image"}
+  {#if nativePreviewError}
+    <div
+      class="bg-muted/30 flex flex-col items-center justify-center gap-4 rounded-lg border p-12"
+    >
+      <p class="font-medium">浏览器无法解码此文件</p>
+      <p class="text-muted-foreground text-sm">可下载后使用本地应用打开</p>
+      <a class="text-primary text-sm underline" href={url} download={fileName}
+        >下载文件</a
+      >
+    </div>
+  {:else if previewType === "image"}
     <div class="bg-muted/30 flex items-center justify-center p-4">
       <img
         src={url}
         alt={fileName}
         class="max-h-[70vh] max-w-full rounded-lg object-contain shadow-lg"
+        onerror={() => (nativePreviewError = true)}
       />
     </div>
   {:else if previewType === "video"}
@@ -91,6 +100,7 @@
         controls
         class="max-h-[70vh] max-w-full rounded-lg"
         preload="metadata"
+        onerror={() => (nativePreviewError = true)}
       >
         <track kind="captions" />
         您的浏览器不支持视频播放
@@ -118,7 +128,12 @@
         </svg>
       </div>
       <p class="text-sm font-medium">{fileName}</p>
-      <audio src={url} controls class="w-full max-w-md">
+      <audio
+        src={url}
+        controls
+        class="w-full max-w-md"
+        onerror={() => (nativePreviewError = true)}
+      >
         您的浏览器不支持音频播放
       </audio>
     </div>
@@ -172,6 +187,9 @@
       </div>
       <p class="text-muted-foreground">此文件类型不支持预览</p>
       <p class="text-muted-foreground text-sm">{contentType}</p>
+      <a class="text-primary text-sm underline" href={url} download={fileName}
+        >下载文件</a
+      >
     </div>
   {/if}
 </div>

--- a/platform-frontend/src/lib/utils/file-preview.test.ts
+++ b/platform-frontend/src/lib/utils/file-preview.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { loadPreviewText } from "./file-preview";
+import {
+  classifyFilePreview,
+  isFilePreviewable,
+  loadPreviewText,
+  TEXT_PREVIEW_TRUNCATION_NOTICE,
+} from "./file-preview";
 
 describe("loadPreviewText", () => {
   it.each(["blob:https://example.test/file", "data:text/plain,hello"])(
@@ -50,4 +55,54 @@ describe("loadPreviewText", () => {
       loadPreviewText("blob:https://example.test/file", vi.fn(), nativeFetch),
     ).rejects.toThrow("请求失败 (400)");
   });
+
+  it("decodes only the bounded prefix of native blob content", async () => {
+    const nativeFetch = vi.fn().mockResolvedValue(
+      new Response("0123456789", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+
+    await expect(
+      loadPreviewText(
+        "blob:https://example.test/file",
+        vi.fn(),
+        nativeFetch,
+        4,
+      ),
+    ).resolves.toBe(`0123${TEXT_PREVIEW_TRUNCATION_NOTICE}`);
+  });
+});
+
+describe("classifyFilePreview", () => {
+  it.each([
+    ["photo.JPG", "image/jpeg", "image"],
+    ["paper.pdf", "application/pdf", "pdf"],
+    ["song.mp3", "audio/mpeg", "audio"],
+    ["clip.webm", "video/webm", "video"],
+    ["data.json", "application/json", "text"],
+  ] as const)("classifies %s as %s", (fileName, contentType, expected) => {
+    expect(classifyFilePreview(fileName, contentType)).toBe(expected);
+    expect(isFilePreviewable(fileName, contentType)).toBe(true);
+  });
+
+  it.each(["payload.html", "vector.svg", "script.js", "module.mjs"])(
+    "forces active content %s into escaped text mode",
+    (fileName) => {
+      expect(classifyFilePreview(fileName, "image/svg+xml")).toBe("text");
+    },
+  );
+
+  it.each(["archive.zip", "report.docx", "photo.tiff", "image.heic"])(
+    "keeps metadata-only format %s unsupported inline",
+    (fileName) => {
+      expect(classifyFilePreview(fileName, "application/octet-stream")).toBe(
+        "unsupported",
+      );
+      expect(isFilePreviewable(fileName, "application/octet-stream")).toBe(
+        false,
+      );
+    },
+  );
 });

--- a/platform-frontend/src/lib/utils/file-preview.ts
+++ b/platform-frontend/src/lib/utils/file-preview.ts
@@ -2,7 +2,125 @@ export type PlatformTextFetcher = (url: string) => Promise<string>;
 
 export type NativePreviewFetcher = (
   url: string,
-) => Promise<Pick<Response, "ok" | "status" | "text">>;
+) => Promise<Pick<Response, "ok" | "status" | "blob">>;
+
+export const MAX_TEXT_PREVIEW_BYTES = 100_000;
+export const TEXT_PREVIEW_TRUNCATION_NOTICE =
+  "\n\n... (内容过长，仅显示前 100000 字节)";
+
+export type FilePreviewType =
+  | "image"
+  | "video"
+  | "audio"
+  | "pdf"
+  | "text"
+  | "unsupported";
+
+const NATIVE_IMAGE_EXTENSIONS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "avif",
+  "bmp",
+]);
+const NATIVE_AUDIO_EXTENSIONS = new Set([
+  "mp3",
+  "wav",
+  "ogg",
+  "oga",
+  "m4a",
+  "aac",
+  "flac",
+  "opus",
+]);
+const NATIVE_VIDEO_EXTENSIONS = new Set([
+  "mp4",
+  "m4v",
+  "webm",
+  "mov",
+  "avi",
+  "mkv",
+]);
+const TEXT_EXTENSIONS = new Set([
+  "txt",
+  "md",
+  "csv",
+  "tsv",
+  "json",
+  "jsonl",
+  "xml",
+  "yaml",
+  "yml",
+  "log",
+  "ini",
+  "conf",
+  "properties",
+  "sql",
+  "html",
+  "htm",
+  "svg",
+  "css",
+  "js",
+  "mjs",
+  "cjs",
+  "ts",
+  "tsx",
+  "jsx",
+  "java",
+  "py",
+  "go",
+  "rs",
+  "c",
+  "cc",
+  "cpp",
+  "h",
+  "hpp",
+  "sh",
+  "bash",
+  "zsh",
+  "ps1",
+]);
+
+/**
+ * Extracts a lowercase extension without the leading dot.
+ */
+export function getFileExtension(fileName: string): string | null {
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) return null;
+  return fileName.slice(dotIndex + 1).toLowerCase();
+}
+
+/**
+ * Classifies previews by the filename policy so active SVG/HTML content is always escaped text.
+ */
+export function classifyFilePreview(
+  fileName: string,
+  contentType: string,
+): FilePreviewType {
+  const extension = getFileExtension(fileName);
+  if (!extension) return "unsupported";
+  if (TEXT_EXTENSIONS.has(extension)) return "text";
+  if (extension === "pdf") return "pdf";
+  if (NATIVE_IMAGE_EXTENSIONS.has(extension)) return "image";
+  if (NATIVE_AUDIO_EXTENSIONS.has(extension)) return "audio";
+  if (NATIVE_VIDEO_EXTENSIONS.has(extension)) return "video";
+
+  const normalizedType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+  if (normalizedType === "application/pdf" && extension === "pdf") return "pdf";
+  return "unsupported";
+}
+
+/**
+ * Reports whether the shared preview component can safely render a file inline.
+ */
+export function isFilePreviewable(
+  fileName: string,
+  contentType: string,
+): boolean {
+  return classifyFilePreview(fileName, contentType) !== "unsupported";
+}
 
 /**
  * Loads preview text without routing already-decrypted same-document URLs through the API client.
@@ -11,6 +129,7 @@ export async function loadPreviewText(
   url: string,
   platformFetchText: PlatformTextFetcher,
   nativeFetch: NativePreviewFetcher = globalThis.fetch,
+  maxBytes = MAX_TEXT_PREVIEW_BYTES,
 ): Promise<string> {
   if (!url.startsWith("blob:") && !url.startsWith("data:")) {
     return platformFetchText(url);
@@ -20,5 +139,10 @@ export async function loadPreviewText(
   if (!response.ok) {
     throw new Error(`请求失败 (${response.status})`);
   }
-  return response.text();
+  const source = await response.blob();
+  const boundedBytes = Math.max(0, maxBytes);
+  const text = await source.slice(0, boundedBytes).text();
+  return source.size > boundedBytes
+    ? text + TEXT_PREVIEW_TRUNCATION_NOTICE
+    : text;
 }

--- a/platform-frontend/src/lib/utils/upload-policy.test.ts
+++ b/platform-frontend/src/lib/utils/upload-policy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { UploadPolicyVO } from "$api/types";
+import {
+  buildUploadAccept,
+  describeUploadPolicy,
+  normalizeUploadMime,
+  validateFileAgainstUploadPolicy,
+} from "./upload-policy";
+
+const policy: UploadPolicyVO = {
+  maxFileSizeBytes: 1024,
+  fileTypes: [
+    {
+      extension: "pdf",
+      category: "document",
+      categoryLabel: "文档",
+      previewMode: "pdf",
+      mimeTypes: ["application/pdf"],
+    },
+    {
+      extension: "svg",
+      category: "text",
+      categoryLabel: "文本/代码",
+      previewMode: "text",
+      mimeTypes: ["image/svg+xml", "text/plain"],
+    },
+  ],
+};
+
+describe("upload policy", () => {
+  it("builds accept and category copy from the server response", () => {
+    expect(buildUploadAccept(policy)).toBe(".pdf,.svg");
+    expect(describeUploadPolicy(policy)).toBe("文档、文本/代码");
+  });
+
+  it("accepts empty and generic MIME but rejects concrete conflicts", () => {
+    expect(
+      validateFileAgainstUploadPolicy(
+        { name: "paper.pdf", size: 10, type: "" },
+        policy,
+      ),
+    ).toBeNull();
+    expect(
+      validateFileAgainstUploadPolicy(
+        {
+          name: "paper.PDF",
+          size: 10,
+          type: "application/octet-stream",
+        },
+        policy,
+      ),
+    ).toBeNull();
+    expect(
+      validateFileAgainstUploadPolicy(
+        { name: "paper.pdf", size: 10, type: "text/plain" },
+        policy,
+      ),
+    ).toContain("不匹配；可上传类型：文档、文本/代码");
+  });
+
+  it("rejects missing, unknown, and oversized files before upload", () => {
+    expect(
+      validateFileAgainstUploadPolicy(
+        { name: "README", size: 10, type: "text/plain" },
+        policy,
+      ),
+    ).toContain("缺少有效扩展名；可上传类型：文档、文本/代码");
+    expect(
+      validateFileAgainstUploadPolicy(
+        { name: "payload.exe", size: 10, type: "image/png" },
+        policy,
+      ),
+    ).toContain(".exe；可上传类型：文档、文本/代码");
+    expect(
+      validateFileAgainstUploadPolicy(
+        { name: "paper.pdf", size: 2048, type: "application/pdf" },
+        policy,
+      ),
+    ).toContain("1024");
+  });
+
+  it("normalizes MIME parameters", () => {
+    expect(normalizeUploadMime(" Application/PDF ; charset=binary")).toBe(
+      "application/pdf",
+    );
+  });
+});

--- a/platform-frontend/src/lib/utils/upload-policy.ts
+++ b/platform-frontend/src/lib/utils/upload-policy.ts
@@ -1,0 +1,59 @@
+import type { UploadPolicyVO } from "$api/types";
+import { getFileExtension } from "$utils/file-preview";
+
+const GENERIC_BINARY_MIME = "application/octet-stream";
+
+/**
+ * Normalizes browser MIME values for comparison with the server policy.
+ */
+export function normalizeUploadMime(contentType: string): string {
+  return (contentType.split(";", 1)[0] ?? "").trim().toLowerCase();
+}
+
+/**
+ * Builds the file input accept contract from server-authorized extensions.
+ */
+export function buildUploadAccept(policy: UploadPolicyVO): string {
+  return policy.fileTypes.map((fileType) => `.${fileType.extension}`).join(",");
+}
+
+/**
+ * Produces a stable human-readable category summary from the server policy.
+ */
+export function describeUploadPolicy(policy: UploadPolicyVO): string {
+  return [
+    ...new Set(policy.fileTypes.map((fileType) => fileType.categoryLabel)),
+  ].join("、");
+}
+
+/**
+ * Performs a fast client-side mirror of the authoritative extension and MIME checks.
+ */
+export function validateFileAgainstUploadPolicy(
+  file: Pick<File, "name" | "size" | "type">,
+  policy: UploadPolicyVO,
+): string | null {
+  if (file.size > policy.maxFileSizeBytes) {
+    return `文件超过 ${policy.maxFileSizeBytes} 字节限制`;
+  }
+  const extension = getFileExtension(file.name);
+  const categorySummary =
+    describeUploadPolicy(policy) || "服务器允许的文件类型";
+  if (!extension) {
+    return `文件缺少有效扩展名；可上传类型：${categorySummary}`;
+  }
+  const fileType = policy.fileTypes.find(
+    (candidate) => candidate.extension === extension,
+  );
+  if (!fileType) {
+    return `不支持的文件扩展名 .${extension}；可上传类型：${categorySummary}`;
+  }
+  const normalizedMime = normalizeUploadMime(file.type);
+  if (!normalizedMime || normalizedMime === GENERIC_BINARY_MIME) {
+    return null;
+  }
+  if (!fileType.mimeTypes.includes(normalizedMime)) {
+    return `文件扩展名 .${extension} 与内容类型 ${normalizedMime} 不匹配；可上传类型：${categorySummary}`;
+  }
+  return null;
+}

--- a/platform-frontend/src/routes/(app)/admin/files/+page.svelte
+++ b/platform-frontend/src/routes/(app)/admin/files/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import { useNotifications } from "$stores/notifications.svelte";
   import { formatFileSize, formatDateTime } from "$utils/format";
+  import { isFilePreviewable } from "$utils/file-preview";
   import {
     getAllFiles,
     getFileDetail,
@@ -345,18 +346,6 @@
     if (previewUrl) URL.revokeObjectURL(previewUrl);
   });
 
-  function isPreviewable(contentType: string): boolean {
-    return (
-      contentType.startsWith("image/") ||
-      contentType.startsWith("video/") ||
-      contentType.startsWith("audio/") ||
-      contentType === "application/pdf" ||
-      contentType.startsWith("text/") ||
-      contentType === "application/json" ||
-      contentType === "application/xml"
-    );
-  }
-
   function getStatusBadgeVariant(
     status: number,
   ): "default" | "secondary" | "destructive" | "outline" {
@@ -504,7 +493,7 @@
                     </Table.Cell>
                     <Table.Cell class="text-right">
                       <div class="flex justify-end gap-1">
-                        {#if file.status === AdminFileStatus.COMPLETED && isPreviewable(file.contentType)}
+                        {#if file.status === AdminFileStatus.COMPLETED && isFilePreviewable(file.fileName, file.contentType)}
                           <Button
                             variant="ghost"
                             size="sm"
@@ -979,7 +968,7 @@
         <div class="flex items-center justify-between">
           <div class="flex gap-2">
             {#if selectedFile.status === AdminFileStatus.COMPLETED}
-              {#if isPreviewable(selectedFile.contentType)}
+              {#if isFilePreviewable(selectedFile.fileName, selectedFile.contentType)}
                 <Button
                   variant="outline"
                   onclick={() =>

--- a/platform-frontend/src/routes/(app)/files/[hash]/+page.svelte
+++ b/platform-frontend/src/routes/(app)/files/[hash]/+page.svelte
@@ -7,6 +7,7 @@
   import { useDownload } from "$stores/download.svelte";
   import { formatFileSize, formatDateTime } from "$utils/format";
   import { getAvatarUrl } from "$utils/avatar";
+  import { isFilePreviewable } from "$utils/file-preview";
   import {
     getFileByHash,
     getTransaction,
@@ -68,22 +69,9 @@
   let isSharingToFriend = $state(false);
   let friendSearchKeyword = $state("");
 
-  // 检查文件类型是否支持预览
-  const canPreview = $derived(file && isPreviewable(file.contentType));
-
-  function isPreviewable(contentType: string): boolean {
-    if (!contentType) return false;
-    return (
-      contentType.startsWith("image/") ||
-      contentType.startsWith("video/") ||
-      contentType.startsWith("audio/") ||
-      contentType.startsWith("text/") ||
-      contentType === "application/pdf" ||
-      contentType === "application/json" ||
-      contentType === "application/xml" ||
-      contentType === "application/javascript"
-    );
-  }
+  const canPreview = $derived(
+    file && isFilePreviewable(file.fileName, file.contentType),
+  );
 
   onMount(() => {
     loadFileDetail();

--- a/platform-frontend/src/routes/(app)/upload/+page.svelte
+++ b/platform-frontend/src/routes/(app)/upload/+page.svelte
@@ -1,552 +1,764 @@
 <script lang="ts">
-	import { useUpload, type UploadTask } from '$stores/upload.svelte';
-	import { useNotifications } from '$stores/notifications.svelte';
-	import { formatFileSize, formatSpeed } from '$utils/format';
-	import * as Dialog from '$components/ui/dialog';
-	import { Button } from '$components/ui/button';
-	import { untrack } from 'svelte';
+  import { useUpload, type UploadTask } from "$stores/upload.svelte";
+  import { useNotifications } from "$stores/notifications.svelte";
+  import { formatFileSize, formatSpeed } from "$utils/format";
+  import * as Dialog from "$components/ui/dialog";
+  import { Button } from "$components/ui/button";
+  import { onMount, untrack } from "svelte";
+  import { getUploadPolicy } from "$api/endpoints/upload";
+  import type { UploadPolicyVO } from "$api/types";
+  import {
+    buildUploadAccept,
+    describeUploadPolicy,
+    validateFileAgainstUploadPolicy,
+  } from "$utils/upload-policy";
 
-	const upload = useUpload();
-	const notifications = useNotifications();
+  const upload = useUpload();
+  const notifications = useNotifications();
 
-	const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024 * 1024;
+  const MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024 * 1024;
 
-	let dragOver = $state(false);
-	let fileInput: HTMLInputElement;
+  let dragOver = $state(false);
+  let fileInput: HTMLInputElement;
+  let uploadPolicy = $state<UploadPolicyVO | null>(null);
+  let policyLoadFailed = $state(false);
+  const uploadAccept = $derived(
+    uploadPolicy ? buildUploadAccept(uploadPolicy) : "",
+  );
+  const policyDescription = $derived(
+    uploadPolicy
+      ? describeUploadPolicy(uploadPolicy)
+      : "由服务器在创建上传会话时校验",
+  );
+  const maxFileSizeBytes = $derived(
+    uploadPolicy?.maxFileSizeBytes ?? MAX_FILE_SIZE_BYTES,
+  );
 
-	let removeDialogOpen = $state(false);
-	let removeTarget = $state<UploadTask | null>(null);
-	let clearDialogOpen = $state(false);
-	let clearFailedDialogOpen = $state(false);
-	let retryAllDialogOpen = $state(false);
-	let cancelAllDialogOpen = $state(false);
+  let removeDialogOpen = $state(false);
+  let removeTarget = $state<UploadTask | null>(null);
+  let clearDialogOpen = $state(false);
+  let clearFailedDialogOpen = $state(false);
+  let retryAllDialogOpen = $state(false);
+  let cancelAllDialogOpen = $state(false);
 
-	let bulkBusy = $state(false);
-	let busyIds = $state<Set<string>>(new Set());
+  let bulkBusy = $state(false);
+  let busyIds = $state<Set<string>>(new Set());
 
-	function setBusy(id: string, value: boolean): void {
-		const next = new Set(busyIds);
-		if (value) next.add(id);
-		else next.delete(id);
-		busyIds = next;
-	}
+  /** Loads the upload policy without widening client-side acceptance on failure. */
+  async function loadUploadPolicy(): Promise<void> {
+    try {
+      uploadPolicy = await getUploadPolicy();
+      policyLoadFailed = false;
+    } catch {
+      policyLoadFailed = true;
+    }
+  }
 
-	function isBusy(id: string): boolean {
-		return busyIds.has(id) || bulkBusy;
-	}
+  onMount(() => {
+    void loadUploadPolicy();
+  });
 
-	let cancelledCount = $derived(
-		upload.tasks.filter((t) => t.status === 'cancelled').length,
-	);
-	let pausedCount = $derived(
-		upload.tasks.filter((t) => t.status === 'paused').length,
-	);
-	let processingCount = $derived(
-		upload.tasks.filter((t) => t.status === 'processing').length,
-	);
-	let retryableCount = $derived(upload.failedTasks.length + cancelledCount);
-	let cancelableCount = $derived(upload.activeTasks.length + processingCount + pausedCount);
+  function setBusy(id: string, value: boolean): void {
+    const next = new Set(busyIds);
+    if (value) next.add(id);
+    else next.delete(id);
+    busyIds = next;
+  }
 
-	function openRemoveDialog(task: UploadTask) {
-		if (isBusy(task.id)) return;
-		removeTarget = task;
-		removeDialogOpen = true;
-	}
+  function isBusy(id: string): boolean {
+    return busyIds.has(id) || bulkBusy;
+  }
 
-	function confirmRemove() {
-		if (!removeTarget) return;
-		upload.removeTask(removeTarget.id);
-		notifications.info('已移除任务', removeTarget.file.name);
-		removeDialogOpen = false;
-		removeTarget = null;
-	}
+  let cancelledCount = $derived(
+    upload.tasks.filter((t) => t.status === "cancelled").length,
+  );
+  let pausedCount = $derived(
+    upload.tasks.filter((t) => t.status === "paused").length,
+  );
+  let processingCount = $derived(
+    upload.tasks.filter((t) => t.status === "processing").length,
+  );
+  let retryableCount = $derived(upload.failedTasks.length + cancelledCount);
+  let cancelableCount = $derived(
+    upload.activeTasks.length + processingCount + pausedCount,
+  );
 
-	function openClearDialog() {
-		clearDialogOpen = true;
-	}
+  function openRemoveDialog(task: UploadTask) {
+    if (isBusy(task.id)) return;
+    removeTarget = task;
+    removeDialogOpen = true;
+  }
 
-	function confirmClearCompleted() {
-		upload.clearCompleted();
-		notifications.success('已清除已完成任务');
-		clearDialogOpen = false;
-	}
+  function confirmRemove() {
+    if (!removeTarget) return;
+    upload.removeTask(removeTarget.id);
+    notifications.info("已移除任务", removeTarget.file.name);
+    removeDialogOpen = false;
+    removeTarget = null;
+  }
 
-	function openClearFailedDialog() {
-		clearFailedDialogOpen = true;
-	}
+  function openClearDialog() {
+    clearDialogOpen = true;
+  }
 
-	function confirmClearFailedAndCancelled() {
-		upload.clearFailedAndCancelled();
-		notifications.success('已清除失败/取消任务');
-		clearFailedDialogOpen = false;
-	}
+  function confirmClearCompleted() {
+    upload.clearCompleted();
+    notifications.success("已清除已完成任务");
+    clearDialogOpen = false;
+  }
 
-	function openRetryAllDialog() {
-		retryAllDialogOpen = true;
-	}
+  function openClearFailedDialog() {
+    clearFailedDialogOpen = true;
+  }
 
-	async function confirmRetryAll() {
-		bulkBusy = true;
-		try {
-			const count = await upload.retryAllFailedAndCancelled();
-			if (count > 0) {
-				notifications.success('已开始重试', `共 ${count} 个任务`);
-			}
-			retryAllDialogOpen = false;
-		} catch (err) {
-			notifications.error('批量重试失败', err instanceof Error ? err.message : '请稍后重试');
-		} finally {
-			bulkBusy = false;
-		}
-	}
+  function confirmClearFailedAndCancelled() {
+    upload.clearFailedAndCancelled();
+    notifications.success("已清除失败/取消任务");
+    clearFailedDialogOpen = false;
+  }
 
-	function openCancelAllDialog() {
-		cancelAllDialogOpen = true;
-	}
+  function openRetryAllDialog() {
+    retryAllDialogOpen = true;
+  }
 
-	async function confirmCancelAll() {
-		bulkBusy = true;
-		try {
-			const count = await upload.cancelAllActiveAndProcessing();
-			if (count > 0) {
-				notifications.success('已取消任务', `共 ${count} 个任务`);
-			}
-			cancelAllDialogOpen = false;
-		} catch (err) {
-			notifications.error('批量取消失败', err instanceof Error ? err.message : '请稍后重试');
-		} finally {
-			bulkBusy = false;
-		}
-	}
+  async function confirmRetryAll() {
+    bulkBusy = true;
+    try {
+      const count = await upload.retryAllFailedAndCancelled();
+      if (count > 0) {
+        notifications.success("已开始重试", `共 ${count} 个任务`);
+      }
+      retryAllDialogOpen = false;
+    } catch (err) {
+      notifications.error(
+        "批量重试失败",
+        err instanceof Error ? err.message : "请稍后重试",
+      );
+    } finally {
+      bulkBusy = false;
+    }
+  }
 
-	async function pauseTask(id: string): Promise<void> {
-		if (isBusy(id)) return;
-		setBusy(id, true);
-		try {
-			await upload.pauseUpload(id);
-		} catch (err) {
-			notifications.error('暂停失败', err instanceof Error ? err.message : '请稍后重试');
-		} finally {
-			setBusy(id, false);
-		}
-	}
+  function openCancelAllDialog() {
+    cancelAllDialogOpen = true;
+  }
 
-	async function resumeTask(id: string): Promise<void> {
-		if (isBusy(id)) return;
-		setBusy(id, true);
-		try {
-			await upload.resumeUpload(id);
-		} catch (err) {
-			notifications.error('恢复失败', err instanceof Error ? err.message : '请稍后重试');
-		} finally {
-			setBusy(id, false);
-		}
-	}
+  async function confirmCancelAll() {
+    bulkBusy = true;
+    try {
+      const count = await upload.cancelAllActiveAndProcessing();
+      if (count > 0) {
+        notifications.success("已取消任务", `共 ${count} 个任务`);
+      }
+      cancelAllDialogOpen = false;
+    } catch (err) {
+      notifications.error(
+        "批量取消失败",
+        err instanceof Error ? err.message : "请稍后重试",
+      );
+    } finally {
+      bulkBusy = false;
+    }
+  }
 
-	async function retryTask(id: string): Promise<void> {
-		if (isBusy(id)) return;
-		setBusy(id, true);
-		try {
-			await upload.retryUpload(id);
-		} catch (err) {
-			notifications.error('重试失败', err instanceof Error ? err.message : '请稍后重试');
-		} finally {
-			setBusy(id, false);
-		}
-	}
+  async function pauseTask(id: string): Promise<void> {
+    if (isBusy(id)) return;
+    setBusy(id, true);
+    try {
+      await upload.pauseUpload(id);
+    } catch (err) {
+      notifications.error(
+        "暂停失败",
+        err instanceof Error ? err.message : "请稍后重试",
+      );
+    } finally {
+      setBusy(id, false);
+    }
+  }
 
-	let prevCompletedIds = new Set<string>();
-	$effect(() => {
-		const completedTasks = upload.completedTasks;
-		const currentIds = new Set(completedTasks.map(t => t.id));
-		const prev = untrack(() => prevCompletedIds);
-		for (const task of completedTasks) {
-			if (!prev.has(task.id)) {
-				notifications.success('上传完成', task.file.name);
-			}
-		}
-		prevCompletedIds = currentIds;
-	});
+  async function resumeTask(id: string): Promise<void> {
+    if (isBusy(id)) return;
+    setBusy(id, true);
+    try {
+      await upload.resumeUpload(id);
+    } catch (err) {
+      notifications.error(
+        "恢复失败",
+        err instanceof Error ? err.message : "请稍后重试",
+      );
+    } finally {
+      setBusy(id, false);
+    }
+  }
 
-	function handleDrop(e: DragEvent) {
-		e.preventDefault();
-		dragOver = false;
+  async function retryTask(id: string): Promise<void> {
+    if (isBusy(id)) return;
+    setBusy(id, true);
+    try {
+      await upload.retryUpload(id);
+    } catch (err) {
+      notifications.error(
+        "重试失败",
+        err instanceof Error ? err.message : "请稍后重试",
+      );
+    } finally {
+      setBusy(id, false);
+    }
+  }
 
-		const files = e.dataTransfer?.files;
-		if (files && files.length > 0) {
-			handleFiles(Array.from(files));
-		}
-	}
+  let prevCompletedIds = new Set<string>();
+  $effect(() => {
+    const completedTasks = upload.completedTasks;
+    const currentIds = new Set(completedTasks.map((t) => t.id));
+    const prev = untrack(() => prevCompletedIds);
+    for (const task of completedTasks) {
+      if (!prev.has(task.id)) {
+        notifications.success("上传完成", task.file.name);
+      }
+    }
+    prevCompletedIds = currentIds;
+  });
 
-	function handleFileSelect(e: Event) {
-		const input = e.target as HTMLInputElement;
-		if (input.files && input.files.length > 0) {
-			handleFiles(Array.from(input.files));
-			input.value = '';
-		}
-	}
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    dragOver = false;
 
-	async function handleFiles(files: File[]) {
-		for (const file of files) {
-			if (file.size > MAX_FILE_SIZE_BYTES) {
-				notifications.warning(
-					'文件过大',
-					`${file.name} 超过 ${formatFileSize(MAX_FILE_SIZE_BYTES)} 限制`,
-				);
-				continue;
-			}
+    const files = e.dataTransfer?.files;
+    if (files && files.length > 0) {
+      handleFiles(Array.from(files));
+    }
+  }
 
-			await upload.addFile(file);
-		}
-	}
+  function handleFileSelect(e: Event) {
+    const input = e.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      handleFiles(Array.from(input.files));
+      input.value = "";
+    }
+  }
 
-	function getStatusText(status: string): string {
-		switch (status) {
-			case 'pending':
-				return '等待中';
-			case 'uploading':
-				return '上传中';
-			case 'processing':
-				return '处理中';
-			case 'paused':
-				return '已暂停';
-			case 'completed':
-				return '已完成';
-			case 'failed':
-				return '上传失败';
-			case 'cancelled':
-				return '已取消';
-			default:
-				return '未知状态';
-		}
-	}
+  async function handleFiles(files: File[]) {
+    for (const file of files) {
+      if (file.size > maxFileSizeBytes) {
+        notifications.warning(
+          "文件过大",
+          `${file.name} 超过 ${formatFileSize(maxFileSizeBytes)} 限制`,
+        );
+        continue;
+      }
+      if (uploadPolicy) {
+        const policyError = validateFileAgainstUploadPolicy(file, uploadPolicy);
+        if (policyError) {
+          notifications.warning(
+            "文件类型不受支持",
+            `${file.name}：${policyError}`,
+          );
+          continue;
+        }
+      }
 
-	function getStatusColor(status: string): string {
-		switch (status) {
-			case 'pending':
-				return 'bg-gray-100 text-gray-700';
-			case 'uploading':
-				return 'bg-blue-100 text-blue-700';
-			case 'processing':
-				return 'bg-purple-100 text-purple-700';
-			case 'paused':
-				return 'bg-yellow-100 text-yellow-700';
-			case 'completed':
-				return 'bg-green-100 text-green-700';
-			case 'failed':
-				return 'bg-red-100 text-red-700';
-			case 'cancelled':
-				return 'bg-gray-100 text-gray-500';
-			default:
-				return 'bg-gray-100 text-gray-700';
-		}
-	}
+      await upload.addFile(file);
+    }
+  }
+
+  function getStatusText(status: string): string {
+    switch (status) {
+      case "pending":
+        return "等待中";
+      case "uploading":
+        return "上传中";
+      case "processing":
+        return "处理中";
+      case "paused":
+        return "已暂停";
+      case "completed":
+        return "已完成";
+      case "failed":
+        return "上传失败";
+      case "cancelled":
+        return "已取消";
+      default:
+        return "未知状态";
+    }
+  }
+
+  function getStatusColor(status: string): string {
+    switch (status) {
+      case "pending":
+        return "bg-gray-100 text-gray-700";
+      case "uploading":
+        return "bg-blue-100 text-blue-700";
+      case "processing":
+        return "bg-purple-100 text-purple-700";
+      case "paused":
+        return "bg-yellow-100 text-yellow-700";
+      case "completed":
+        return "bg-green-100 text-green-700";
+      case "failed":
+        return "bg-red-100 text-red-700";
+      case "cancelled":
+        return "bg-gray-100 text-gray-500";
+      default:
+        return "bg-gray-100 text-gray-700";
+    }
+  }
 </script>
 
 <svelte:head>
-	<title>上传文件 - 存证平台</title>
+  <title>上传文件 - 存证平台</title>
 </svelte:head>
 
 <div class="space-y-6">
-	<div>
-		<h1 class="text-2xl font-bold">上传文件</h1>
-		<p class="text-muted-foreground">上传文件并存证到区块链</p>
-	</div>
+  <div>
+    <h1 class="text-2xl font-bold">上传文件</h1>
+    <p class="text-muted-foreground">上传文件并存证到区块链</p>
+  </div>
 
-	<!-- 拖拽区域 -->
-	<div
-		class="rounded-lg border-2 border-dashed p-12 text-center transition-colors {dragOver ? 'border-primary bg-primary/5' : ''}"
-		ondragover={(e) => { e.preventDefault(); dragOver = true; }}
-		ondragleave={() => dragOver = false}
-		ondrop={handleDrop}
-		role="button"
-		tabindex="0"
-		onclick={() => fileInput.click()}
-		onkeydown={(e) => e.key === 'Enter' && fileInput.click()}
-	>
-		<input
-			type="file"
-			bind:this={fileInput}
-			onchange={handleFileSelect}
-			multiple
-			class="hidden"
-		/>
+  <!-- 拖拽区域 -->
+  <div
+    class="rounded-lg border-2 border-dashed p-12 text-center transition-colors {dragOver
+      ? 'border-primary bg-primary/5'
+      : ''}"
+    ondragover={(e) => {
+      e.preventDefault();
+      dragOver = true;
+    }}
+    ondragleave={() => (dragOver = false)}
+    ondrop={handleDrop}
+    role="button"
+    tabindex="0"
+    onclick={() => fileInput.click()}
+    onkeydown={(e) => e.key === "Enter" && fileInput.click()}
+  >
+    <input
+      type="file"
+      bind:this={fileInput}
+      onchange={handleFileSelect}
+      multiple
+      accept={uploadAccept}
+      class="hidden"
+    />
 
-		<div class="flex flex-col items-center gap-4">
-			<div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
-				<svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-				</svg>
-			</div>
-			<div>
-				<p class="text-lg font-medium">拖拽文件到此处或点击上传</p>
-				<p class="text-sm text-muted-foreground">
-					支持任意格式，单文件最大 {formatFileSize(MAX_FILE_SIZE_BYTES)}
-				</p>
-			</div>
-		</div>
-	</div>
+    <div class="flex flex-col items-center gap-4">
+      <div
+        class="bg-primary/10 text-primary flex h-16 w-16 items-center justify-center rounded-full"
+      >
+        <svg
+          class="h-8 w-8"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+          />
+        </svg>
+      </div>
+      <div>
+        <p class="text-lg font-medium">拖拽文件到此处或点击上传</p>
+        <p class="text-muted-foreground text-sm">
+          支持{policyDescription}，单文件最大 {formatFileSize(maxFileSizeBytes)}
+        </p>
+        {#if policyLoadFailed}
+          <p class="mt-1 text-xs text-amber-600">
+            上传策略暂时无法加载，将由服务器最终校验
+          </p>
+        {/if}
+      </div>
+    </div>
+  </div>
 
-	<!-- 上传队列 -->
-	{#if upload.tasks.length > 0}
-		<div class="rounded-lg border bg-card">
-			<div class="flex items-center justify-between gap-3 border-b p-4">
-				<h2 class="font-semibold">上传队列 ({upload.tasks.length})</h2>
-				<div class="flex flex-wrap items-center gap-2">
-					{#if cancelableCount > 0}
-			<Button variant="outline" size="sm" onclick={openCancelAllDialog} disabled={bulkBusy}>
-				全部取消 ({cancelableCount})
-			</Button>
-					{/if}
-					{#if retryableCount > 0}
-			<Button variant="outline" size="sm" onclick={openRetryAllDialog} disabled={bulkBusy}>
-				重试失败/取消 ({retryableCount})
-			</Button>
-			<Button variant="outline" size="sm" onclick={openClearFailedDialog} disabled={bulkBusy}>
-				清除失败/取消 ({retryableCount})
-			</Button>
-					{/if}
-					{#if upload.completedTasks.length > 0}
-					<Button variant="link" class="h-auto p-0" onclick={openClearDialog} disabled={bulkBusy}>
-						清除已完成 ({upload.completedTasks.length})
-					</Button>
-					{/if}
-				</div>
-			</div>
+  <!-- 上传队列 -->
+  {#if upload.tasks.length > 0}
+    <div class="bg-card rounded-lg border">
+      <div class="flex items-center justify-between gap-3 border-b p-4">
+        <h2 class="font-semibold">上传队列 ({upload.tasks.length})</h2>
+        <div class="flex flex-wrap items-center gap-2">
+          {#if cancelableCount > 0}
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={openCancelAllDialog}
+              disabled={bulkBusy}
+            >
+              全部取消 ({cancelableCount})
+            </Button>
+          {/if}
+          {#if retryableCount > 0}
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={openRetryAllDialog}
+              disabled={bulkBusy}
+            >
+              重试失败/取消 ({retryableCount})
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={openClearFailedDialog}
+              disabled={bulkBusy}
+            >
+              清除失败/取消 ({retryableCount})
+            </Button>
+          {/if}
+          {#if upload.completedTasks.length > 0}
+            <Button
+              variant="link"
+              class="h-auto p-0"
+              onclick={openClearDialog}
+              disabled={bulkBusy}
+            >
+              清除已完成 ({upload.completedTasks.length})
+            </Button>
+          {/if}
+        </div>
+      </div>
 
-			<div class="divide-y">
-				{#each upload.tasks as task (task.id)}
-					{@const t = task}
-					<div class="p-4">
-						<div class="flex items-start justify-between gap-4">
-							<div class="flex items-start gap-3">
-								<div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-									<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-									</svg>
-								</div>
-								<div class="min-w-0">
-									<p class="truncate font-medium">{task.file.name}</p>
-									<p class="text-sm text-muted-foreground">
-										{formatFileSize(task.file.size)}
-										{#if t.status === 'uploading' && task.speed > 0}
-											· {formatSpeed(task.speed)}
-										{/if}
-									</p>
-								</div>
-							</div>
+      <div class="divide-y">
+        {#each upload.tasks as task (task.id)}
+          {@const t = task}
+          <div class="p-4">
+            <div class="flex items-start justify-between gap-4">
+              <div class="flex items-start gap-3">
+                <div
+                  class="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-lg"
+                >
+                  <svg
+                    class="h-5 w-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
+                  </svg>
+                </div>
+                <div class="min-w-0">
+                  <p class="truncate font-medium">{task.file.name}</p>
+                  <p class="text-muted-foreground text-sm">
+                    {formatFileSize(task.file.size)}
+                    {#if t.status === "uploading" && task.speed > 0}
+                      · {formatSpeed(task.speed)}
+                    {/if}
+                  </p>
+                </div>
+              </div>
 
-							<div class="flex items-center gap-2">
-								<span class="rounded-full px-2 py-1 text-xs {getStatusColor(t.status)}">
-									{getStatusText(t.status)}
-								</span>
+              <div class="flex items-center gap-2">
+                <span
+                  class="rounded-full px-2 py-1 text-xs {getStatusColor(
+                    t.status,
+                  )}"
+                >
+                  {getStatusText(t.status)}
+                </span>
 
-								{#if t.status === 'uploading'}
-									<button
-										class="rounded p-1 hover:bg-accent disabled:opacity-50"
-										onclick={() => pauseTask(task.id)}
-										disabled={isBusy(task.id)}
-										title={isBusy(task.id) ? '处理中...' : '暂停'}
-									>
-										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-										</svg>
-									</button>
-								{:else if t.status === 'paused'}
-									<button
-										class="rounded p-1 hover:bg-accent disabled:opacity-50"
-										onclick={() => resumeTask(task.id)}
-										disabled={isBusy(task.id)}
-										title={isBusy(task.id) ? '处理中...' : '继续'}
-									>
-										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-										</svg>
-									</button>
-								{:else if t.status === 'failed' || t.status === 'cancelled'}
-									<button
-										class="rounded p-1 hover:bg-accent disabled:opacity-50"
-										onclick={() => retryTask(task.id)}
-										disabled={isBusy(task.id)}
-										title={isBusy(task.id) ? '处理中...' : '重试'}
-									>
-										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-										</svg>
-									</button>
-								{/if}
+                {#if t.status === "uploading"}
+                  <button
+                    class="hover:bg-accent rounded p-1 disabled:opacity-50"
+                    onclick={() => pauseTask(task.id)}
+                    disabled={isBusy(task.id)}
+                    title={isBusy(task.id) ? "处理中..." : "暂停"}
+                  >
+                    <svg
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  </button>
+                {:else if t.status === "paused"}
+                  <button
+                    class="hover:bg-accent rounded p-1 disabled:opacity-50"
+                    onclick={() => resumeTask(task.id)}
+                    disabled={isBusy(task.id)}
+                    title={isBusy(task.id) ? "处理中..." : "继续"}
+                  >
+                    <svg
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                      />
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  </button>
+                {:else if t.status === "failed" || t.status === "cancelled"}
+                  <button
+                    class="hover:bg-accent rounded p-1 disabled:opacity-50"
+                    onclick={() => retryTask(task.id)}
+                    disabled={isBusy(task.id)}
+                    title={isBusy(task.id) ? "处理中..." : "重试"}
+                  >
+                    <svg
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                      />
+                    </svg>
+                  </button>
+                {/if}
 
-								{#if t.status !== 'completed'}
-									<button
-										class="rounded p-1 text-destructive hover:bg-destructive/10 disabled:opacity-50"
-										onclick={() => openRemoveDialog(task)}
-										disabled={isBusy(task.id)}
-										title={isBusy(task.id) ? '处理中...' : '删除'}
-									>
-										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-										</svg>
-									</button>
-								{/if}
-							</div>
-						</div>
+                {#if t.status !== "completed"}
+                  <button
+                    class="text-destructive hover:bg-destructive/10 rounded p-1 disabled:opacity-50"
+                    onclick={() => openRemoveDialog(task)}
+                    disabled={isBusy(task.id)}
+                    title={isBusy(task.id) ? "处理中..." : "删除"}
+                  >
+                    <svg
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                {/if}
+              </div>
+            </div>
 
-						<!-- 进度条 -->
-						{#if t.status === 'uploading' || t.status === 'paused' || t.status === 'processing'}
-							{@const isProcessing = t.status === 'processing'}
-							{@const displayProgress = isProcessing ? (t.processProgress ?? 0) : task.progress}
-							<div class="mt-3">
-								<div class="mb-1 flex justify-between text-xs text-muted-foreground">
-									{#if isProcessing}
-										<span>处理中</span>
-									{:else}
-										<span>{task.uploadedChunks.length}/{task.totalChunks} 分片</span>
-									{/if}
-									<span>{displayProgress}%</span>
-								</div>
-								<div class="h-2 overflow-hidden rounded-full bg-secondary">
-									<div
-										class="h-full transition-all"
-										class:bg-primary={!isProcessing}
-										class:bg-purple-500={isProcessing}
-										class:animate-pulse={t.status === 'uploading' || t.status === 'processing'}
-										style="width: {displayProgress}%"
-									></div>
-								</div>
-								{#if isProcessing}
-									<p class="mt-2 text-xs text-muted-foreground">
-										上传已完成，正在加密/存储/存证，请稍候…
-									</p>
-								{/if}
-							</div>
-						{/if}
+            <!-- 进度条 -->
+            {#if t.status === "uploading" || t.status === "paused" || t.status === "processing"}
+              {@const isProcessing = t.status === "processing"}
+              {@const displayProgress = isProcessing
+                ? (t.processProgress ?? 0)
+                : task.progress}
+              <div class="mt-3">
+                <div
+                  class="text-muted-foreground mb-1 flex justify-between text-xs"
+                >
+                  {#if isProcessing}
+                    <span>处理中</span>
+                  {:else}
+                    <span
+                      >{task.uploadedChunks.length}/{task.totalChunks} 分片</span
+                    >
+                  {/if}
+                  <span>{displayProgress}%</span>
+                </div>
+                <div class="bg-secondary h-2 overflow-hidden rounded-full">
+                  <div
+                    class="h-full transition-all"
+                    class:bg-primary={!isProcessing}
+                    class:bg-purple-500={isProcessing}
+                    class:animate-pulse={t.status === "uploading" ||
+                      t.status === "processing"}
+                    style="width: {displayProgress}%"
+                  ></div>
+                </div>
+                {#if isProcessing}
+                  <p class="text-muted-foreground mt-2 text-xs">
+                    上传已完成，正在加密/存储/存证，请稍候…
+                  </p>
+                {/if}
+              </div>
+            {/if}
 
-						<!-- 错误信息 -->
-						{#if task.error}
-							<p class="mt-2 text-sm text-destructive">{task.error}</p>
-						{/if}
-					</div>
-				{/each}
-			</div>
-		</div>
-	{:else}
-		<div class="rounded-lg border bg-card p-8 text-center">
-			<div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-				<svg class="h-8 w-8 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-				</svg>
-			</div>
-			<p class="font-medium">暂无上传任务</p>
-			<p class="mt-2 text-sm text-muted-foreground">选择文件或拖拽到上方区域开始上传</p>
-			<Button class="mt-4" onclick={() => fileInput.click()}>选择文件</Button>
-		</div>
-	{/if}
+            <!-- 错误信息 -->
+            {#if task.error}
+              <p class="text-destructive mt-2 text-sm">{task.error}</p>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+  {:else}
+    <div class="bg-card rounded-lg border p-8 text-center">
+      <div
+        class="bg-muted mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full"
+      >
+        <svg
+          class="text-muted-foreground h-8 w-8"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+          />
+        </svg>
+      </div>
+      <p class="font-medium">暂无上传任务</p>
+      <p class="text-muted-foreground mt-2 text-sm">
+        选择文件或拖拽到上方区域开始上传
+      </p>
+      <Button class="mt-4" onclick={() => fileInput.click()}>选择文件</Button>
+    </div>
+  {/if}
 
-	<!-- 提示 -->
-	<div class="rounded-lg border bg-muted/50 p-4">
-		<h3 class="mb-2 font-medium">上传说明</h3>
-		<ul class="space-y-1 text-sm text-muted-foreground">
-			<li>• 支持断点续传，上传中断后可继续上传</li>
-			<li>• 文件上传后将进行加密处理并存储到分布式系统</li>
-			<li>• 文件哈希将被记录到区块链，作为存证凭证</li>
-			<li>• 存证完成后可获取交易哈希，用于验证文件真实性</li>
-		</ul>
-	</div>
+  <!-- 提示 -->
+  <div class="bg-muted/50 rounded-lg border p-4">
+    <h3 class="mb-2 font-medium">上传说明</h3>
+    <ul class="text-muted-foreground space-y-1 text-sm">
+      <li>• 支持断点续传，上传中断后可继续上传</li>
+      <li>• 文件上传后将进行加密处理并存储到分布式系统</li>
+      <li>• 文件哈希将被记录到区块链，作为存证凭证</li>
+      <li>• 存证完成后可获取交易哈希，用于验证文件真实性</li>
+    </ul>
+  </div>
 </div>
 
 <Dialog.Root bind:open={removeDialogOpen}>
-	<Dialog.Content class="sm:max-w-md">
-		<Dialog.Header>
-			<Dialog.Title>确认移除任务</Dialog.Title>
-			<Dialog.Description>移除后将停止上传/处理。</Dialog.Description>
-		</Dialog.Header>
-		<div class="space-y-2 py-4">
-			<p class="text-sm">
-				确定要移除
-				<span class="font-medium">{removeTarget?.file.name}</span>
-				吗？
-			</p>
-		</div>
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (removeDialogOpen = false)}>取消</Button>
-			<Button variant="destructive" onclick={confirmRemove}>移除</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>确认移除任务</Dialog.Title>
+      <Dialog.Description>移除后将停止上传/处理。</Dialog.Description>
+    </Dialog.Header>
+    <div class="space-y-2 py-4">
+      <p class="text-sm">
+        确定要移除
+        <span class="font-medium">{removeTarget?.file.name}</span>
+        吗？
+      </p>
+    </div>
+    <Dialog.Footer>
+      <Button variant="outline" onclick={() => (removeDialogOpen = false)}
+        >取消</Button
+      >
+      <Button variant="destructive" onclick={confirmRemove}>移除</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
 </Dialog.Root>
 
 <Dialog.Root bind:open={clearDialogOpen}>
-	<Dialog.Content class="sm:max-w-md">
-		<Dialog.Header>
-			<Dialog.Title>清除已完成</Dialog.Title>
-			<Dialog.Description>仅清除状态为“已完成”的任务记录。</Dialog.Description>
-		</Dialog.Header>
-		<div class="space-y-2 py-4">
-			<p class="text-sm">确定要清除所有已完成任务吗？</p>
-		</div>
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (clearDialogOpen = false)} disabled={bulkBusy}>
-				取消
-			</Button>
-			<Button onclick={confirmClearCompleted} disabled={bulkBusy}>清除</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>清除已完成</Dialog.Title>
+      <Dialog.Description>仅清除状态为“已完成”的任务记录。</Dialog.Description>
+    </Dialog.Header>
+    <div class="space-y-2 py-4">
+      <p class="text-sm">确定要清除所有已完成任务吗？</p>
+    </div>
+    <Dialog.Footer>
+      <Button
+        variant="outline"
+        onclick={() => (clearDialogOpen = false)}
+        disabled={bulkBusy}
+      >
+        取消
+      </Button>
+      <Button onclick={confirmClearCompleted} disabled={bulkBusy}>清除</Button>
+    </Dialog.Footer>
+  </Dialog.Content>
 </Dialog.Root>
 
 <Dialog.Root bind:open={clearFailedDialogOpen}>
-	<Dialog.Content class="sm:max-w-md">
-		<Dialog.Header>
-			<Dialog.Title>清除失败/取消</Dialog.Title>
-			<Dialog.Description>仅清除失败或已取消的任务记录。</Dialog.Description>
-		</Dialog.Header>
-		<div class="space-y-2 py-4">
-			<p class="text-sm">确定要清除所有失败/取消任务吗？</p>
-		</div>
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (clearFailedDialogOpen = false)} disabled={bulkBusy}>
-				取消
-			</Button>
-			<Button onclick={confirmClearFailedAndCancelled} disabled={bulkBusy}>清除</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>清除失败/取消</Dialog.Title>
+      <Dialog.Description>仅清除失败或已取消的任务记录。</Dialog.Description>
+    </Dialog.Header>
+    <div class="space-y-2 py-4">
+      <p class="text-sm">确定要清除所有失败/取消任务吗？</p>
+    </div>
+    <Dialog.Footer>
+      <Button
+        variant="outline"
+        onclick={() => (clearFailedDialogOpen = false)}
+        disabled={bulkBusy}
+      >
+        取消
+      </Button>
+      <Button onclick={confirmClearFailedAndCancelled} disabled={bulkBusy}
+        >清除</Button
+      >
+    </Dialog.Footer>
+  </Dialog.Content>
 </Dialog.Root>
 
 <Dialog.Root bind:open={retryAllDialogOpen}>
-	<Dialog.Content class="sm:max-w-md">
-		<Dialog.Header>
-			<Dialog.Title>批量重试</Dialog.Title>
-			<Dialog.Description>将重新开始所有失败/取消的任务。</Dialog.Description>
-		</Dialog.Header>
-		<div class="space-y-2 py-4">
-			<p class="text-sm">确定要重试所有失败/取消任务吗？</p>
-		</div>
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (retryAllDialogOpen = false)} disabled={bulkBusy}>
-				取消
-			</Button>
-			<Button onclick={confirmRetryAll} disabled={bulkBusy}>
-				{bulkBusy ? '处理中…' : '重试'}
-			</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>批量重试</Dialog.Title>
+      <Dialog.Description>将重新开始所有失败/取消的任务。</Dialog.Description>
+    </Dialog.Header>
+    <div class="space-y-2 py-4">
+      <p class="text-sm">确定要重试所有失败/取消任务吗？</p>
+    </div>
+    <Dialog.Footer>
+      <Button
+        variant="outline"
+        onclick={() => (retryAllDialogOpen = false)}
+        disabled={bulkBusy}
+      >
+        取消
+      </Button>
+      <Button onclick={confirmRetryAll} disabled={bulkBusy}>
+        {bulkBusy ? "处理中…" : "重试"}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
 </Dialog.Root>
 
 <Dialog.Root bind:open={cancelAllDialogOpen}>
-	<Dialog.Content class="sm:max-w-md">
-		<Dialog.Header>
-			<Dialog.Title>批量取消</Dialog.Title>
-			<Dialog.Description>将取消所有上传中/暂停/处理中的任务。</Dialog.Description>
-		</Dialog.Header>
-		<div class="space-y-2 py-4">
-			<p class="text-sm">确定要取消所有进行中的任务吗？</p>
-		</div>
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (cancelAllDialogOpen = false)} disabled={bulkBusy}>
-				取消
-			</Button>
-			<Button variant="destructive" onclick={confirmCancelAll} disabled={bulkBusy}>
-				{bulkBusy ? '处理中…' : '取消'}
-			</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>批量取消</Dialog.Title>
+      <Dialog.Description
+        >将取消所有上传中/暂停/处理中的任务。</Dialog.Description
+      >
+    </Dialog.Header>
+    <div class="space-y-2 py-4">
+      <p class="text-sm">确定要取消所有进行中的任务吗？</p>
+    </div>
+    <Dialog.Footer>
+      <Button
+        variant="outline"
+        onclick={() => (cancelAllDialogOpen = false)}
+        disabled={bulkBusy}
+      >
+        取消
+      </Button>
+      <Button
+        variant="destructive"
+        onclick={confirmCancelAll}
+        disabled={bulkBusy}
+      >
+        {bulkBusy ? "处理中…" : "取消"}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
 </Dialog.Root>

--- a/platform-frontend/src/routes/(app)/upload/upload-policy.render.test.ts
+++ b/platform-frontend/src/routes/(app)/upload/upload-policy.render.test.ts
@@ -1,0 +1,123 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getUploadPolicy: vi.fn(),
+  addFile: vi.fn(),
+  warning: vi.fn(),
+}));
+
+vi.mock("$api/endpoints/upload", () => ({
+  getUploadPolicy: mocks.getUploadPolicy,
+}));
+
+vi.mock("$stores/upload.svelte", () => ({
+  useUpload: () => ({
+    tasks: [],
+    failedTasks: [],
+    activeTasks: [],
+    completedTasks: [],
+    addFile: mocks.addFile,
+    removeTask: vi.fn(),
+    clearCompleted: vi.fn(),
+    clearFailedAndCancelled: vi.fn(),
+    retryAllFailedAndCancelled: vi.fn(),
+    cancelAllActiveAndProcessing: vi.fn(),
+    pauseUpload: vi.fn(),
+    resumeUpload: vi.fn(),
+    retryUpload: vi.fn(),
+  }),
+}));
+
+vi.mock("$stores/notifications.svelte", () => ({
+  useNotifications: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: mocks.warning,
+  }),
+}));
+
+import UploadPage from "./+page.svelte";
+
+const policy = {
+  maxFileSizeBytes: 1024,
+  fileTypes: [
+    {
+      extension: "pdf",
+      category: "document",
+      categoryLabel: "文档",
+      previewMode: "pdf" as const,
+      mimeTypes: ["application/pdf"],
+    },
+  ],
+};
+
+describe("upload page policy wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.addFile.mockResolvedValue("task-id");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("applies the server accept contract and rejects mismatches before adding a task", async () => {
+    mocks.getUploadPolicy.mockResolvedValue(policy);
+    const view = render(UploadPage);
+    const input =
+      view.container.querySelector<HTMLInputElement>('input[type="file"]');
+    const dropTarget =
+      view.container.querySelector<HTMLElement>('[role="button"]');
+    expect(input).not.toBeNull();
+    expect(dropTarget).not.toBeNull();
+
+    await waitFor(() => expect(input?.getAttribute("accept")).toBe(".pdf"));
+    expect(view.getByText(/支持文档，单文件最大/)).toBeTruthy();
+
+    await fireEvent.drop(dropTarget!, {
+      dataTransfer: {
+        files: [new File(["bad"], "payload.exe", { type: "image/png" })],
+      },
+    });
+    expect(mocks.addFile).not.toHaveBeenCalled();
+    expect(mocks.warning).toHaveBeenCalledWith(
+      "文件类型不受支持",
+      expect.stringContaining(".exe；可上传类型：文档"),
+    );
+
+    const accepted = new File(["pdf"], "paper.pdf", {
+      type: "application/pdf",
+    });
+    await fireEvent.drop(dropTarget!, {
+      dataTransfer: { files: [accepted] },
+    });
+    await waitFor(() => expect(mocks.addFile).toHaveBeenCalledWith(accepted));
+  });
+
+  it("keeps the selector unconstrained and delegates final validation when policy loading fails", async () => {
+    mocks.getUploadPolicy.mockRejectedValue(new Error("offline"));
+    const view = render(UploadPage);
+
+    await waitFor(() =>
+      expect(
+        view.getByText("上传策略暂时无法加载，将由服务器最终校验"),
+      ).toBeTruthy(),
+    );
+    const input =
+      view.container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input?.getAttribute("accept")).toBe("");
+
+    const fallbackFile = new File(["unknown"], "sample.unknown", {
+      type: "application/octet-stream",
+    });
+    await fireEvent.drop(
+      view.container.querySelector<HTMLElement>('[role="button"]')!,
+      { dataTransfer: { files: [fallbackFile] } },
+    );
+    await waitFor(() =>
+      expect(mocks.addFile).toHaveBeenCalledWith(fallbackFile),
+    );
+  });
+});


### PR DESCRIPTION
## 变更范围

- 新增后端统一文件扩展名/MIME 策略注册表，并让普通与直传上传会话共用同一校验入口
- 新增受保护的上传策略接口，前端据此生成文件选择范围、大小限制和快速失败提示
- 扩展常用文档、文本/代码、图片、音频、视频与压缩包类型，继续排除可执行文件和安装包
- 统一文件预览分类；HTML、SVG 与源代码仅以转义文本显示，原生媒体解码失败时回退到下载
- 文本 Blob 仅解码前 100000 字节，并处理预览组件切换文件时的异步旧状态
- 同步 OpenAPI 类型、API 文档、测试基线与回归测试

## 验证

- `mvn -f platform-backend/pom.xml clean test -pl backend-common,backend-service,backend-web -am`
- 聚焦上传策略/服务/控制器/OpenAPI 测试通过
- `pnpm types:gen:check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm check`
- `pnpm test:coverage`（48 个测试文件，604 个测试通过）
- `pnpm build`
- 文档一致性检查及 11 个文档单测通过
- Codex Security 差异审查无可报告发现

## 环境说明

本机无 Docker，因此 `verify -Pit` 的 Testcontainers 套件按 fail-closed 方式报告 Docker 环境不可用；由 GitHub CI 完成真实容器集成验证。