### PR TITLE
fix: 修复审计统计与预览显示问题

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,8 +28,8 @@
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
 | 后端服务类 | 213 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 219 | `platform-backend/**/src/test/java` |
-| 数据库迁移 | 38（V1.0.0 ~ V1.20.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
+| 后端测试文件 | 220 | `platform-backend/**/src/test/java` |
+| 数据库迁移 | 39（V1.0.0 ~ V1.20.1） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 
 | 组件 | 当前基线 | 演进原则 |

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,19 +2,19 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（340 files）
+## 当前测试文件快照（344 files）
 
-> 2026-09-02 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
+> 2026-09-03 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
 | Component | Test files |
 | --- | ---: |
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
 | `platform-backend/backend-service` | 97 |
-| `platform-backend/backend-web` | 108 |
-| `platform-backend` | 219 |
+| `platform-backend/backend-web` | 109 |
+| `platform-backend` | 220 |
 | `platform-storage` | 28 |
-| `platform-frontend` | 49 |
+| `platform-frontend` | 52 |
 | `platform-verifier` | 15 |
 | `platform-fisco` | 14 |
 | `platform-api` | 3 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 12 |
-| `total` | 340 |
+| `total` | 344 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 
@@ -149,6 +149,7 @@
 | BaseControllerIntegrationTest | 控制器集成测试基类 |
 | OpenApiContractExportTest | OpenAPI 契约导出与稳定性校验 |
 | AuditHighFrequencyTenantIsolationIT | 高频告警列表、KPI 与异常检测的租户/阈值一致性 |
+| SysOperationLogMapperContractTest | 审计备份/清理显式租户边界与下载类型半开区间查询合同 |
 
 ### 前端测试（platform-frontend，代表性测试文件）
 
@@ -204,6 +205,9 @@
 | route-loaders.test.ts | 路由数据加载器 |
 | app-layout-load.test.ts | 应用布局加载逻辑 |
 | AuditDashboard.render.test.ts | 高频告警聚焦与精确身份、IP、时间窗钻取 |
+| audit-log-display.test.ts | 敏感日志 DTO 显式映射与审计 JSON/纯文本格式化 |
+| LogDetailDialog.render.test.ts | 审计详情字段语义、长内容布局与格式化展示 |
+| admin/files/page.render.test.ts | 文件审计预览弹窗的滚动区域、放大/恢复与状态重置 |
 | chartLifecycle.test.ts | ECharts 同步初始化、单次重试、resize 与销毁 |
 | charts.render.test.ts | 三类审计图表挂载后生成 canvas |
 | upload-policy.render.test.ts | 上传页策略加载、accept 同步、快速拒绝与加载失败回退 |

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/SysOperationLogMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/SysOperationLogMapper.java
@@ -5,6 +5,7 @@ import cn.flying.dao.vo.audit.AuditConfigVO;
 import cn.flying.dao.vo.audit.ErrorOperationStatsVO;
 import cn.flying.dao.vo.audit.HighFrequencyOperationVO;
 import cn.flying.dao.vo.audit.UserTimeDistributionVO;
+import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -72,6 +73,7 @@ public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
      * @param cutoffTime 截止时间
      * @return 插入备份表的行数
      */
+    @InterceptorIgnore(tenantLine = "true")
     int insertOperationLogBackup(@Param("tenantId") Long tenantId, @Param("cutoffTime") LocalDateTime cutoffTime);
 
     /**
@@ -81,6 +83,7 @@ public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
      * @param cutoffTime 截止时间
      * @return 删除行数
      */
+    @InterceptorIgnore(tenantLine = "true")
     int deleteOperationLogsBefore(@Param("tenantId") Long tenantId, @Param("cutoffTime") LocalDateTime cutoffTime);
 
     /**
@@ -91,6 +94,8 @@ public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
             @Param("username") String username,
             @Param("module") String module,
             @Param("operationType") String operationType,
+            @Param("status") Integer status,
+            @Param("requestIp") String requestIp,
             @Param("startTime") String startTime,
             @Param("endTime") String endTime,
             @Param("limit") int limit,
@@ -105,6 +110,8 @@ public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
             @Param("username") String username,
             @Param("module") String module,
             @Param("operationType") String operationType,
+            @Param("status") Integer status,
+            @Param("requestIp") String requestIp,
             @Param("startTime") String startTime,
             @Param("endTime") String endTime
     );
@@ -143,6 +150,20 @@ public interface SysOperationLogMapper extends BaseMapper<SysOperationLog> {
      * 查询指定时间范围内的操作日志数 (sys_operation_log)
      */
     Long selectOperationsBetween(@Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+
+    /**
+     * Count one operation type in a half-open time window for the current tenant.
+     *
+     * @param operationType canonical operation type
+     * @param startTime inclusive window start
+     * @param endTime exclusive window end
+     * @return matching operation count
+     */
+    Long countOperationsByTypeBetween(
+            @Param("operationType") String operationType,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime
+    );
 
     /**
      * 查询总错误操作日志数 (sys_operation_log where status=1)

--- a/platform-backend/backend-dao/src/main/resources/mapper/SysOperationLogMapper.xml
+++ b/platform-backend/backend-dao/src/main/resources/mapper/SysOperationLogMapper.xml
@@ -65,7 +65,8 @@
         SELECT
         id, user_id as userId, username, request_ip as requestIp, module,
         operation_type as operationType, description, method, request_url as requestUrl,
-        request_param as requestParam, operation_time as operationTime, status
+        request_param as requestParam, operation_time as operationTime, status,
+        error_msg as errorMsg, execution_time as executionTime
         FROM v_sensitive_operations
         <where>
             <if test="userId != null and userId != ''">
@@ -79,6 +80,12 @@
             </if>
             <if test="operationType != null and operationType != ''">
                 AND operation_type = #{operationType}
+            </if>
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+            <if test="requestIp != null and requestIp != ''">
+                AND request_ip = #{requestIp}
             </if>
             <if test="startTime != null and startTime != ''">
                 AND operation_time >= #{startTime}
@@ -107,6 +114,12 @@
             </if>
             <if test="operationType != null and operationType != ''">
                 AND operation_type = #{operationType}
+            </if>
+            <if test="status != null">
+                AND status = #{status}
+            </if>
+            <if test="requestIp != null and requestIp != ''">
+                AND request_ip = #{requestIp}
             </if>
             <if test="startTime != null and startTime != ''">
                 AND operation_time >= #{startTime}
@@ -183,6 +196,13 @@
     <select id="selectOperationsBetween" resultType="java.lang.Long">
         SELECT COUNT(*) FROM sys_operation_log
         WHERE operation_time >= #{startTime} AND operation_time &lt; #{endTime}
+    </select>
+
+    <select id="countOperationsByTypeBetween" resultType="java.lang.Long">
+        SELECT COUNT(*) FROM sys_operation_log
+        WHERE operation_type = #{operationType}
+          AND operation_time >= #{startTime}
+          AND operation_time &lt; #{endTime}
     </select>
 
     <select id="selectTotalErrorOperations" resultType="java.lang.Long">

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/SysAuditServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/SysAuditServiceImpl.java
@@ -81,6 +81,8 @@ public class SysAuditServiceImpl implements SysAuditService {
                 escapedUsername,
                 escapedModule,
                 queryVO.getOperationType(),
+                queryVO.getStatus(),
+                queryVO.getRequestIp(),
                 queryVO.getStartTime(),
                 queryVO.getEndTime(),
                 queryVO.getPageSize(),
@@ -93,6 +95,8 @@ public class SysAuditServiceImpl implements SysAuditService {
                 escapedUsername,
                 escapedModule,
                 queryVO.getOperationType(),
+                queryVO.getStatus(),
+                queryVO.getRequestIp(),
                 queryVO.getStartTime(),
                 queryVO.getEndTime()
         );

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/SysAuditServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/SysAuditServiceImplTest.java
@@ -161,12 +161,14 @@ class SysAuditServiceImplTest {
         @Test
         @DisplayName("should return sensitive operations with pagination")
         void shouldReturnSensitiveOperationsWithPagination() {
+            defaultQuery.setStatus(1);
+            defaultQuery.setRequestIp("10.1.0.2");
             SysOperationLog log = createOperationLog(1L);
             when(operationLogMapper.selectSensitiveOperations(
-                    any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                    any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
                     .thenReturn(List.of(log));
             when(operationLogMapper.countSensitiveOperations(
-                    any(), any(), any(), any(), any(), any()))
+                    any(), any(), any(), any(), any(), any(), any(), any()))
                     .thenReturn(1L);
 
             IPage<SysOperationLog> result = sysAuditService.getSensitiveOperations(defaultQuery);
@@ -174,6 +176,12 @@ class SysAuditServiceImplTest {
             assertThat(result).isNotNull();
             assertThat(result.getRecords()).hasSize(1);
             assertThat(result.getTotal()).isEqualTo(1L);
+            verify(operationLogMapper).selectSensitiveOperations(
+                    isNull(), isNull(), isNull(), isNull(), eq(1), eq("10.1.0.2"),
+                    isNull(), isNull(), eq(10), eq(0));
+            verify(operationLogMapper).countSensitiveOperations(
+                    isNull(), isNull(), isNull(), isNull(), eq(1), eq("10.1.0.2"),
+                    isNull(), isNull());
         }
     }
 

--- a/platform-backend/backend-web/src/main/java/cn/flying/service/impl/SystemMonitorServiceImpl.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/service/impl/SystemMonitorServiceImpl.java
@@ -48,6 +48,7 @@ public class SystemMonitorServiceImpl implements SystemMonitorService {
     private static final String FALLBACK_CHAIN_TYPE = "UNKNOWN";
     private static final String STORAGE_CAPACITY_FALLBACK_MARKER = "MONITOR_STORAGE_CAPACITY_FALLBACK";
     private static final long FILE_ESTIMATE_BYTES = 1024L * 1024L;
+    private static final String DOWNLOAD_OPERATION_TYPE = "下载";
 
     // Health indicators injected by name
     @Resource(name = "database")
@@ -101,8 +102,8 @@ public class SystemMonitorServiceImpl implements SystemMonitorService {
             );
 
             // 今日下载次数 (从操作日志统计)
-            Long todayDownloads = operationLogMapper.selectOperationsBetween(
-                    todayStart, LocalDateTime.now()
+            Long todayDownloads = operationLogMapper.countOperationsByTypeBetween(
+                    DOWNLOAD_OPERATION_TYPE, todayStart, LocalDateTime.now()
             );
 
             // 区块链交易数

--- a/platform-backend/backend-web/src/main/resources/db/migration/V1.20.1__filter_sensitive_operation_view.sql
+++ b/platform-backend/backend-web/src/main/resources/db/migration/V1.20.1__filter_sensitive_operation_view.sql
@@ -1,0 +1,23 @@
+-- Restrict the sensitive-operation view to the established audit categories.
+-- This forward migration repairs already-deployed databases without rewriting released history.
+CREATE OR REPLACE VIEW `v_sensitive_operations` AS
+SELECT
+    `id`,
+    `tenant_id`,
+    `module`,
+    `operation_type`,
+    `description`,
+    `method`,
+    `request_url`,
+    `request_method`,
+    `request_ip`,
+    `request_param`,
+    `response_result`,
+    `status`,
+    `error_msg`,
+    `user_id`,
+    `username`,
+    `operation_time`,
+    `execution_time`
+FROM `sys_operation_log`
+WHERE `operation_type` IN ('删除', '授权', '撤销', '备份', '上报');

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SysAuditControllerIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SysAuditControllerIntegrationTest.java
@@ -17,6 +17,7 @@ import cn.flying.test.support.JwtTestSupport;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
@@ -40,6 +41,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
 
     private static final String BASE_URL = "/api/v1/system/audit";
+    private static final long MAPPER_TEST_TENANT = 929101L;
+    private static final long MAPPER_OTHER_TENANT = 929102L;
 
     @Autowired
     private AccountMapper accountMapper;
@@ -55,6 +58,9 @@ class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     private Account adminAccount;
     private Account monitorAccount;
@@ -130,6 +136,22 @@ class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
 
     private SysOperationLog createTestLog(Long userId, String username, String module,
                                           String operationType, Integer status) {
+        return createTestLog(
+                testTenantId,
+                userId,
+                username,
+                module,
+                operationType,
+                status,
+                LocalDateTime.now()
+        );
+    }
+
+    /**
+     * Creates one operation-log fixture for the specified tenant and timestamp.
+     */
+    private SysOperationLog createTestLog(Long tenantId, Long userId, String username, String module,
+                                          String operationType, Integer status, LocalDateTime operationTime) {
         SysOperationLog log = new SysOperationLog();
         log.setUserId(String.valueOf(userId));
         log.setUsername(username);
@@ -141,9 +163,9 @@ class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
         log.setRequestIp("127.0.0.1");
         log.setStatus(status);
         log.setExecutionTime(100L);
-        log.setOperationTime(LocalDateTime.now());
-        log.setTenantId(testTenantId);
-        TenantContext.runWithTenant(testTenantId, () -> operationLogMapper.insert(log));
+        log.setOperationTime(operationTime);
+        log.setTenantId(tenantId);
+        TenantContext.runWithTenantIsolation(tenantId, () -> operationLogMapper.insert(log));
         return log;
     }
 
@@ -353,14 +375,25 @@ class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
         @Test
         @DisplayName("should return sensitive operations")
         void shouldReturnSensitiveOperations() throws Exception {
+            String username = "sensitive-filter-user";
+            createTestLog(testUserId, username, "file", "查询", 0);
+            createTestLog(testUserId, username, "file", "删除", 0);
+            createTestLog(2L, 200L, username, "file", "删除", 0, LocalDateTime.now());
+
             AuditLogQueryVO queryVO = new AuditLogQueryVO();
             queryVO.setPageNum(1);
             queryVO.setPageSize(20);
+            queryVO.setUsername(username);
+            queryVO.setStatus(0);
+            queryVO.setRequestIp("127.0.0.1");
 
             performPost(BASE_URL + "/sensitive/page", queryVO)
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200))
-                    .andExpect(jsonPath("$.data.records").isArray());
+                    .andExpect(jsonPath("$.data.total").value(1))
+                    .andExpect(jsonPath("$.data.records.length()").value(1))
+                    .andExpect(jsonPath("$.data.records[0].operationType").value("删除"))
+                    .andExpect(jsonPath("$.data.records[0].executionTime").value(100));
         }
     }
 
@@ -447,6 +480,46 @@ class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
     class BackupLogsTests {
 
         @Test
+        @DisplayName("should bypass tenant rewriting while keeping backup and cleanup tenant scoped")
+        void shouldKeepBackupAndCleanupTenantScoped() {
+            LocalDateTime oldOperationTime = LocalDateTime.now().minusDays(2);
+            LocalDateTime cutoffTime = LocalDateTime.now().minusDays(1);
+            SysOperationLog currentTenantLog = createTestLog(
+                    MAPPER_TEST_TENANT, testUserId, "backup-current", "audit", "备份", 0, oldOperationTime);
+            SysOperationLog otherTenantLog = createTestLog(
+                    MAPPER_OTHER_TENANT, 200L, "backup-other", "audit", "备份", 0, oldOperationTime);
+
+            int backedUp = operationLogMapper.insertOperationLogBackup(MAPPER_TEST_TENANT, cutoffTime);
+            int deleted = operationLogMapper.deleteOperationLogsBefore(MAPPER_TEST_TENANT, cutoffTime);
+
+            assertThat(backedUp).isEqualTo(1);
+            assertThat(deleted).isEqualTo(1);
+            assertThat(countBackupRowsById(currentTenantLog.getId())).isEqualTo(1);
+            assertThat(countBackupRowsById(otherTenantLog.getId())).isZero();
+            assertThat(countOperationRowsById(currentTenantLog.getId())).isZero();
+            assertThat(countOperationRowsById(otherTenantLog.getId())).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should count only current-tenant downloads in the half-open window")
+        void shouldCountOnlyCurrentTenantDownloads() {
+            LocalDateTime startTime = LocalDateTime.now().minusMinutes(5);
+            LocalDateTime endTime = LocalDateTime.now().plusMinutes(5);
+            createTestLog(MAPPER_TEST_TENANT, testUserId, "download-query", "file", "查询", 0, LocalDateTime.now());
+            createTestLog(MAPPER_TEST_TENANT, testUserId, "download-update", "file", "修改", 0, LocalDateTime.now());
+            createTestLog(MAPPER_TEST_TENANT, testUserId, "download-current-1", "file", "下载", 0, LocalDateTime.now());
+            createTestLog(MAPPER_TEST_TENANT, testUserId, "download-current-2", "file", "下载", 0, LocalDateTime.now());
+            createTestLog(MAPPER_OTHER_TENANT, 200L, "download-other", "file", "下载", 0, LocalDateTime.now());
+
+            Long downloads = TenantContext.callWithTenantIsolation(
+                    MAPPER_TEST_TENANT,
+                    () -> operationLogMapper.countOperationsByTypeBetween("下载", startTime, endTime)
+            );
+
+            assertThat(downloads).isEqualTo(2L);
+        }
+
+        @Test
         @DisplayName("should backup logs with default parameters")
         void shouldBackupLogsWithDefaultParameters() throws Exception {
             performPost(BASE_URL + "/logs/backups?days=180&deleteAfterBackup=false", null)
@@ -461,6 +534,30 @@ class SysAuditControllerIntegrationTest extends BaseControllerIntegrationTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200));
         }
+    }
+
+    /**
+     * Counts one source-log fixture by ID without applying the application tenant interceptor.
+     */
+    private int countOperationRowsById(Long id) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM sys_operation_log WHERE id = ?",
+                Integer.class,
+                id
+        );
+        return count == null ? 0 : count;
+    }
+
+    /**
+     * Counts one backup-log fixture by ID without applying the application tenant interceptor.
+     */
+    private int countBackupRowsById(Long id) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM sys_operation_log_backup WHERE id = ?",
+                Integer.class,
+                id
+        );
+        return count == null ? 0 : count;
     }
 
     @Nested

--- a/platform-backend/backend-web/src/test/java/cn/flying/dao/mapper/SysOperationLogMapperContractTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/dao/mapper/SysOperationLogMapperContractTest.java
@@ -1,0 +1,97 @@
+package cn.flying.dao.mapper;
+
+import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SysOperationLogMapperContractTest {
+
+    /**
+     * Locks the local interceptor bypass to statements that explicitly enforce tenant and cutoff predicates.
+     */
+    @Test
+    @DisplayName("should keep audit backup and cleanup explicitly tenant scoped")
+    void shouldKeepAuditBackupAndCleanupExplicitlyTenantScoped() throws Exception {
+        assertTenantInterceptorBypassed("insertOperationLogBackup");
+        assertTenantInterceptorBypassed("deleteOperationLogsBefore");
+
+        String mapperXml = loadMapperXml().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
+        String backupSql = extractStatement(mapperXml, "<insert id=\"insertoperationlogbackup\"", "</insert>");
+        String deleteSql = extractStatement(mapperXml, "<delete id=\"deleteoperationlogsbefore\"", "</delete>");
+
+        String targetColumns = backupSql.substring(backupSql.indexOf('(') + 1, backupSql.indexOf(") select"));
+        String selectedColumns = backupSql.substring(backupSql.indexOf(") select") + 8, backupSql.indexOf(" from `sys_operation_log`"));
+
+        assertEquals(1, countOccurrences(targetColumns, "`tenant_id`"));
+        assertEquals(1, countOccurrences(selectedColumns, "`tenant_id`"));
+        assertTrue(backupSql.contains("where `tenant_id` = #{tenantid}"));
+        assertTrue(backupSql.contains("and `operation_time` &lt; #{cutofftime}"));
+        assertTrue(deleteSql.contains("where `tenant_id` = #{tenantid}"));
+        assertTrue(deleteSql.contains("and `operation_time` &lt; #{cutofftime}"));
+    }
+
+    /**
+     * Verifies the monitoring query counts only one canonical type in a half-open window.
+     */
+    @Test
+    @DisplayName("should count only the requested operation type in a half-open window")
+    void shouldCountOnlyRequestedOperationTypeInHalfOpenWindow() throws IOException {
+        String mapperXml = loadMapperXml().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
+        String sql = extractStatement(
+                mapperXml,
+                "<select id=\"countoperationsbytypebetween\"",
+                "</select>");
+
+        assertTrue(sql.contains("operation_type = #{operationtype}"));
+        assertTrue(sql.contains("operation_time >= #{starttime}"));
+        assertTrue(sql.contains("operation_time &lt; #{endtime}"));
+    }
+
+    private void assertTenantInterceptorBypassed(String methodName) throws NoSuchMethodException {
+        Method method = SysOperationLogMapper.class.getMethod(
+                methodName,
+                Long.class,
+                LocalDateTime.class);
+        InterceptorIgnore annotation = method.getAnnotation(InterceptorIgnore.class);
+
+        assertNotNull(annotation);
+        assertEquals("true", annotation.tenantLine());
+    }
+
+    private String loadMapperXml() throws IOException {
+        try (InputStream input = SysOperationLogMapper.class.getResourceAsStream(
+                "/mapper/SysOperationLogMapper.xml")) {
+            assertNotNull(input, "SysOperationLogMapper.xml must be available on the test classpath");
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private String extractStatement(String xml, String startMarker, String endMarker) {
+        int start = xml.indexOf(startMarker);
+        assertTrue(start >= 0, "Missing mapper statement: " + startMarker);
+        int end = xml.indexOf(endMarker, start);
+        assertTrue(end > start, "Unclosed mapper statement: " + startMarker);
+        return xml.substring(start, end + endMarker.length());
+    }
+
+    private int countOccurrences(String value, String token) {
+        int count = 0;
+        int index = 0;
+        while ((index = value.indexOf(token, index)) >= 0) {
+            count++;
+            index += token.length();
+        }
+        return count;
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
@@ -53,6 +53,7 @@ class FlywayMigrationVersionTest {
         assertTrue(migrationFiles.contains("V1.18.0__key_wrapping_provider_metadata.sql"));
         assertTrue(migrationFiles.contains("V1.19.0__automated_key_rotation.sql"));
         assertTrue(migrationFiles.contains("V1.20.0__runtime_crypto_agility.sql"));
+        assertTrue(migrationFiles.contains("V1.20.1__filter_sensitive_operation_view.sql"));
         assertFalse(migrationFiles.contains("V1.5.0__add_account_nickname.sql"));
         assertFalse(migrationFiles.contains("V1.7.3__integrity_alert.sql"));
 
@@ -126,6 +127,21 @@ class FlywayMigrationVersionTest {
         assertTrue(normalizedSql.contains("CREATE TABLE IF NOT EXISTS `tenant_crypto_policy_audit`"));
         assertTrue(normalizedSql.contains("FOREIGN KEY (`tenant_id`, `policy_id`) REFERENCES `tenant_crypto_policy` (`tenant_id`, `id`)"));
         assertFalse(normalizedSql.matches("(?is).*DROP\\s+(TABLE|COLUMN).*"));
+    }
+
+    /**
+     * Verifies the forward view repair uses the canonical sensitive-operation set.
+     */
+    @Test
+    @DisplayName("should filter the sensitive operation view through a forward migration")
+    void shouldFilterSensitiveOperationViewThroughForwardMigration() throws IOException {
+        String sql = Files.readString(resolveMigrationDir().resolve(
+                "V1.20.1__filter_sensitive_operation_view.sql"));
+        String normalizedSql = sql.replaceAll("\\s+", " ").trim();
+
+        assertTrue(normalizedSql.contains("CREATE OR REPLACE VIEW `v_sensitive_operations` AS"));
+        assertTrue(normalizedSql.contains("FROM `sys_operation_log` WHERE `operation_type` IN ('删除', '授权', '撤销', '备份', '上报')"));
+        assertFalse(normalizedSql.contains("SELECT *"));
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayReleasedMigrationCompatibilityIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayReleasedMigrationCompatibilityIT.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Testcontainers(disabledWithoutDocker = false)
 class FlywayReleasedMigrationCompatibilityIT {
 
-    private static final String LATEST_VERSION = "1.20.0";
+    private static final String LATEST_VERSION = "1.20.1";
     private static final String RELEASED_VERSION = "1.7.0";
     private static final String RELEASED_V1_SHA256 =
             "2d62aa70b0f58851579db62034ad12556409201a3cd2e7ad036d709348150645";
@@ -52,7 +52,7 @@ class FlywayReleasedMigrationCompatibilityIT {
     private static final int KNOWN_REWRITTEN_NICKNAME_FLYWAY_CHECKSUM = 529309880;
     private static final int KNOWN_REWRITTEN_SOFT_DELETE_FLYWAY_CHECKSUM = 1607980540;
     private static final int KNOWN_REWRITTEN_INTEGRITY_FLYWAY_CHECKSUM = 2100652293;
-    private static final int KNOWN_REWRITTEN_MIGRATION_COUNT = 38;
+    private static final int KNOWN_REWRITTEN_MIGRATION_COUNT = 39;
 
     @Container
     private static final MySQLContainer<?> MYSQL =

--- a/platform-backend/backend-web/src/test/java/cn/flying/service/impl/SystemMonitorServiceImplTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/service/impl/SystemMonitorServiceImplTest.java
@@ -93,7 +93,7 @@ class SystemMonitorServiceImplTest {
         void shouldReturnSystemStatsWithAllFields() {
             when(accountMapper.selectCount(any())).thenReturn(100L);
             when(fileMapper.selectCount(any())).thenReturn(500L);
-            when(operationLogMapper.selectOperationsBetween(any(), any())).thenReturn(50L);
+            when(operationLogMapper.countOperationsByTypeBetween(eq("下载"), any(), any())).thenReturn(2L);
 
             BlockChainMessage chainMessage = new BlockChainMessage(null, 1000L, null, null, null);
             when(fileRemoteClient.getCurrentBlockChainMessage()).thenReturn(Result.success(chainMessage));
@@ -103,8 +103,10 @@ class SystemMonitorServiceImplTest {
             assertThat(result).isNotNull();
             assertThat(result.totalUsers()).isEqualTo(100L);
             assertThat(result.totalFiles()).isEqualTo(500L);
-            assertThat(result.todayDownloads()).isEqualTo(50L);
+            assertThat(result.todayDownloads()).isEqualTo(2L);
             assertThat(result.totalTransactions()).isEqualTo(1000L);
+            verify(operationLogMapper).countOperationsByTypeBetween(eq("下载"), any(), any());
+            verify(operationLogMapper, never()).selectOperationsBetween(any(), any());
         }
 
         @Test
@@ -112,7 +114,7 @@ class SystemMonitorServiceImplTest {
         void shouldReturnZeroWhenBlockchainFails() {
             when(accountMapper.selectCount(any())).thenReturn(100L);
             when(fileMapper.selectCount(any())).thenReturn(500L);
-            when(operationLogMapper.selectOperationsBetween(any(), any())).thenReturn(50L);
+            when(operationLogMapper.countOperationsByTypeBetween(eq("下载"), any(), any())).thenReturn(0L);
             when(fileRemoteClient.getCurrentBlockChainMessage()).thenThrow(new RuntimeException("Chain error"));
 
             SystemStatsVO result = systemMonitorService.getSystemStats();
@@ -126,7 +128,7 @@ class SystemMonitorServiceImplTest {
         void shouldHandleNullBlockchainResponse() {
             when(accountMapper.selectCount(any())).thenReturn(100L);
             when(fileMapper.selectCount(any())).thenReturn(500L);
-            when(operationLogMapper.selectOperationsBetween(any(), any())).thenReturn(50L);
+            when(operationLogMapper.countOperationsByTypeBetween(eq("下载"), any(), any())).thenReturn(0L);
             when(fileRemoteClient.getCurrentBlockChainMessage()).thenReturn(null);
 
             SystemStatsVO result = systemMonitorService.getSystemStats();
@@ -310,7 +312,7 @@ class SystemMonitorServiceImplTest {
         void shouldAggregateAllMetrics() {
             when(accountMapper.selectCount(any())).thenReturn(100L);
             when(fileMapper.selectCount(any())).thenReturn(500L);
-            when(operationLogMapper.selectOperationsBetween(any(), any())).thenReturn(50L);
+            when(operationLogMapper.countOperationsByTypeBetween(eq("下载"), any(), any())).thenReturn(50L);
 
             BlockChainMessage chainMessage = new BlockChainMessage(100L, 1000L, null, null, null);
             when(fileRemoteClient.getCurrentBlockChainMessage()).thenReturn(Result.success(chainMessage));
@@ -341,7 +343,7 @@ class SystemMonitorServiceImplTest {
 
             when(accountMapper.selectCount(any())).thenReturn(1L);
             when(fileMapper.selectCount(any())).thenReturn(1L);
-            when(operationLogMapper.selectOperationsBetween(any(), any())).thenReturn(0L);
+            when(operationLogMapper.countOperationsByTypeBetween(eq("下载"), any(), any())).thenReturn(0L);
             when(fileRemoteClient.getCurrentBlockChainMessage()).thenReturn(Result.success(new BlockChainMessage(null, null, null, null, null)));
 
             Health upHealth = Health.up().build();

--- a/platform-frontend/pnpm-lock.yaml
+++ b/platform-frontend/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   cookie@0.6.0: 0.7.0
   esbuild@0.21.5: 0.25.0
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   js-yaml@>=4.0.0 <5: 4.3.1
   minimatch@3: 3.1.4
   minimatch@5: 5.1.8
@@ -1389,8 +1389,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -2800,7 +2800,7 @@ snapshots:
   '@redocly/ajv@8.17.4':
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3602,7 +3602,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/platform-frontend/pnpm-workspace.yaml
+++ b/platform-frontend/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ overrides:
   cookie@0.6.0: 0.7.0
   esbuild@0.21.5: 0.25.0
   esbuild@>=0.27.3 <0.28.1: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   js-yaml@>=4.0.0 <5: 4.3.1
   minimatch@3: 3.1.4
   minimatch@5: 5.1.8

--- a/platform-frontend/src/lib/components/FilePreview.render.test.ts
+++ b/platform-frontend/src/lib/components/FilePreview.render.test.ts
@@ -78,6 +78,25 @@ describe("FilePreview", () => {
     expect(view.getByRole("link", { name: "下载文件" })).toBeTruthy();
   });
 
+  it("preserves wide text lines inside a horizontally scrollable preview", async () => {
+    const wideLine = "SELECT " + "column_name,".repeat(200);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(wideLine, { status: 200 })),
+    );
+    const view = render(FilePreview, {
+      url: "blob:https://example.test/wide-sql",
+      fileName: "wide.sql",
+      contentType: "text/plain",
+    });
+
+    await waitFor(() => expect(view.getByText(wideLine)).toBeTruthy());
+    const preview = view.container.querySelector("pre");
+    expect(preview).not.toBeNull();
+    expect(preview?.className).toContain("overflow-auto");
+    expect(window.getComputedStyle(preview!).whiteSpace).toBe("pre");
+  });
+
   it("resets a native decode failure and reloads text when the source changes", async () => {
     vi.stubGlobal(
       "fetch",

--- a/platform-frontend/src/lib/components/FilePreview.svelte
+++ b/platform-frontend/src/lib/components/FilePreview.svelte
@@ -7,9 +7,16 @@
     contentType: string;
     fileName: string;
     class?: string;
+    fillContainer?: boolean;
   }
 
-  let { url, contentType, fileName, class: className = "" }: Props = $props();
+  let {
+    url,
+    contentType,
+    fileName,
+    class: className = "",
+    fillContainer = false,
+  }: Props = $props();
 
   let textContent = $state("");
   let loadingText = $state(false);
@@ -73,7 +80,11 @@
   }
 </script>
 
-<div class="file-preview {className}">
+<div
+  class="file-preview min-h-0 min-w-0 {fillContainer
+    ? 'h-full w-full'
+    : ''} {className}"
+>
   {#if nativePreviewError}
     <div
       class="bg-muted/30 flex flex-col items-center justify-center gap-4 rounded-lg border p-12"
@@ -85,20 +96,32 @@
       >
     </div>
   {:else if previewType === "image"}
-    <div class="bg-muted/30 flex items-center justify-center p-4">
+    <div
+      class="bg-muted/30 flex items-center justify-center p-4 {fillContainer
+        ? 'h-full'
+        : ''}"
+    >
       <img
         src={url}
         alt={fileName}
-        class="max-h-[70vh] max-w-full rounded-lg object-contain shadow-lg"
+        class="max-w-full rounded-lg object-contain shadow-lg {fillContainer
+          ? 'max-h-full'
+          : 'max-h-[70vh]'}"
         onerror={() => (nativePreviewError = true)}
       />
     </div>
   {:else if previewType === "video"}
-    <div class="flex items-center justify-center bg-black p-4">
+    <div
+      class="flex items-center justify-center bg-black p-4 {fillContainer
+        ? 'h-full'
+        : ''}"
+    >
       <video
         src={url}
         controls
-        class="max-h-[70vh] max-w-full rounded-lg"
+        class="max-w-full rounded-lg {fillContainer
+          ? 'max-h-full'
+          : 'max-h-[70vh]'}"
         preload="metadata"
         onerror={() => (nativePreviewError = true)}
       >
@@ -138,7 +161,7 @@
       </audio>
     </div>
   {:else if previewType === "pdf"}
-    <div class="h-[70vh] w-full">
+    <div class="w-full {fillContainer ? 'h-full' : 'h-[70vh]'}">
       <iframe
         src={url}
         title={fileName}
@@ -146,7 +169,11 @@
       ></iframe>
     </div>
   {:else if previewType === "text"}
-    <div class="bg-muted/30 overflow-hidden rounded-lg border">
+    <div
+      class="bg-muted/30 rounded-lg border {fillContainer
+        ? 'min-h-full min-w-full'
+        : 'overflow-hidden'}"
+    >
       {#if loadingText}
         <div class="flex items-center justify-center p-8">
           <div
@@ -159,7 +186,9 @@
         </div>
       {:else}
         <pre
-          class="max-h-[70vh] overflow-auto p-4 text-sm {getLanguageClass(
+          class="p-4 text-sm {fillContainer
+            ? 'min-h-full min-w-max'
+            : 'max-h-[70vh] overflow-auto'} {getLanguageClass(
             contentType,
           )}"><code>{textContent}</code></pre>
       {/if}
@@ -197,8 +226,9 @@
 <style>
   pre {
     margin: 0;
-    white-space: pre-wrap;
-    word-wrap: break-word;
+    white-space: pre;
+    overflow-wrap: normal;
+    word-break: normal;
   }
   code {
     font-family:

--- a/platform-frontend/src/routes/(app)/admin/audit/components/AuditDashboard.render.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/AuditDashboard.render.test.ts
@@ -8,12 +8,21 @@ const apiMocks = vi.hoisted(() => ({
   getUserTimeDistribution: vi.fn(),
   getAuditLogs: vi.fn(),
   getAuditLog: vi.fn(),
+  getSensitiveOperations: vi.fn(),
 }));
 
 vi.mock("$api/endpoints/system", () => apiMocks);
 
 import AuditDashboard from "./AuditDashboard.svelte";
 import AuditLogList from "./AuditLogList.svelte";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
 
 describe("AuditDashboard high-frequency drill", () => {
   const alert = {
@@ -36,6 +45,10 @@ describe("AuditDashboard high-frequency drill", () => {
     apiMocks.getErrorOperationStats.mockResolvedValue([]);
     apiMocks.getUserTimeDistribution.mockResolvedValue([]);
     apiMocks.getAuditLogs.mockResolvedValue({ records: [], total: 0 });
+    apiMocks.getSensitiveOperations.mockResolvedValue({
+      records: [],
+      total: 0,
+    });
     vi.stubGlobal("scrollTo", vi.fn());
     Element.prototype.scrollIntoView = vi.fn();
   });
@@ -105,5 +118,101 @@ describe("AuditDashboard high-frequency drill", () => {
     expect(
       (view.getByPlaceholderText("请求 IP") as HTMLInputElement).value,
     ).toBe(alert.requestIp);
+  });
+
+  it("uses server-side pagination when sensitive mode is selected", async () => {
+    apiMocks.getSensitiveOperations.mockResolvedValue({
+      records: [
+        {
+          id: "ext-sensitive-1",
+          module: "权限管理",
+          operationType: "授权",
+          requestIp: "10.1.0.2",
+          status: 0,
+          userId: "user-1",
+          username: "tester",
+          operationTime: "2026-09-03 09:45:50",
+          executionTime: 9,
+        },
+      ],
+      total: 21,
+    });
+    const view = render(AuditLogList);
+
+    await waitFor(() => expect(apiMocks.getAuditLogs).toHaveBeenCalled());
+    await fireEvent.click(view.getByRole("button", { name: "敏感" }));
+
+    await waitFor(() => {
+      expect(apiMocks.getSensitiveOperations).toHaveBeenCalledWith({
+        pageNum: 1,
+        pageSize: 20,
+      });
+    });
+    expect(view.getAllByText("授权")).toHaveLength(2);
+    expect(view.getByText(/共 21 条/)).toBeTruthy();
+    expect(apiMocks.getAuditLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores an older ordinary-page response after switching to sensitive mode", async () => {
+    const ordinaryRequest = deferred<{
+      records: Array<{
+        id: string;
+        userId: string;
+        username: string;
+        action: string;
+        module: string;
+        ip: string;
+        status: number;
+        duration: number;
+        createTime: string;
+      }>;
+      total: number;
+    }>();
+    apiMocks.getAuditLogs.mockReturnValueOnce(ordinaryRequest.promise);
+    apiMocks.getSensitiveOperations.mockResolvedValueOnce({
+      records: [
+        {
+          id: "ext-sensitive-latest",
+          module: "权限管理",
+          operationType: "删除",
+          requestIp: "10.1.0.2",
+          status: 0,
+          userId: "user-1",
+          username: "sensitive-latest",
+          operationTime: "2026-09-03 09:45:50",
+          executionTime: 9,
+        },
+      ],
+      total: 1,
+    });
+
+    const view = render(AuditLogList);
+    await waitFor(() => expect(apiMocks.getAuditLogs).toHaveBeenCalledOnce());
+    await fireEvent.click(view.getByRole("button", { name: "敏感" }));
+    await waitFor(() =>
+      expect(view.getByText("sensitive-latest")).toBeTruthy(),
+    );
+
+    ordinaryRequest.resolve({
+      records: [
+        {
+          id: "ext-ordinary-stale",
+          userId: "user-2",
+          username: "ordinary-stale",
+          action: "查询",
+          module: "系统审计",
+          ip: "10.1.0.3",
+          status: 0,
+          duration: 3,
+          createTime: "2026-09-03 09:45:49",
+        },
+      ],
+      total: 1,
+    });
+
+    await waitFor(() => {
+      expect(view.queryByText("ordinary-stale")).toBeNull();
+      expect(view.getByText("sensitive-latest")).toBeTruthy();
+    });
   });
 });

--- a/platform-frontend/src/routes/(app)/admin/audit/components/AuditLogList.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/AuditLogList.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { onMount, untrack } from "svelte";
   import { formatDateTime } from "$utils/format";
-  import { getAuditLogs, getAuditLog } from "$api/endpoints/system";
+  import {
+    getAuditLogs,
+    getAuditLog,
+    getSensitiveOperations,
+  } from "$api/endpoints/system";
   import type {
     AuditLogVO,
     AuditLogQueryParams,
@@ -14,6 +18,7 @@
   import * as Card from "$components/ui/card";
   import DateTimePicker from "$components/ui/date-picker/date-time-picker.svelte";
   import LogDetailDialog from "./dialogs/LogDetailDialog.svelte";
+  import { mapSensitiveOperation } from "./audit-log-display";
   import { useNotifications } from "$stores/notifications.svelte";
   import {
     AUDIT_MODULES,
@@ -47,6 +52,7 @@
   let page = $state(1);
   let pageSize = $state(20);
   let total = $state(0);
+  let loadSequence = 0;
 
   let filterUsername = $state("");
   let filterUserId = $state("");
@@ -99,6 +105,7 @@
   });
 
   async function loadLogs() {
+    const requestSequence = ++loadSequence;
     loading = true;
     try {
       const params: AuditLogQueryParams & {
@@ -117,16 +124,25 @@
       if (filterStartTime) params.startTime = filterStartTime;
       if (filterEndTime) params.endTime = filterEndTime;
 
-      const result = await getAuditLogs(params);
-      logs = result.records;
-      total = result.total;
+      if (onlySensitive) {
+        const result = await getSensitiveOperations(params);
+        if (requestSequence !== loadSequence) return;
+        logs = result.records.map(mapSensitiveOperation);
+        total = result.total;
+      } else {
+        const result = await getAuditLogs(params);
+        if (requestSequence !== loadSequence) return;
+        logs = result.records;
+        total = result.total;
+      }
     } catch (err) {
+      if (requestSequence !== loadSequence) return;
       notifications.error(
         "加载失败",
         err instanceof Error ? err.message : "请稍后重试",
       );
     } finally {
-      loading = false;
+      if (requestSequence === loadSequence) loading = false;
     }
   }
 
@@ -190,13 +206,6 @@
       }
     }
   }
-
-  /** 显示的日志列表（考虑 onlySensitive 客户端过滤） */
-  const displayLogs = $derived(
-    onlySensitive
-      ? logs.filter((log) => isSensitiveOperation(log.action))
-      : logs,
-  );
 
   const totalPages = $derived(Math.max(1, Math.ceil(total / pageSize)));
 </script>
@@ -313,7 +322,7 @@
             </Table.Row>
           </Table.Header>
           <Table.Body>
-            {#each displayLogs as log (log.id)}
+            {#each logs as log (log.id)}
               <Table.Row
                 class="hover:bg-muted/40 cursor-pointer"
                 onclick={() => openLogDetail(log)}
@@ -367,7 +376,7 @@
         </Table.Root>
       </div>
 
-      {#if displayLogs.length === 0}
+      {#if logs.length === 0}
         <div class="text-muted-foreground p-6 text-center text-sm">
           {onlySensitive ? "暂无敏感操作日志" : "暂无日志"}
         </div>

--- a/platform-frontend/src/routes/(app)/admin/audit/components/audit-log-display.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/audit-log-display.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatAuditPayload, mapSensitiveOperation } from "./audit-log-display";
+
+describe("audit log display helpers", () => {
+  it("maps a sensitive operation into the shared table contract", () => {
+    expect(
+      mapSensitiveOperation({
+        id: "ext-log-1",
+        module: "权限管理",
+        operationType: "授权",
+        requestIp: "10.1.0.2",
+        status: 0,
+        userId: "user-1",
+        username: "tester",
+        operationTime: "2026-09-03 09:45:50",
+        executionTime: 9,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        id: "ext-log-1",
+        action: "授权",
+        module: "权限管理",
+        ip: "10.1.0.2",
+        duration: 9,
+        createTime: "2026-09-03 09:45:50",
+      }),
+    );
+  });
+
+  it("formats valid JSON and preserves plain text", () => {
+    expect(formatAuditPayload('{"status":"ok","count":2}')).toBe(
+      '{\n  "status": "ok",\n  "count": 2\n}',
+    );
+    expect(formatAuditPayload("plain response")).toBe("plain response");
+    expect(formatAuditPayload("  ")).toBe("-");
+  });
+});

--- a/platform-frontend/src/routes/(app)/admin/audit/components/audit-log-display.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/audit-log-display.ts
@@ -1,0 +1,29 @@
+import type { AuditLogVO, SysOperationLog } from "$api/types";
+
+/** Maps the sensitive-operation DTO into the shared audit table row contract. */
+export function mapSensitiveOperation(log: SysOperationLog): AuditLogVO {
+  return {
+    id: String(log.id),
+    userId: log.userId ?? "",
+    username: log.username ?? "",
+    action: log.operationType,
+    module: log.module,
+    detail: log.requestParam,
+    ip: log.requestIp ?? "",
+    status: log.status ?? 0,
+    errorMessage: log.errorMsg,
+    duration: log.executionTime ?? 0,
+    createTime: log.operationTime ?? "",
+  };
+}
+
+/** Formats structured audit payloads while preserving non-JSON text verbatim. */
+export function formatAuditPayload(value?: string | null): string {
+  if (!value || value.trim() === "") return "-";
+
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}

--- a/platform-frontend/src/routes/(app)/admin/audit/components/dialogs/LogDetailDialog.render.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/dialogs/LogDetailDialog.render.test.ts
@@ -1,0 +1,77 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import LogDetailDialog from "./LogDetailDialog.svelte";
+
+describe("LogDetailDialog", () => {
+  afterEach(cleanup);
+
+  it("separates HTTP method from handler and formats structured payloads", () => {
+    const view = render(LogDetailDialog, {
+      open: true,
+      loading: false,
+      onOpenChange: () => undefined,
+      log: {
+        id: "ext-log-1",
+        userId: "user-1",
+        username: "tester",
+        action: "查询",
+        module: "系统审计",
+        ip: "10.1.0.2",
+        status: 0,
+        duration: 9,
+        createTime: "2026-09-03 09:45:50",
+      },
+      detail: {
+        id: "ext-log-1",
+        module: "系统审计",
+        operationType: "查询",
+        description: "获取审计概览数据",
+        method: "cn.flying.controller.SysAuditController.getAuditOverview",
+        requestUrl: "/record-platform/api/v1/system/audit/overview",
+        requestMethod: "GET",
+        requestIp: "10.1.0.2",
+        requestParam: '{"page":1}',
+        responseResult: '{"code":200}',
+        status: 0,
+        username: "tester",
+        operationTime: "2026-09-03 09:45:50",
+        executionTime: 9,
+      },
+    });
+
+    expect(view.getByText("HTTP 请求方式")).toBeTruthy();
+    expect(view.getByText("GET")).toBeTruthy();
+    expect(view.getByText("处理方法")).toBeTruthy();
+    expect(
+      view.getByText(
+        "cn.flying.controller.SysAuditController.getAuditOverview",
+      ),
+    ).toBeTruthy();
+    expect(view.getByText("操作描述")).toBeTruthy();
+    expect(view.getByText("操作时间")).toBeTruthy();
+    expect(view.getByText(/"page": 1/)).toBeTruthy();
+    expect(view.getByText(/"code": 200/)).toBeTruthy();
+    expect(view.getByText("9ms")).toBeTruthy();
+    expect(view.getByText("错误信息")).toBeTruthy();
+    expect(view.getByTestId("audit-error-message").textContent).toBe("-");
+  });
+
+  it("shows a placeholder instead of fabricating zero duration", () => {
+    const view = render(LogDetailDialog, {
+      open: true,
+      loading: false,
+      onOpenChange: () => undefined,
+      log: null,
+      detail: {
+        id: "ext-log-empty",
+        module: "系统审计",
+        operationType: "查询",
+        status: 0,
+      },
+    });
+
+    const durationLabel = view.getByText("执行耗时");
+    expect(durationLabel.parentElement?.textContent).toContain("-");
+    expect(durationLabel.parentElement?.textContent).not.toContain("0ms");
+  });
+});

--- a/platform-frontend/src/routes/(app)/admin/audit/components/dialogs/LogDetailDialog.svelte
+++ b/platform-frontend/src/routes/(app)/admin/audit/components/dialogs/LogDetailDialog.svelte
@@ -2,6 +2,7 @@
   import * as Dialog from "$components/ui/dialog";
   import { Badge } from "$components/ui/badge";
   import type { SysOperationLog, AuditLogVO } from "$api/types";
+  import { formatAuditPayload } from "../audit-log-display";
 
   interface Props {
     open: boolean;
@@ -23,7 +24,9 @@
 </script>
 
 <Dialog.Root {open} {onOpenChange}>
-  <Dialog.Content class="max-w-3xl">
+  <Dialog.Content
+    class="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-5xl grid-rows-[auto_minmax(0,1fr)] overflow-hidden sm:max-w-5xl"
+  >
     <Dialog.Header>
       <Dialog.Title>日志详情</Dialog.Title>
       {#if log}
@@ -35,62 +38,104 @@
 
     {#if loading}
       <div class="flex items-center justify-center p-10">
-        <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+        <div
+          class="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent"
+        ></div>
       </div>
     {:else}
-      <div class="grid gap-4">
+      <div class="min-h-0 min-w-0 overflow-y-auto pr-1">
         {#if detail}
-          <div class="grid gap-4 rounded-lg border p-4">
-            <div class="grid gap-4 md:grid-cols-2">
-              <div>
-                <p class="text-xs text-muted-foreground">请求URL</p>
-                <p class="mt-1 break-all font-mono text-sm">{detail.requestUrl || "-"}</p>
+          <div class="grid min-w-0 gap-4 rounded-lg border p-4">
+            <div class="grid min-w-0 gap-4 md:grid-cols-2">
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">请求 URL</p>
+                <p class="mt-1 font-mono text-sm break-all">
+                  {detail.requestUrl || "-"}
+                </p>
               </div>
-              <div>
-                <p class="text-xs text-muted-foreground">请求方法</p>
-                <p class="mt-1 font-mono text-sm">{detail.method || detail.requestMethod || "-"}</p>
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">HTTP 请求方式</p>
+                <p class="mt-1 font-mono text-sm break-all">
+                  {detail.requestMethod || "-"}
+                </p>
               </div>
-              <div>
-                <p class="text-xs text-muted-foreground">IP地址</p>
-                <p class="mt-1 font-mono text-sm">{detail.requestIp || "-"}</p>
+              <div class="min-w-0 md:col-span-2">
+                <p class="text-muted-foreground text-xs">处理方法</p>
+                <p class="mt-1 font-mono text-sm break-all">
+                  {detail.method || "-"}
+                </p>
               </div>
-              <div>
-                <p class="text-xs text-muted-foreground">执行耗时</p>
-                <p class="mt-1 font-mono text-sm">{detail.executionTime ?? 0}ms</p>
+              <div class="min-w-0 md:col-span-2">
+                <p class="text-muted-foreground text-xs">操作描述</p>
+                <p class="mt-1 text-sm break-words">
+                  {detail.description || "-"}
+                </p>
               </div>
-              <div>
-                <p class="text-xs text-muted-foreground">状态</p>
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">操作时间</p>
+                <p class="mt-1 font-mono text-sm break-all">
+                  {detail.operationTime || "-"}
+                </p>
+              </div>
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">IP 地址</p>
+                <p class="mt-1 font-mono text-sm break-all">
+                  {detail.requestIp || "-"}
+                </p>
+              </div>
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">执行耗时</p>
+                <p class="mt-1 font-mono text-sm">
+                  {detail.executionTime == null
+                    ? "-"
+                    : `${detail.executionTime}ms`}
+                </p>
+              </div>
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">状态</p>
                 <div class="mt-1">
                   <Badge variant={getStatusVariant(detail.status)}>
                     {getStatusLabel(detail.status)}
                   </Badge>
                 </div>
               </div>
-              <div>
-                <p class="text-xs text-muted-foreground">操作用户</p>
-                <p class="mt-1 text-sm">{detail.username || detail.userId || "-"}</p>
+              <div class="min-w-0">
+                <p class="text-muted-foreground text-xs">操作用户</p>
+                <p class="mt-1 text-sm break-all">
+                  {detail.username || detail.userId || "-"}
+                </p>
               </div>
             </div>
 
-            <div>
-              <p class="text-xs text-muted-foreground">请求参数</p>
-              <pre class="mt-1 max-h-[180px] overflow-auto rounded-md bg-muted/30 p-3 font-mono text-xs">{detail.requestParam || "-"}</pre>
+            <div class="min-w-0">
+              <p class="text-muted-foreground text-xs">请求参数</p>
+              <pre
+                class="bg-muted/30 mt-1 max-h-[240px] max-w-full overflow-auto rounded-md p-3 font-mono text-xs break-words whitespace-pre-wrap">{formatAuditPayload(
+                  detail.requestParam,
+                )}</pre>
             </div>
 
-            <div>
-              <p class="text-xs text-muted-foreground">响应结果</p>
-              <pre class="mt-1 max-h-[180px] overflow-auto rounded-md bg-muted/30 p-3 font-mono text-xs">{detail.responseResult || "-"}</pre>
+            <div class="min-w-0">
+              <p class="text-muted-foreground text-xs">响应结果</p>
+              <pre
+                class="bg-muted/30 mt-1 max-h-[240px] max-w-full overflow-auto rounded-md p-3 font-mono text-xs break-words whitespace-pre-wrap">{formatAuditPayload(
+                  detail.responseResult,
+                )}</pre>
             </div>
 
-            {#if detail.errorMsg}
-              <div>
-                <p class="text-xs text-muted-foreground">错误信息</p>
-                <pre class="mt-1 max-h-[120px] overflow-auto rounded-md bg-destructive/10 p-3 font-mono text-xs text-destructive">{detail.errorMsg}</pre>
-              </div>
-            {/if}
+            <div class="min-w-0">
+              <p class="text-muted-foreground text-xs">错误信息</p>
+              <pre
+                data-testid="audit-error-message"
+                class="bg-destructive/10 text-destructive mt-1 max-h-[180px] max-w-full overflow-auto rounded-md p-3 font-mono text-xs break-words whitespace-pre-wrap">{formatAuditPayload(
+                  detail.errorMsg,
+                )}</pre>
+            </div>
           </div>
         {:else}
-          <div class="p-6 text-center text-sm text-muted-foreground">无法获取详情</div>
+          <div class="text-muted-foreground p-6 text-center text-sm">
+            无法获取详情
+          </div>
         {/if}
       </div>
     {/if}

--- a/platform-frontend/src/routes/(app)/admin/files/+page.svelte
+++ b/platform-frontend/src/routes/(app)/admin/files/+page.svelte
@@ -283,6 +283,7 @@
   let previewContentType = $state("");
   let previewFileName = $state("");
   let previewLoading = $state(false);
+  let previewExpanded = $state(false);
 
   // 下载状态
   let downloadingHash = $state<string | null>(null);
@@ -294,6 +295,7 @@
   ) {
     previewLoading = true;
     previewDialogOpen = true;
+    previewExpanded = false;
     previewContentType = contentType;
     previewFileName = fileName;
     previewUrl = "";
@@ -313,6 +315,7 @@
 
   function closePreview() {
     previewDialogOpen = false;
+    previewExpanded = false;
     if (previewUrl) {
       URL.revokeObjectURL(previewUrl);
       previewUrl = "";
@@ -1204,26 +1207,45 @@
     if (!open) closePreview();
   }}
 >
-  <Dialog.Content class="max-h-[90vh] max-w-4xl overflow-y-auto">
+  <Dialog.Content
+    class={previewExpanded
+      ? "h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-[calc(100vw-2rem)]"
+      : "h-[min(80vh,48rem)] w-[calc(100vw-2rem)] max-w-4xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-4xl"}
+    data-preview-expanded={previewExpanded}
+  >
     <Dialog.Header>
       <Dialog.Title>文件预览</Dialog.Title>
       <Dialog.Description>{previewFileName}</Dialog.Description>
     </Dialog.Header>
-    {#if previewLoading}
-      <div class="flex items-center justify-center p-16">
-        <div
-          class="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent"
-        ></div>
-        <span class="text-muted-foreground ml-3 text-sm">加载中...</span>
-      </div>
-    {:else if previewUrl}
-      <FilePreview
-        url={previewUrl}
-        contentType={previewContentType}
-        fileName={previewFileName}
-      />
-    {/if}
+    <div
+      class="bg-muted/10 min-h-0 min-w-0 overflow-auto rounded-lg"
+      data-testid="file-preview-scroll-region"
+    >
+      {#if previewLoading}
+        <div class="flex min-h-full items-center justify-center p-16">
+          <div
+            class="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent"
+          ></div>
+          <span class="text-muted-foreground ml-3 text-sm">加载中...</span>
+        </div>
+      {:else if previewUrl}
+        <FilePreview
+          url={previewUrl}
+          contentType={previewContentType}
+          fileName={previewFileName}
+          fillContainer={true}
+          class="min-h-full min-w-full"
+        />
+      {/if}
+    </div>
     <Dialog.Footer>
+      <Button
+        variant="outline"
+        aria-pressed={previewExpanded}
+        onclick={() => (previewExpanded = !previewExpanded)}
+      >
+        {previewExpanded ? "恢复窗口" : "放大查看"}
+      </Button>
       <Button variant="outline" onclick={closePreview}>关闭</Button>
     </Dialog.Footer>
   </Dialog.Content>

--- a/platform-frontend/src/routes/(app)/admin/files/page.render.test.ts
+++ b/platform-frontend/src/routes/(app)/admin/files/page.render.test.ts
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const adminApiMocks = vi.hoisted(() => ({
+  getAllFiles: vi.fn(),
+  getFileDetail: vi.fn(),
+  updateFileStatus: vi.fn(),
+  forceDeleteFile: vi.fn(),
+  getAllShares: vi.fn(),
+  forceCancelShare: vi.fn(),
+  getShareAccessLogs: vi.fn(),
+}));
+const fileApiMocks = vi.hoisted(() => ({ downloadFile: vi.fn() }));
+
+vi.mock("$api/endpoints/admin", () => adminApiMocks);
+vi.mock("$api/endpoints/files", () => fileApiMocks);
+
+import AdminFilesPage from "./+page.svelte";
+
+describe("admin file preview dialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminApiMocks.getAllFiles.mockResolvedValue({
+      records: [
+        {
+          id: "file-1",
+          fileName: "wide.sql",
+          fileHash: "hash-1",
+          fileSize: 1024,
+          contentType: "text/plain",
+          status: 1,
+          statusDesc: "已完成",
+          ownerId: "owner-1",
+          ownerName: "tester",
+          isOriginal: true,
+          depth: 0,
+          createTime: "2026-09-03 09:45:50",
+        },
+      ],
+      total: 1,
+    });
+    fileApiMocks.downloadFile.mockResolvedValue(
+      new Blob(["SELECT " + "column_name,".repeat(200)], {
+        type: "text/plain",
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("wide line")),
+    );
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: vi.fn(() => "blob:preview-file-1"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("provides a bounded scroll region and resets expanded mode after close", async () => {
+    const view = render(AdminFilesPage);
+    await waitFor(() => expect(view.getByText("wide.sql")).toBeTruthy());
+
+    await fireEvent.click(view.getByTitle("预览"));
+    await waitFor(() => expect(view.getByText("放大查看")).toBeTruthy());
+
+    const scrollRegion = view.getByTestId("file-preview-scroll-region");
+    expect(scrollRegion.className).toContain("overflow-auto");
+    await waitFor(() =>
+      expect(scrollRegion.querySelector("pre")).not.toBeNull(),
+    );
+    expect(scrollRegion.querySelector("pre")?.className).toContain("min-w-max");
+    expect(scrollRegion.querySelector("pre")?.className).not.toContain(
+      "overflow-auto",
+    );
+    const dialog = scrollRegion.closest('[data-slot="dialog-content"]');
+    expect(dialog?.getAttribute("data-preview-expanded")).toBe("false");
+
+    await fireEvent.click(view.getByRole("button", { name: "放大查看" }));
+    expect(view.getByRole("button", { name: "恢复窗口" })).toBeTruthy();
+    expect(dialog?.getAttribute("data-preview-expanded")).toBe("true");
+
+    await fireEvent.click(view.getByRole("button", { name: "关闭" }));
+    await fireEvent.click(view.getByTitle("预览"));
+    await waitFor(() => expect(view.getByText("放大查看")).toBeTruthy());
+    expect(
+      view
+        .getByTestId("file-preview-scroll-region")
+        .closest('[data-slot="dialog-content"]')
+        ?.getAttribute("data-preview-expanded"),
+    ).toBe("false");
+  });
+});


### PR DESCRIPTION
## 修复内容

- 修复审计日志备份被多租户拦截器重复追加 tenant_id
- 修复系统监控将全部操作统计为下载
- 修复敏感日志视图、服务端筛选和分页竞态
- 优化文件审计预览窗口的自适应、放大和双轴滚动
- 修复审计日志详情字段语义、长内容和 JSON 展示

## 数据库

- 新增前向迁移 V1.20.1__filter_sensitive_operation_view.sql
- 历史迁移未修改

## 验证

- 前端 51 个测试文件、612 项测试通过
- 前端 format、lint、Svelte check、coverage、build 通过
- backend-service 1464 项单元测试通过
- backend-web 567 项单元测试通过
- 后端 focused tests 36 项通过
- Flyway 版本与 released migration checksum 检查通过
- 本机无 Docker；新增真实 MySQL/Testcontainers 场景已编译，交由 Required CI 实际执行

## 范围边界

本 PR 不包含租户内用户管理或全局管理员功能；相关系统优化将在本 PR 合并部署后独立规划。