### PR TITLE
feat: 建立平台身份与租户状态授权基础

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,14 @@ MINIO_B_CONSOLE_PORT=9011
 # JWT 密钥 (建议使用 32 字符以上的随机字符串)
 # 同时用于 ID 加密密钥派生，无需额外配置
 JWT_KEY=your_jwt_secret_key_at_least_32_characters
+# Platform identity remains disabled until the forward migration and one-time bootstrap are ready.
+PLATFORM_IDENTITY_ENABLED=false
+AUTHORIZATION_STATE_CACHE_TTL=30s
+# One-time bootstrap: all values are intentionally blank and password content stays in a local file.
+PLATFORM_BOOTSTRAP_ENABLED=false
+PLATFORM_BOOTSTRAP_USERNAME=
+PLATFORM_BOOTSTRAP_EMAIL=
+PLATFORM_BOOTSTRAP_PASSWORD_FILE=
 # 文件密钥信封 provider。生产必须显式选择 local 或 vault-transit。
 FILE_KEY_ENVELOPE_ACTIVE_PROVIDER=local
 FILE_KEY_ENVELOPE_ACTIVE_PROVIDER_CONTRACT_VERSION=1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,9 +27,9 @@
 | 指标 | 当前值 | 自动校验来源 |
 | --- | ---: | --- |
 | REST 控制器 | 33 | `platform-backend/backend-web/src/main/java` |
-| 后端服务类 | 213 | `platform-backend/backend-service/src/main/java` |
-| 后端测试文件 | 220 | `platform-backend/**/src/test/java` |
-| 数据库迁移 | 39（V1.0.0 ~ V1.20.1） | `platform-backend/backend-web/src/main/resources/db/migration` |
+| 后端服务类 | 216 | `platform-backend/backend-service/src/main/java` |
+| 后端测试文件 | 226 | `platform-backend/**/src/test/java` |
+| 数据库迁移 | 40（V1.0.0 ~ V1.21.0） | `platform-backend/backend-web/src/main/resources/db/migration` |
 | 核心工作流 | 5 | `test.yml`、`perf-smoke.yml`、`docs.yml`、`security-poc.yml`、`docs-consistency.yml` |
 
 | 组件 | 当前基线 | 演进原则 |

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 本项目采用"单元测试优先 + 少量高价值集成测试"的策略，目标是在 CI 中尽早发现回归，同时保持本地开发的执行成本足够低。
 
-## 当前测试文件快照（344 files）
+## 当前测试文件快照（350 files）
 
 > 2026-09-03 按 canonical source tree 中的 `*Test.java` / `*IT.java` / `*.test.ts` / `*.spec.ts` / `test_*.py` / `*_test.py` 统计。该数字是文件快照，不等同 test case 数；以下长表只说明代表性覆盖。`tools/docs/check_consistency.py --check-evidence` 会从 exact tree 重新计算并核对本表。
 
@@ -10,9 +10,9 @@
 | --- | ---: |
 | `platform-backend/backend-common` | 13 |
 | `platform-backend/backend-api` | 1 |
-| `platform-backend/backend-service` | 97 |
-| `platform-backend/backend-web` | 109 |
-| `platform-backend` | 220 |
+| `platform-backend/backend-service` | 100 |
+| `platform-backend/backend-web` | 112 |
+| `platform-backend` | 226 |
 | `platform-storage` | 28 |
 | `platform-frontend` | 52 |
 | `platform-verifier` | 15 |
@@ -22,7 +22,7 @@
 | `tools/contracts` | 4 |
 | `tools/docs` | 1 |
 | `tools` | 12 |
-| `total` | 344 |
+| `total` | 350 |
 
 ### 后端单元测试（backend-common，代表性测试类）
 

--- a/docs/en/deployment/index.md
+++ b/docs/en/deployment/index.md
@@ -9,6 +9,7 @@ Deployment and operations guide for RecordPlatform.
 - [Production](production.md) - Production environment setup
 - [Monitoring](monitoring) - Metrics, alerts, and health checks
 - [Container releases](container-release) - Public GHCR packages and anonymous pull verification
+- [Platform administrator bootstrap](platform-administrator-bootstrap) - One-time local password-file provisioning and recovery boundary
 
 ## Deployment Options
 

--- a/docs/en/deployment/platform-administrator-bootstrap.md
+++ b/docs/en/deployment/platform-administrator-bootstrap.md
@@ -1,0 +1,20 @@
+# Platform Administrator Bootstrap
+
+The platform identity foundation is disabled by default. Complete the `V1.21.0` Flyway migration and verify MySQL and Redis availability before enabling it.
+
+## One-time procedure
+
+1. Stop all but one backend replica.
+2. Create a local password file outside the repository. Restrict it to the backend operator and write one password of at least 16 characters containing lower-case, upper-case, digit, and symbol characters.
+3. Configure `PLATFORM_BOOTSTRAP_USERNAME`, `PLATFORM_BOOTSTRAP_EMAIL`, and `PLATFORM_BOOTSTRAP_PASSWORD_FILE` with no password value in environment or Nacos.
+4. Set `PLATFORM_BOOTSTRAP_ENABLED=true` and start the backend once. Startup fails if configuration is incomplete, the file is unavailable, or any current or soft-deleted platform administrator row already exists.
+5. Confirm the sanitized completion message. Stop the backend, set `PLATFORM_BOOTSTRAP_ENABLED=false`, and move the password file to the operating system trash.
+6. Set `PLATFORM_IDENTITY_ENABLED=true`, restart the normal replica set, and require a new login. Tokens issued before this release do not contain `scope` and `authVersion` and are intentionally rejected.
+
+Platform requests always send `X-Tenant-ID: 0`. A target business tenant must never be supplied through that identity header. The system tenant `0` may still contain legacy `user`, `admin`, or `monitor` accounts; only the `platform_admin` role with `scope=platform` has platform authority.
+
+## Rotation and recovery
+
+Password or account-state changes increment `auth_version`, invalidate authorization cache entries, delete outstanding SSE short tokens, and close current SSE connections. The one-time bootstrap does not bypass an existing historical platform-administrator row; lost-access recovery therefore requires an explicitly reviewed operator database procedure. There is no public recovery endpoint.
+
+Do not commit bootstrap identity values, password files, password hashes, or generated tokens. Treat source deployment as incomplete until a real login, fixed tenant header, cross-route denial, Redis failure, and disable/restore drill have been verified on the target host.

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/constant/UserRole.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/constant/UserRole.java
@@ -13,8 +13,9 @@ import lombok.Getter;
 @Schema(description = "用户权限枚举")
 public enum UserRole {
     ROLE_DEFAULT("user", "普通用户"),
-    ROLE_ADMINISTER("admin", "超级管理员"),
+    ROLE_ADMINISTER("admin", "租户管理员"),
     ROLE_MONITOR("monitor", "系统监控员"),
+    ROLE_PLATFORM_ADMIN("platform_admin", "平台管理员"),
     ROLE_NOOP("noop", "未登录用户");
 
     @Schema(description = "角色")
@@ -39,5 +40,29 @@ public enum UserRole {
             }
         }
         return ROLE_NOOP;
+    }
+
+    /**
+     * Returns the immutable token scope for this role.
+     *
+     * @return platform for platform administrators, tenant for business roles, or null for unsupported roles
+     */
+    public String scope() {
+        if (this == ROLE_PLATFORM_ADMIN) {
+            return "platform";
+        }
+        if (this == ROLE_DEFAULT || this == ROLE_ADMINISTER || this == ROLE_MONITOR) {
+            return "tenant";
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether the role may authenticate to ordinary tenant routes.
+     *
+     * @return true for the three supported tenant roles
+     */
+    public boolean isTenantRole() {
+        return this == ROLE_DEFAULT || this == ROLE_ADMINISTER || this == ROLE_MONITOR;
     }
 }

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/Const.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/Const.java
@@ -31,6 +31,8 @@ public final class Const {
     public final static String ATTR_SSE_TENANT_HINT = "sseTenantHint";
     public final static String ATTR_REQ_ID = "reqId";
     public final static String ATTR_LOGIN_USERNAME = "loginUsername";
+    public final static String ATTR_AUTH_SCOPE = "authScope";
+    public final static String ATTR_AUTH_VERSION = "authVersion";
     //分布式追踪
     public final static String TRACE_ID = "traceId";
     //消息队列
@@ -48,5 +50,10 @@ public final class Const {
 
     //SSE短期令牌
     public final static String SSE_TOKEN_PREFIX = "sse:token:";
+    public final static String SSE_TOKEN_USER_INDEX_PREFIX = "sse:token:user:";
     public final static long SSE_TOKEN_TTL = 30;  // 30秒有效期
+
+    // Current authorization state cache
+    public final static String AUTH_ACCOUNT_STATE_PREFIX = "auth:account:";
+    public final static String AUTH_TENANT_STATE_PREFIX = "auth:tenant:";
 }

--- a/platform-backend/backend-common/src/main/java/cn/flying/common/util/JwtUtils.java
+++ b/platform-backend/backend-common/src/main/java/cn/flying/common/util/JwtUtils.java
@@ -6,6 +6,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import cn.flying.common.constant.UserRole;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
@@ -174,11 +175,18 @@ public class JwtUtils {
     }
 
     /**
-     * 根据UserDetails生成对应的Jwt令牌
-     * @param user 用户信息
-     * @return 令牌
+     * Creates a JWT containing the immutable identity scope and current account authorization version.
+     *
+     * @param user current authenticated principal
+     * @param username canonical username
+     * @param userId account identifier
+     * @param tenantId identity tenant identifier
+     * @param authVersion current account-wide session version
+     * @return signed JWT, or null when issuance is rate limited
      */
-    public String createJwt(UserDetails user, String username, Long userId, Long tenantId) {
+    public String createJwt(UserDetails user, String username, Long userId, Long tenantId, Long authVersion) {
+        String role = roleFromAuthorities(user);
+        String scope = requireScope(role, tenantId, authVersion);
         if(this.frequencyCheck(userId)) {
             Date expire = this.expireTime();
             return JWT.create()
@@ -188,9 +196,9 @@ public class JwtUtils {
                     .withClaim("id", userId)
                     .withClaim("tenantId", tenantId)
                     .withClaim("name", username)
-                    .withClaim("authorities", user.getAuthorities()
-                            .stream()
-                            .map(GrantedAuthority::getAuthority).toList())
+                    .withClaim("scope", scope)
+                    .withClaim("authVersion", authVersion)
+                    .withClaim("authorities", java.util.List.of("ROLE_" + role))
                     .withExpiresAt(expire)
                     .withIssuedAt(new Date())
                     .sign(algorithm);
@@ -211,13 +219,16 @@ public class JwtUtils {
         }
         try {
             DecodedJWT verify = verifier.verify(token);
+            Map<String, Claim> claims = verify.getClaims();
+            if (!hasRequiredIdentityClaims(verify, claims)) {
+                return null;
+            }
             if(this.isInvalidToken(verify.getId())) {
                 return null;
             }
-            Map<String, Claim> claims = verify.getClaims();
             return new Date().after(claims.get("exp").asDate()) ? null : verify;
-        } catch (JWTVerificationException e) {
-            log.debug("JWT verification failed: {}", e.getMessage());
+        } catch (RuntimeException e) {
+            log.debug("JWT verification failed: exceptionType={}", e.getClass().getSimpleName());
             return null;
         }
     }
@@ -252,21 +263,7 @@ public class JwtUtils {
      * @return 用户角色（如 "admin", "monitor", "user"）
      */
     public String toRole(DecodedJWT jwt) {
-        Map<String, Claim> claims = jwt.getClaims();
-        Claim authoritiesClaim = claims.get("authorities");
-        if (authoritiesClaim == null || authoritiesClaim.isNull()) {
-            return null;
-        }
-        java.util.List<String> authorities = authoritiesClaim.asList(String.class);
-        if (authorities == null || authorities.isEmpty()) {
-            return null;
-        }
-        // 提取第一个角色，并去除 "ROLE_" 前缀以匹配 UserRole 枚举
-        String role = authorities.get(0);
-        if (role != null && role.startsWith("ROLE_")) {
-            return role.substring(5); // 去除 "ROLE_" 前缀
-        }
-        return role;
+        return toRoleFromClaims(jwt.getClaims());
     }
 
     /**
@@ -278,6 +275,28 @@ public class JwtUtils {
         Map<String, Claim> claims = jwt.getClaims();
         Claim tenantClaim = claims.get("tenantId");
         return tenantClaim == null ? null : tenantClaim.asLong();
+    }
+
+    /**
+     * Extracts the closed-set identity scope from a verified JWT.
+     *
+     * @param jwt verified JWT
+     * @return tenant or platform, otherwise null
+     */
+    public String toScope(DecodedJWT jwt) {
+        Claim claim = jwt.getClaims().get("scope");
+        return claim == null ? null : claim.asString();
+    }
+
+    /**
+     * Extracts the account-wide authorization version from a verified JWT.
+     *
+     * @param jwt verified JWT
+     * @return authorization version, otherwise null
+     */
+    public Long toAuthVersion(DecodedJWT jwt) {
+        Claim claim = jwt.getClaims().get("authVersion");
+        return claim == null ? null : claim.asLong();
     }
 
     /**
@@ -297,6 +316,8 @@ public class JwtUtils {
         Long tenantId = claims.get("tenantId") != null ? claims.get("tenantId").asLong() : null;
         String username = claims.get("name").asString();
         String[] authorities = claims.get("authorities").asArray(String.class);
+        String scope = claims.get("scope").asString();
+        Long authVersion = claims.get("authVersion").asLong();
 
         // 频率检测
         if (!this.frequencyCheck(userId)) {
@@ -316,6 +337,8 @@ public class JwtUtils {
                 .withClaim("id", userId)
                 .withClaim("tenantId", tenantId)
                 .withClaim("name", username)
+                .withClaim("scope", scope)
+                .withClaim("authVersion", authVersion)
                 .withClaim("authorities", java.util.Arrays.asList(authorities))
                 .withExpiresAt(expire)
                 .withIssuedAt(new Date())
@@ -323,6 +346,78 @@ public class JwtUtils {
 
         log.info("Token refreshed for user: {}", userId);
         return newToken;
+    }
+
+    /**
+     * Resolves the single role authority used by the platform identity model.
+     */
+    private String roleFromAuthorities(UserDetails user) {
+        java.util.List<String> roles = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(authority -> authority != null && authority.startsWith("ROLE_"))
+                .map(authority -> authority.substring(5))
+                .distinct()
+                .toList();
+        if (roles.size() != 1 || UserRole.getRole(roles.getFirst()) == UserRole.ROLE_NOOP) {
+            throw new IllegalArgumentException("Exactly one supported role authority is required");
+        }
+        return roles.getFirst();
+    }
+
+    /**
+     * Validates role, tenant and version before writing identity claims.
+     */
+    private String requireScope(String role, Long tenantId, Long authVersion) {
+        UserRole userRole = UserRole.getRole(role);
+        String scope = userRole.scope();
+        if (scope == null || tenantId == null || tenantId < 0 || authVersion == null || authVersion < 0) {
+            throw new IllegalArgumentException("Invalid authorization identity");
+        }
+        if (userRole == UserRole.ROLE_PLATFORM_ADMIN && tenantId != 0L) {
+            throw new IllegalArgumentException("Invalid authorization identity");
+        }
+        return scope;
+    }
+
+    /**
+     * Rejects pre-rollout or malformed identity tokens before authorization state lookup.
+     */
+    private boolean hasRequiredIdentityClaims(DecodedJWT jwt, Map<String, Claim> claims) {
+        try {
+            Long id = claims.get("id").asLong();
+            Long tenantId = claims.get("tenantId").asLong();
+            Long authVersion = claims.get("authVersion").asLong();
+            String name = claims.get("name").asString();
+            String scope = claims.get("scope").asString();
+            String role = toRoleFromClaims(claims);
+            UserRole userRole = UserRole.getRole(role);
+            return StringUtils.hasText(jwt.getId())
+                    && StringUtils.hasText(name)
+                    && claims.get("exp").asDate() != null
+                    && id != null && id > 0
+                    && tenantId != null && tenantId >= 0
+                    && authVersion != null && authVersion >= 0
+                    && scope != null && scope.equals(userRole.scope())
+                    && (userRole != UserRole.ROLE_PLATFORM_ADMIN || tenantId == 0L);
+        } catch (RuntimeException exception) {
+            return false;
+        }
+    }
+
+    /**
+     * Extracts the first role authority from raw claims without trusting arbitrary authorities.
+     */
+    private String toRoleFromClaims(Map<String, Claim> claims) {
+        Claim authoritiesClaim = claims.get("authorities");
+        if (authoritiesClaim == null || authoritiesClaim.isNull()) {
+            return null;
+        }
+        java.util.List<String> authorities = authoritiesClaim.asList(String.class);
+        if (authorities == null || authorities.size() != 1) {
+            return null;
+        }
+        String authority = authorities.get(0);
+        return authority != null && authority.startsWith("ROLE_") ? authority.substring(5) : null;
     }
 
     /**
@@ -393,15 +488,24 @@ public class JwtUtils {
      * @param userId   用户ID
      * @param tenantId 租户ID
      * @param role     用户角色
+     * @param authVersion 签发 JWT 中已经验证的账户授权版本
      * @return SSE 短期令牌
      */
-    public String createSseToken(Long userId, Long tenantId, String role) {
+    public String createSseToken(Long userId, Long tenantId, String role, Long authVersion) {
+        UserRole userRole = UserRole.getRole(role);
+        if (userId == null || userId <= 0 || tenantId == null || tenantId < 0
+                || !userRole.isTenantRole() || authVersion == null || authVersion < 0) {
+            throw new IllegalArgumentException("Invalid SSE authorization identity");
+        }
         String token = UUID.randomUUID().toString().replace("-", "");
-        String key = TenantKeyUtils.tenantKey(Const.SSE_TOKEN_PREFIX + token);
+        String key = TenantKeyUtils.tenantKey(Const.SSE_TOKEN_PREFIX + token, tenantId);
+        String userIndexKey = TenantKeyUtils.tenantKey(Const.SSE_TOKEN_USER_INDEX_PREFIX + userId, tenantId);
 
-        // 存储用户信息到 Redis，格式：userId:tenantId:role
-        String value = userId + ":" + tenantId + ":" + role;
+        // 存储用户信息到 Redis，格式：userId:tenantId:role:authVersion
+        String value = userId + ":" + tenantId + ":" + role + ":" + authVersion;
         template.opsForValue().set(key, value, Const.SSE_TOKEN_TTL, TimeUnit.SECONDS);
+        template.opsForSet().add(userIndexKey, key);
+        template.expire(userIndexKey, Const.SSE_TOKEN_TTL, TimeUnit.SECONDS);
 
         log.debug("SSE token created: userId={}, tenantId={}", userId, tenantId);
         return token;
@@ -412,7 +516,7 @@ public class JwtUtils {
      * 验证成功后立即删除令牌，防止重放攻击
      *
      * @param token SSE 令牌
-     * @return 用户信息数组 [userId, tenantId, role]，验证失败返回 null
+     * @return 用户信息数组 [userId, tenantId, role, authVersion]，验证失败返回 null
      */
     public String[] validateAndConsumeSseToken(String token) {
         if (token == null || token.isEmpty()) {
@@ -429,12 +533,43 @@ public class JwtUtils {
         }
 
         String[] parts = value.split(":", -1);
-        if (parts.length != 3) {
+        if (parts.length != 4) {
             log.warn("Invalid SSE token payload format");
+            return null;
+        }
+
+        try {
+            Long userId = Long.parseLong(parts[0]);
+            Long tenantId = Long.parseLong(parts[1]);
+            Long authVersion = Long.parseLong(parts[3]);
+            if (userId <= 0 || tenantId < 0 || authVersion < 0
+                    || !UserRole.getRole(parts[2]).isTenantRole()) {
+                log.warn("Invalid SSE token payload identity");
+                return null;
+            }
+            String userIndexKey = TenantKeyUtils.tenantKey(Const.SSE_TOKEN_USER_INDEX_PREFIX + userId, tenantId);
+            template.opsForSet().remove(userIndexKey, key);
+        } catch (NumberFormatException exception) {
+            log.warn("Invalid SSE token payload identity");
             return null;
         }
 
         log.debug("SSE token consumed");
         return parts;
+    }
+
+    /**
+     * Deletes every outstanding SSE short token tracked for one account.
+     *
+     * @param tenantId account tenant
+     * @param userId account identifier
+     */
+    public void invalidateUserSseTokens(Long tenantId, Long userId) {
+        String indexKey = TenantKeyUtils.tenantKey(Const.SSE_TOKEN_USER_INDEX_PREFIX + userId, tenantId);
+        java.util.Set<String> tokenKeys = template.opsForSet().members(indexKey);
+        if (tokenKeys != null && !tokenKeys.isEmpty()) {
+            template.delete(tokenKeys);
+        }
+        template.delete(indexKey);
     }
 }

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/JwtUtilsTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/JwtUtilsTest.java
@@ -247,6 +247,20 @@ class JwtUtilsTest {
         }
 
         @Test
+        @DisplayName("should reject a missing tenant identity")
+        void createJwt_rejectsMissingTenantIdentity() {
+            UserDetails user = User.withUsername("operator")
+                    .password("password")
+                    .authorities(new SimpleGrantedAuthority("ROLE_user"))
+                    .build();
+
+            assertThatThrownBy(() -> jwtUtils.createJwt(user, "operator", 900L, null, 0L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid authorization identity");
+            verifyNoInteractions(flowUtils);
+        }
+
+        @Test
         @DisplayName("should reject principals with more than one role authority")
         void createJwt_rejectsMultipleRoleAuthorities() {
             UserDetails user = User.withUsername("operator")
@@ -501,6 +515,18 @@ class JwtUtilsTest {
 
             assertThat(role).isEqualTo("admin");
         }
+
+        @Test
+        @DisplayName("should return null for absent optional identity claims")
+        void extraction_returnsNullForAbsentIdentityClaims() {
+            String token = JWT.create().sign(Algorithm.HMAC512(TEST_KEY));
+            DecodedJWT jwt = JWT.decode(token);
+
+            assertThat(jwtUtils.toTenantId(jwt)).isNull();
+            assertThat(jwtUtils.toScope(jwt)).isNull();
+            assertThat(jwtUtils.toAuthVersion(jwt)).isNull();
+            assertThat(jwtUtils.toRole(jwt)).isNull();
+        }
     }
 
     @Nested
@@ -638,6 +664,67 @@ class JwtUtilsTest {
             when(valueOperations.getAndDelete(anyString())).thenReturn("123:456:user");
 
             assertThat(jwtUtils.validateAndConsumeSseToken("legacy-token")).isNull();
+        }
+
+        /** Rejects malformed numeric and unsupported-role identities after one-time consumption. */
+        @Test
+        @DisplayName("should reject malformed SSE identities")
+        void validateAndConsumeSseToken_rejectsMalformedIdentity() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.getAndDelete(anyString())).thenReturn(
+                    "bad:456:user:7",
+                    "0:456:user:7",
+                    "123:-1:user:7",
+                    "123:456:platform_admin:7",
+                    "123:456:user:-1");
+
+            assertThat(jwtUtils.validateAndConsumeSseToken("bad-number")).isNull();
+            assertThat(jwtUtils.validateAndConsumeSseToken("bad-user")).isNull();
+            assertThat(jwtUtils.validateAndConsumeSseToken("bad-tenant")).isNull();
+            assertThat(jwtUtils.validateAndConsumeSseToken("bad-role")).isNull();
+            assertThat(jwtUtils.validateAndConsumeSseToken("bad-version")).isNull();
+        }
+
+        /** Rejects invalid short-token inputs before writing Redis state. */
+        @Test
+        @DisplayName("should reject invalid SSE token issuance identities")
+        void createSseToken_rejectsInvalidIdentity() {
+            assertThatThrownBy(() -> jwtUtils.createSseToken(null, 456L, "user", 0L))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> jwtUtils.createSseToken(0L, 456L, "user", 0L))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> jwtUtils.createSseToken(123L, -1L, "user", 0L))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> jwtUtils.createSseToken(123L, 456L, "platform_admin", 0L))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> jwtUtils.createSseToken(123L, 456L, "user", -1L))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(redisTemplate, never()).opsForValue();
+        }
+
+        /** Deletes all indexed one-time tokens before deleting the per-account index. */
+        @Test
+        @DisplayName("should invalidate every outstanding SSE token")
+        void invalidateUserSseTokens_deletesIndexedTokens() {
+            when(setOperations.members(anyString())).thenReturn(java.util.Set.of("token-key-a", "token-key-b"));
+
+            jwtUtils.invalidateUserSseTokens(456L, 123L);
+
+            verify(redisTemplate).delete(java.util.Set.of("token-key-a", "token-key-b"));
+            verify(redisTemplate).delete(Const.SSE_TOKEN_USER_INDEX_PREFIX + 123L);
+        }
+
+        /** Empty indexes still get removed without issuing a bulk delete. */
+        @Test
+        @DisplayName("should remove an empty SSE token index")
+        void invalidateUserSseTokens_removesEmptyIndex() {
+            when(setOperations.members(anyString())).thenReturn(null);
+
+            jwtUtils.invalidateUserSseTokens(456L, 123L);
+
+            verify(redisTemplate, never()).delete(any(java.util.Collection.class));
+            verify(redisTemplate).delete(Const.SSE_TOKEN_USER_INDEX_PREFIX + 123L);
         }
 
         /**

--- a/platform-backend/backend-common/src/test/java/cn/flying/common/util/JwtUtilsTest.java
+++ b/platform-backend/backend-common/src/test/java/cn/flying/common/util/JwtUtilsTest.java
@@ -1,5 +1,7 @@
 package cn.flying.common.util;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -12,6 +14,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.*;
@@ -34,6 +38,9 @@ class JwtUtilsTest {
 
     @Mock
     private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private SetOperations<String, String> setOperations;
 
     @Mock
     private FlowUtils flowUtils;
@@ -71,6 +78,9 @@ class JwtUtilsTest {
         tenantKeyUtilsMock = mockStatic(TenantKeyUtils.class);
         tenantKeyUtilsMock.when(() -> TenantKeyUtils.tenantKey(anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
+        tenantKeyUtilsMock.when(() -> TenantKeyUtils.tenantKey(anyString(), anyLong()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(redisTemplate.opsForSet()).thenReturn(setOperations);
     }
 
     @AfterEach
@@ -155,7 +165,7 @@ class JwtUtilsTest {
             when(flowUtils.limitOnceUpgradeCheck(anyString(), anyInt(), anyInt(), anyInt()))
                     .thenReturn(true);
 
-            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
 
             assertThat(token).isNotNull();
             assertThat(token).isNotEmpty();
@@ -174,7 +184,7 @@ class JwtUtilsTest {
             when(flowUtils.limitOnceUpgradeCheck(anyString(), anyInt(), anyInt(), anyInt()))
                     .thenReturn(false);
 
-            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
 
             assertThat(token).isNull();
         }
@@ -191,13 +201,79 @@ class JwtUtilsTest {
                     .thenReturn(true);
             when(redisTemplate.hasKey(anyString())).thenReturn(false);
 
-            String token = jwtUtils.createJwt(user, "testuser", 456L, 789L);
+            String token = jwtUtils.createJwt(user, "testuser", 456L, 789L, 0L);
             DecodedJWT jwt = jwtUtils.resolveJwt("Bearer " + token);
 
             assertThat(jwt).isNotNull();
             assertThat(jwtUtils.toId(jwt)).isEqualTo(456L);
             assertThat(jwtUtils.toTenantId(jwt)).isEqualTo(789L);
             assertThat(jwt.getClaim("name").asString()).isEqualTo("testuser");
+            assertThat(jwtUtils.toScope(jwt)).isEqualTo("tenant");
+            assertThat(jwtUtils.toAuthVersion(jwt)).isZero();
+        }
+
+        @Test
+        @DisplayName("should issue platform scope only for a tenant-zero platform administrator")
+        void createJwt_issuesBoundPlatformIdentity() {
+            UserDetails user = User.withUsername("operator")
+                    .password("password")
+                    .authorities(new SimpleGrantedAuthority("ROLE_platform_admin"))
+                    .build();
+            when(flowUtils.limitOnceUpgradeCheck(anyString(), anyInt(), anyInt(), anyInt())).thenReturn(true);
+            when(redisTemplate.hasKey(anyString())).thenReturn(false);
+
+            String token = jwtUtils.createJwt(user, "operator", 900L, 0L, 7L);
+            DecodedJWT jwt = jwtUtils.resolveJwt("Bearer " + token);
+
+            assertThat(jwt).isNotNull();
+            assertThat(jwtUtils.toScope(jwt)).isEqualTo("platform");
+            assertThat(jwtUtils.toAuthVersion(jwt)).isEqualTo(7L);
+            assertThat(jwtUtils.toTenantId(jwt)).isZero();
+            assertThat(jwtUtils.toRole(jwt)).isEqualTo("platform_admin");
+        }
+
+        @Test
+        @DisplayName("should reject a platform administrator bound to a business tenant")
+        void createJwt_rejectsPlatformIdentityOutsideSystemTenant() {
+            UserDetails user = User.withUsername("operator")
+                    .password("password")
+                    .authorities(new SimpleGrantedAuthority("ROLE_platform_admin"))
+                    .build();
+
+            assertThatThrownBy(() -> jwtUtils.createJwt(user, "operator", 900L, 42L, 0L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid authorization identity");
+            verifyNoInteractions(flowUtils);
+        }
+
+        @Test
+        @DisplayName("should reject principals with more than one role authority")
+        void createJwt_rejectsMultipleRoleAuthorities() {
+            UserDetails user = User.withUsername("operator")
+                    .password("password")
+                    .authorities(
+                            new SimpleGrantedAuthority("ROLE_admin"),
+                            new SimpleGrantedAuthority("ROLE_user"))
+                    .build();
+
+            assertThatThrownBy(() -> jwtUtils.createJwt(user, "operator", 900L, 42L, 0L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Exactly one supported role authority is required");
+            verifyNoInteractions(flowUtils);
+        }
+
+        @Test
+        @DisplayName("should reject principals with an unsupported role authority")
+        void createJwt_rejectsUnsupportedRoleAuthority() {
+            UserDetails user = User.withUsername("operator")
+                    .password("password")
+                    .authorities(new SimpleGrantedAuthority("ROLE_root"))
+                    .build();
+
+            assertThatThrownBy(() -> jwtUtils.createJwt(user, "operator", 900L, 42L, 0L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Exactly one supported role authority is required");
+            verifyNoInteractions(flowUtils);
         }
     }
 
@@ -214,7 +290,7 @@ class JwtUtilsTest {
             when(flowUtils.limitOnceUpgradeCheck(anyString(), anyInt(), anyInt(), anyInt()))
                     .thenReturn(true);
 
-            return jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            return jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
         }
 
         @Test
@@ -273,6 +349,45 @@ class JwtUtilsTest {
 
             assertThat(jwt).isNull();
         }
+
+        @Test
+        @DisplayName("should reject a signed token without a JWT identifier before Redis lookup")
+        void resolveJwt_rejectsMissingJwtIdBeforeBlacklistLookup() {
+            String token = signedIdentityToken(null, "testuser");
+
+            assertThat(jwtUtils.resolveJwt("Bearer " + token)).isNull();
+
+            verify(redisTemplate, never()).hasKey(anyString());
+        }
+
+        @Test
+        @DisplayName("should reject a signed token with a blank account name before Redis lookup")
+        void resolveJwt_rejectsBlankNameBeforeBlacklistLookup() {
+            String token = signedIdentityToken("token-id", " ");
+
+            assertThat(jwtUtils.resolveJwt("Bearer " + token)).isNull();
+
+            verify(redisTemplate, never()).hasKey(anyString());
+        }
+
+        /** Signs a structurally controlled token to exercise required-claim rejection. */
+        private String signedIdentityToken(String jwtId, String name) {
+            Algorithm algorithm = (Algorithm) ReflectionTestUtils.getField(jwtUtils, "algorithm");
+            var builder = JWT.create()
+                    .withIssuer("record-platform")
+                    .withAudience("record-platform-api")
+                    .withClaim("id", 123L)
+                    .withClaim("tenantId", 1L)
+                    .withClaim("name", name)
+                    .withClaim("scope", "tenant")
+                    .withClaim("authVersion", 0L)
+                    .withClaim("authorities", List.of("ROLE_user"))
+                    .withExpiresAt(new Date(System.currentTimeMillis() + 60_000));
+            if (jwtId != null) {
+                builder.withJWTId(jwtId);
+            }
+            return builder.sign(algorithm);
+        }
     }
 
     @Nested
@@ -292,7 +407,7 @@ class JwtUtilsTest {
             when(redisTemplate.hasKey(anyString())).thenReturn(false);
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
-            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
             boolean result = jwtUtils.invalidateJwt("Bearer " + token);
 
             assertThat(result).isTrue();
@@ -319,7 +434,7 @@ class JwtUtilsTest {
                     .thenReturn(true);
             when(redisTemplate.hasKey(anyString())).thenReturn(true);
 
-            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            String token = jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
             boolean result = jwtUtils.invalidateJwt("Bearer " + token);
 
             assertThat(result).isFalse();
@@ -333,16 +448,14 @@ class JwtUtilsTest {
         private DecodedJWT createAndResolveToken() {
             UserDetails user = User.withUsername("testuser")
                     .password("password")
-                    .authorities(
-                            new SimpleGrantedAuthority("ROLE_admin"),
-                            new SimpleGrantedAuthority("ROLE_user"))
+                    .authorities(new SimpleGrantedAuthority("ROLE_admin"))
                     .build();
 
             when(flowUtils.limitOnceUpgradeCheck(anyString(), anyInt(), anyInt(), anyInt()))
                     .thenReturn(true);
             when(redisTemplate.hasKey(anyString())).thenReturn(false);
 
-            String token = jwtUtils.createJwt(user, "testuser", 123L, 456L);
+            String token = jwtUtils.createJwt(user, "testuser", 123L, 456L, 0L);
             return jwtUtils.resolveJwt("Bearer " + token);
         }
 
@@ -356,7 +469,7 @@ class JwtUtilsTest {
             assertThat(user.getUsername()).isEqualTo("testuser");
             assertThat(user.getAuthorities())
                     .extracting(auth -> auth.getAuthority())
-                    .contains("ROLE_admin", "ROLE_user");
+                    .containsExactly("ROLE_admin");
         }
 
         @Test
@@ -407,7 +520,7 @@ class JwtUtilsTest {
             when(redisTemplate.hasKey(anyString())).thenReturn(false);
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
-            String originalToken = jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            String originalToken = jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
             String refreshedToken = jwtUtils.refreshJwt("Bearer " + originalToken);
 
             assertThat(refreshedToken).isNotNull();
@@ -437,7 +550,7 @@ class JwtUtilsTest {
                     .thenReturn(false);
             when(redisTemplate.hasKey(anyString())).thenReturn(false);
 
-            String originalToken = jwtUtils.createJwt(user, "testuser", 123L, 1L);
+            String originalToken = jwtUtils.createJwt(user, "testuser", 123L, 1L, 0L);
             String refreshedToken = jwtUtils.refreshJwt("Bearer " + originalToken);
 
             assertThat(refreshedToken).isNull();
@@ -453,13 +566,13 @@ class JwtUtilsTest {
         void createSseToken_createsToken() {
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
-            String token = jwtUtils.createSseToken(123L, 456L, "user");
+            String token = jwtUtils.createSseToken(123L, 456L, "user", 7L);
 
             assertThat(token).isNotNull();
             assertThat(token).hasSize(32); // UUID without dashes
             verify(valueOperations).set(
                     contains("sse:token:"),
-                    eq("123:456:user"),
+                    eq("123:456:user:7"),
                     eq(Const.SSE_TOKEN_TTL),
                     eq(TimeUnit.SECONDS));
         }
@@ -468,15 +581,16 @@ class JwtUtilsTest {
         @DisplayName("should validate and consume SSE token")
         void validateAndConsumeSseToken_validatesToken() {
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.getAndDelete(anyString())).thenReturn("123:456:admin");
+            when(valueOperations.getAndDelete(anyString())).thenReturn("123:456:admin:7");
 
             String[] result = jwtUtils.validateAndConsumeSseToken("test-token");
 
             assertThat(result).isNotNull();
-            assertThat(result).hasSize(3);
+            assertThat(result).hasSize(4);
             assertThat(result[0]).isEqualTo("123");
             assertThat(result[1]).isEqualTo("456");
             assertThat(result[2]).isEqualTo("admin");
+            assertThat(result[3]).isEqualTo("7");
         }
 
         @Test
@@ -517,6 +631,15 @@ class JwtUtilsTest {
             assertThat(result).isNull();
         }
 
+        @Test
+        @DisplayName("should reject legacy payloads without an authorization version")
+        void validateAndConsumeSseToken_rejectsLegacyPayload() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.getAndDelete(anyString())).thenReturn("123:456:user");
+
+            assertThat(jwtUtils.validateAndConsumeSseToken("legacy-token")).isNull();
+        }
+
         /**
          * 验证创建、未命中和损坏载荷日志都不会包含一次性短令牌原文。
          */
@@ -535,7 +658,7 @@ class JwtUtilsTest {
             jwtLogger.addAppender(appender);
             List<String> sensitiveTokens = new java.util.ArrayList<>();
             try {
-                sensitiveTokens.add(jwtUtils.createSseToken(123L, 456L, "user"));
+                sensitiveTokens.add(jwtUtils.createSseToken(123L, 456L, "user", 7L));
                 sensitiveTokens.add("missing-sensitive-sse-token");
                 sensitiveTokens.add("malformed-sensitive-sse-token");
                 assertThat(jwtUtils.validateAndConsumeSseToken(sensitiveTokens.get(1))).isNull();

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/dto/Account.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/dto/Account.java
@@ -36,6 +36,15 @@ public class Account implements BaseData {
     @Schema(description = "角色")
     private String role;
 
+    @Schema(description = "授权状态：1-启用，0-禁用")
+    private Integer status;
+
+    @Schema(description = "账户全会话撤销版本")
+    private Long authVersion;
+
+    @Schema(description = "最后成功登录时间")
+    private Date lastLoginTime;
+
     @Schema(description = "头像Url")
     private String avatar;
 

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/entity/Tenant.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/entity/Tenant.java
@@ -29,6 +29,14 @@ public class Tenant {
 
     private Integer status;
 
+    private Long version;
+
+    private String disabledReason;
+
+    private Date disabledAt;
+
+    private Long disabledBy;
+
     @TableLogic
     @Schema(description = "逻辑删除标记 0=正常 1=已删除")
     private Integer deleted;

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/AccountMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/AccountMapper.java
@@ -3,6 +3,10 @@ package cn.flying.dao.mapper;
 import cn.flying.dao.dto.Account;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
 
 /**
  * @program: RecordPlatform
@@ -11,4 +15,56 @@ import org.apache.ibatis.annotations.Mapper;
  */
 @Mapper
 public interface AccountMapper extends BaseMapper<Account> {
+
+    /** Loads only fields required to authorize one account in one tenant. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("""
+            SELECT id, tenant_id, role, status, auth_version, deleted
+              FROM account
+             WHERE id = #{accountId} AND tenant_id = #{tenantId}
+             LIMIT 1
+            """)
+    Account selectAuthorizationState(@Param("tenantId") Long tenantId, @Param("accountId") Long accountId);
+
+    /** Atomically increments the account-wide session version inside the caller transaction. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Update("""
+            UPDATE account
+               SET auth_version = auth_version + 1,
+                   update_time = CURRENT_TIMESTAMP
+             WHERE id = #{accountId} AND tenant_id = #{tenantId} AND deleted = 0
+            """)
+    int incrementAuthVersion(@Param("tenantId") Long tenantId, @Param("accountId") Long accountId);
+
+    /** Updates a password and revokes all existing account tokens in one database statement. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Update("""
+            UPDATE account
+               SET password = #{passwordHash},
+                   auth_version = auth_version + 1,
+                   update_time = CURRENT_TIMESTAMP
+             WHERE id = #{accountId} AND tenant_id = #{tenantId} AND deleted = 0 AND status = 1
+            """)
+    int updatePasswordAndIncrementAuthVersion(
+            @Param("tenantId") Long tenantId,
+            @Param("accountId") Long accountId,
+            @Param("passwordHash") String passwordHash);
+
+    /** Records operational login time without changing authorization state. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Update("""
+            UPDATE account
+               SET last_login_time = CURRENT_TIMESTAMP
+             WHERE id = #{accountId} AND tenant_id = #{tenantId} AND deleted = 0
+            """)
+    int updateLastLoginTime(@Param("tenantId") Long tenantId, @Param("accountId") Long accountId);
+
+    /** Counts existing platform administrators without exposing account details. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("""
+            SELECT COUNT(*)
+              FROM account
+             WHERE tenant_id = 0 AND role = 'platform_admin'
+            """)
+    long countPlatformAdministrators();
 }

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/TenantMapper.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/mapper/TenantMapper.java
@@ -5,6 +5,7 @@ import com.baomidou.mybatisplus.annotation.InterceptorIgnore;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -12,6 +13,21 @@ import java.util.List;
 public interface TenantMapper extends BaseMapper<Tenant> {
 
     @InterceptorIgnore(tenantLine = "true")
-    @Select("SELECT id FROM tenant WHERE status = 1")
+    @Select("SELECT id FROM tenant WHERE status = 1 AND deleted = 0")
     List<Long> selectActiveTenantIds();
+
+    /** Loads only fields required for current tenant authorization. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("""
+            SELECT id, status, version, deleted
+              FROM tenant
+             WHERE id = #{tenantId}
+             LIMIT 1
+            """)
+    Tenant selectAuthorizationState(@Param("tenantId") Long tenantId);
+
+    /** Serializes first-platform-administrator creation across backend replicas. */
+    @InterceptorIgnore(tenantLine = "true")
+    @Select("SELECT id FROM tenant WHERE id = 0 FOR UPDATE")
+    Long lockSystemTenantForPlatformBootstrap();
 }

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/auth/AccountVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/auth/AccountVO.java
@@ -28,6 +28,13 @@ public class AccountVO {
     String email;
     @Schema(description = "角色")
     String role;
+    @Schema(
+            description = "身份作用域：tenant 或 platform",
+            allowableValues = {"tenant", "platform"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    String scope;
+    @Schema(description = "授权状态：1-启用，0-禁用")
+    Integer status;
     @Schema(description = "头像Url")
     String avatar;
     @Schema(description = "昵称")
@@ -45,6 +52,8 @@ public class AccountVO {
                 ", username='" + username + '\'' +
                 ", email='" + email + '\'' +
                 ", role='" + role + '\'' +
+                ", scope='" + scope + '\'' +
+                ", status=" + status +
                 ", avatar='" + avatar + '\'' +
                 ", nickname='" + nickname + '\'' +
                 ", registerTime=" + registerTime +

--- a/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/auth/AuthorizeVO.java
+++ b/platform-backend/backend-dao/src/main/java/cn/flying/dao/vo/auth/AuthorizeVO.java
@@ -17,6 +17,11 @@ public class AuthorizeVO {
     String username;
     @Schema(description = "角色")
     String role;
+    @Schema(
+            description = "身份作用域：tenant 或 platform",
+            allowableValues = {"tenant", "platform"},
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    String scope;
     @Schema(description = "token")
     String token;
     @Schema(description = "token过期时间")
@@ -27,7 +32,8 @@ public class AuthorizeVO {
         return "AuthorizeVO{" +
                 "username='" + username + '\'' +
                 ", role='" + role + '\'' +
-                ", token='" + token + '\'' +
+                ", scope='" + scope + '\'' +
+                ", token='[REDACTED]'" +
                 ", expire=" + expire +
                 '}';
     }

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/AccountService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/AccountService.java
@@ -26,6 +26,12 @@ public interface AccountService extends IService<Account>, UserDetailsService {
     String modifyEmail(Long userId, ModifyEmailVO modifyEmailVO);
     String changePassword(Long userId, ChangePasswordVO changePasswordVO);
 
+    /** Creates the one allowed bootstrap platform administrator in system tenant zero. */
+    Account createPlatformAdministrator(String username, String email, String passwordHash);
+
+    /** Records a successful login timestamp for operational visibility. */
+    void recordSuccessfulLogin(Account account);
+
     /**
      * 更新用户信息（头像等）
      * @param userId 用户ID

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/auth/AccountSessionRevocationService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/auth/AccountSessionRevocationService.java
@@ -1,0 +1,69 @@
+package cn.flying.service.auth;
+
+import cn.flying.common.util.JwtUtils;
+import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.service.sse.SseEmitterManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Coordinates account-wide token, cache and live SSE revocation after identity mutations.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccountSessionRevocationService {
+
+    private final AccountMapper accountMapper;
+    private final AuthorizationStateService authorizationStateService;
+    private final JwtUtils jwtUtils;
+    private final SseEmitterManager sseEmitterManager;
+
+    /**
+     * Increments the persistent account authorization version and invalidates all local session state.
+     *
+     * @param tenantId account tenant
+     * @param accountId account identifier
+     */
+    @Transactional
+    public void revokeAllSessions(Long tenantId, Long accountId) {
+        if (accountMapper.incrementAuthVersion(tenantId, accountId) != 1) {
+            throw new IllegalStateException("Account session revocation failed");
+        }
+        invalidateAfterVersionChange(tenantId, accountId);
+    }
+
+    /**
+     * Invalidates cached and ephemeral session state after a caller atomically changed auth_version.
+     */
+    public void invalidateAfterVersionChange(Long tenantId, Long accountId) {
+        authorizationStateService.fenceAccount(tenantId, accountId);
+        jwtUtils.invalidateUserSseTokens(tenantId, accountId);
+        sseEmitterManager.closeUserConnections(tenantId, accountId);
+        evictFenceAfterTransaction(tenantId, accountId);
+    }
+
+    /** Keeps the fail-closed fence until the surrounding database transaction has completed. */
+    private void evictFenceAfterTransaction(Long tenantId, Long accountId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            authorizationStateService.evictAccount(tenantId, accountId);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                try {
+                    authorizationStateService.evictAccount(tenantId, accountId);
+                } catch (RuntimeException exception) {
+                    // The bounded malformed fence intentionally keeps authorization fail-closed until expiry.
+                    log.error("Account authorization fence cleanup failed: exceptionType={}",
+                            exception.getClass().getSimpleName());
+                }
+            }
+        });
+    }
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/auth/AuthorizationStateService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/auth/AuthorizationStateService.java
@@ -1,0 +1,218 @@
+package cn.flying.service.auth;
+
+import cn.flying.common.constant.UserRole;
+import cn.flying.common.util.Const;
+import cn.flying.common.util.TenantKeyUtils;
+import cn.flying.dao.dto.Account;
+import cn.flying.dao.entity.Tenant;
+import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.dao.mapper.TenantMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import jakarta.annotation.PostConstruct;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Resolves current account and tenant authorization facts and compares them with token claims.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthorizationStateService {
+
+    private static final int ACTIVE = 1;
+    private static final int NOT_DELETED = 0;
+
+    private final AccountMapper accountMapper;
+    private final TenantMapper tenantMapper;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${security.platform-identity.enabled:false}")
+    private boolean platformIdentityEnabled;
+
+    @Value("${security.authorization-state.cache-ttl:30s}")
+    private Duration cacheTtl;
+
+    /** Validates the bounded cache freshness contract at application startup. */
+    @PostConstruct
+    void validateConfiguration() {
+        if (cacheTtl == null || cacheTtl.compareTo(Duration.ofSeconds(1)) < 0
+                || cacheTtl.compareTo(Duration.ofMinutes(5)) > 0) {
+            throw new IllegalStateException("security.authorization-state.cache-ttl must be between 1s and 5m");
+        }
+    }
+
+    /**
+     * Validates all current-state claims needed by a protected JWT request.
+     * Infrastructure failures intentionally propagate so callers fail closed.
+     */
+    public boolean isTokenAuthorized(
+            Long accountId,
+            Long tenantId,
+            String tokenRole,
+            String tokenScope,
+            Long tokenAuthVersion) {
+        if (accountId == null || accountId <= 0 || tenantId == null || tenantId < 0
+                || tokenAuthVersion == null || tokenAuthVersion < 0) {
+            return false;
+        }
+        UserRole role = UserRole.getRole(tokenRole);
+        if (role == UserRole.ROLE_NOOP || !Objects.equals(role.scope(), tokenScope)) {
+            return false;
+        }
+        if (role == UserRole.ROLE_PLATFORM_ADMIN) {
+            if (!platformIdentityEnabled || tenantId != 0L) {
+                return false;
+            }
+        } else if (!role.isTenantRole()) {
+            return false;
+        }
+
+        AccountState account = loadAccountState(tenantId, accountId);
+        if (account == null
+                || !Objects.equals(account.status(), ACTIVE)
+                || !Objects.equals(account.deleted(), NOT_DELETED)
+                || account.authVersion() == null
+                || account.authVersion() < 0
+                || !Objects.equals(account.role(), tokenRole)
+                || !Objects.equals(account.authVersion(), tokenAuthVersion)) {
+            return false;
+        }
+
+        if (role == UserRole.ROLE_PLATFORM_ADMIN) {
+            return true;
+        }
+        TenantState tenant = loadTenantState(tenantId);
+        return tenant != null
+                && Objects.equals(tenant.status(), ACTIVE)
+                && Objects.equals(tenant.deleted(), NOT_DELETED)
+                && tenant.version() != null
+                && tenant.version() >= 0;
+    }
+
+    /**
+     * Validates an account returned by password authentication before token issuance.
+     */
+    public boolean isLoginAuthorized(Account account) {
+        if (account == null || account.getAuthVersion() == null || account.getAuthVersion() < 0) {
+            return false;
+        }
+        UserRole role = UserRole.getRole(account.getRole());
+        return isTokenAuthorized(
+                account.getId(),
+                account.getTenantId(),
+                account.getRole(),
+                role.scope(),
+                account.getAuthVersion());
+    }
+
+    /**
+     * Revalidates an SSE identity after its one-time Redis token is consumed.
+     */
+    public boolean isSseIdentityAuthorized(Long accountId, Long tenantId, String role, Long tokenAuthVersion) {
+        return isTokenAuthorized(accountId, tenantId, role, "tenant", tokenAuthVersion);
+    }
+
+    /** Evicts one account authorization entry after a committed identity mutation. */
+    public void evictAccount(Long tenantId, Long accountId) {
+        redisTemplate.delete(accountKey(tenantId, accountId));
+    }
+
+    /** Replaces cached account state with a bounded fail-closed fence until the mutation completes. */
+    public void fenceAccount(Long tenantId, Long accountId) {
+        redisTemplate.opsForValue().set(accountKey(tenantId, accountId), "invalidating", cacheTtl);
+    }
+
+    /** Evicts one tenant authorization entry after a committed lifecycle mutation. */
+    public void evictTenant(Long tenantId) {
+        redisTemplate.delete(tenantKey(tenantId));
+    }
+
+    /** Replaces cached tenant state with a bounded fail-closed fence until the mutation completes. */
+    public void fenceTenant(Long tenantId) {
+        redisTemplate.opsForValue().set(tenantKey(tenantId), "invalidating", cacheTtl);
+    }
+
+    private AccountState loadAccountState(Long tenantId, Long accountId) {
+        String key = accountKey(tenantId, accountId);
+        String cached = redisTemplate.opsForValue().get(key);
+        if (cached != null) {
+            return parseAccountState(cached);
+        }
+        Account account = accountMapper.selectAuthorizationState(tenantId, accountId);
+        if (account == null) {
+            return null;
+        }
+        AccountState state = new AccountState(
+                account.getRole(),
+                account.getStatus(),
+                account.getAuthVersion(),
+                account.getDeleted());
+        redisTemplate.opsForValue().set(key, formatAccountState(state), cacheTtl);
+        return state;
+    }
+
+    private TenantState loadTenantState(Long tenantId) {
+        String key = tenantKey(tenantId);
+        String cached = redisTemplate.opsForValue().get(key);
+        if (cached != null) {
+            return parseTenantState(cached);
+        }
+        Tenant tenant = tenantMapper.selectAuthorizationState(tenantId);
+        if (tenant == null) {
+            return null;
+        }
+        TenantState state = new TenantState(tenant.getStatus(), tenant.getVersion(), tenant.getDeleted());
+        redisTemplate.opsForValue().set(key, formatTenantState(state), cacheTtl);
+        return state;
+    }
+
+    private String accountKey(Long tenantId, Long accountId) {
+        return TenantKeyUtils.tenantKey(Const.AUTH_ACCOUNT_STATE_PREFIX + accountId, tenantId);
+    }
+
+    private String tenantKey(Long tenantId) {
+        return TenantKeyUtils.tenantKey(Const.AUTH_TENANT_STATE_PREFIX + "current", tenantId);
+    }
+
+    private String formatAccountState(AccountState state) {
+        return state.role() + "|" + state.status() + "|" + state.authVersion() + "|" + state.deleted();
+    }
+
+    private AccountState parseAccountState(String value) {
+        String[] parts = value.split("\\|", -1);
+        if (parts.length != 4) {
+            throw new IllegalStateException("Invalid cached account authorization state");
+        }
+        try {
+            return new AccountState(parts[0], Integer.valueOf(parts[1]), Long.valueOf(parts[2]), Integer.valueOf(parts[3]));
+        } catch (NumberFormatException exception) {
+            throw new IllegalStateException("Invalid cached account authorization state", exception);
+        }
+    }
+
+    private String formatTenantState(TenantState state) {
+        return state.status() + "|" + state.version() + "|" + state.deleted();
+    }
+
+    private TenantState parseTenantState(String value) {
+        String[] parts = value.split("\\|", -1);
+        if (parts.length != 3) {
+            throw new IllegalStateException("Invalid cached tenant authorization state");
+        }
+        try {
+            return new TenantState(Integer.valueOf(parts[0]), Long.valueOf(parts[1]), Integer.valueOf(parts[2]));
+        } catch (NumberFormatException exception) {
+            throw new IllegalStateException("Invalid cached tenant authorization state", exception);
+        }
+    }
+
+    private record AccountState(String role, Integer status, Long authVersion, Integer deleted) {
+    }
+
+    private record TenantState(Integer status, Long version, Integer deleted) {
+    }
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/auth/TenantSessionRevocationService.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/auth/TenantSessionRevocationService.java
@@ -1,0 +1,54 @@
+package cn.flying.service.auth;
+
+import cn.flying.service.sse.SseEmitterManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Clears current authorization and live-session state after a tenant lifecycle change.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantSessionRevocationService {
+
+    private final AuthorizationStateService authorizationStateService;
+    private final SseEmitterManager sseEmitterManager;
+
+    /**
+     * Makes a committed tenant status/version mutation effective for the next request and live connection.
+     *
+     * @param tenantId changed tenant
+     */
+    public void invalidateAfterLifecycleChange(Long tenantId) {
+        if (tenantId == null || tenantId < 0) {
+            throw new IllegalArgumentException("Tenant identifier is invalid");
+        }
+        authorizationStateService.fenceTenant(tenantId);
+        sseEmitterManager.closeTenantConnections(tenantId);
+        evictFenceAfterTransaction(tenantId);
+    }
+
+    /** Keeps tenant authorization fail-closed until the lifecycle transaction has completed. */
+    private void evictFenceAfterTransaction(Long tenantId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            authorizationStateService.evictTenant(tenantId);
+            return;
+        }
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(int status) {
+                try {
+                    authorizationStateService.evictTenant(tenantId);
+                } catch (RuntimeException exception) {
+                    // The bounded malformed fence intentionally keeps authorization fail-closed until expiry.
+                    log.error("Tenant authorization fence cleanup failed: exceptionType={}",
+                            exception.getClass().getSimpleName());
+                }
+            }
+        });
+    }
+}

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/impl/AccountServiceImpl.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/impl/AccountServiceImpl.java
@@ -7,8 +7,10 @@ import cn.flying.common.util.FlowUtils;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.dto.Account;
 import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.dao.mapper.TenantMapper;
 import cn.flying.dao.vo.auth.*;
 import cn.flying.service.AccountService;
+import cn.flying.service.auth.AccountSessionRevocationService;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.util.Collection;
@@ -52,6 +55,17 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> impl
     private final StringRedisTemplate stringRedisTemplate;
     private final PasswordEncoder passwordEncoder;
     private final FlowUtils flow;
+    private final AccountSessionRevocationService accountSessionRevocationService;
+    private final TenantMapper tenantMapper;
+
+    /**
+     * Enforces the platform-account tenant invariant at the service provisioning boundary.
+     */
+    @Override
+    public boolean save(Account account) {
+        validateAccountIdentity(account);
+        return super.save(account);
+    }
 
     /**
      * 从数据库中通过用户名或邮箱查找用户详细信息
@@ -209,13 +223,20 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> impl
      * @return 操作结果，null表示正常，否则为错误原因
      */
     @Override
+    @Transactional
     public String resetEmailAccountPassword(EmailResetVO info) {
         String verify = resetConfirm(new ConfirmResetVO(info.getEmail(), info.getCode()));
         if(verify != null) return verify;
         String email = info.getEmail();
+        Account account = findAccountByNameOrEmail(email);
+        if (account == null) {
+            return "更新失败，请联系管理员";
+        }
         String password = passwordEncoder.encode(info.getPassword());
-        boolean update = this.update().eq("email", email).set("password", password).update();
+        boolean update = baseMapper.updatePasswordAndIncrementAuthVersion(
+                account.getTenantId(), account.getId(), password) == 1;
         if(update) {
+            accountSessionRevocationService.invalidateAfterVersionChange(account.getTenantId(), account.getId());
             this.deleteEmailVerifyCode(email);
         }
         return update ? null : "更新失败，请联系管理员";
@@ -267,6 +288,7 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> impl
      * @return 操作结果，null表示正常，否则为错误原因
      */
     @Override
+    @Transactional
     public String changePassword(Long userId, ChangePasswordVO changePasswordVO) {
         Account account = this.query().eq("id", userId).one();
         if (account == null) {
@@ -275,10 +297,66 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> impl
         if (!passwordEncoder.matches(changePasswordVO.getPassword(), account.getPassword())) {
             return "原密码错误，请重新输入";
         }
-        boolean success = this.update().eq("id", userId)
-                .set("password", passwordEncoder.encode(changePasswordVO.getNew_password()))
-                .update();
+        boolean success = this.baseMapper.updatePasswordAndIncrementAuthVersion(
+                account.getTenantId(),
+                userId,
+                passwordEncoder.encode(changePasswordVO.getNew_password())) == 1;
+        if (success) {
+            accountSessionRevocationService.invalidateAfterVersionChange(account.getTenantId(), userId);
+        }
         return success ? null : "更新失败，请联系管理员";
+    }
+
+    /**
+     * Creates an active platform administrator only in system tenant zero.
+     */
+    @Override
+    @Transactional
+    public Account createPlatformAdministrator(String username, String email, String passwordHash) {
+        if (!Objects.equals(tenantMapper.lockSystemTenantForPlatformBootstrap(), 0L)) {
+            throw new IllegalStateException("System tenant is unavailable for platform administrator bootstrap");
+        }
+        if (baseMapper.countPlatformAdministrators() != 0) {
+            throw new IllegalStateException("Platform administrator bootstrap requires an empty platform administrator set");
+        }
+        Account account = new Account();
+        account.setId(IdUtils.nextUserId());
+        account.setTenantId(0L);
+        account.setUsername(username);
+        account.setEmail(email);
+        account.setPassword(passwordHash);
+        account.setRole(UserRole.ROLE_PLATFORM_ADMIN.getRole());
+        account.setStatus(1);
+        account.setAuthVersion(0L);
+        account.setRegisterTime(new java.util.Date());
+        account.setUpdateTime(new java.util.Date());
+        account.setDeleted(0);
+        if (!save(account)) {
+            throw new IllegalStateException("Platform administrator bootstrap failed");
+        }
+        return account;
+    }
+
+    /** Records the last successful login without changing token authorization state. */
+    @Override
+    public void recordSuccessfulLogin(Account account) {
+        if (account == null || baseMapper.updateLastLoginTime(account.getTenantId(), account.getId()) != 1) {
+            throw new IllegalStateException("Login state update failed");
+        }
+    }
+
+    /** Validates closed-set account role and platform tenant binding before persistence. */
+    private void validateAccountIdentity(Account account) {
+        if (account == null) {
+            throw new IllegalArgumentException("Account is required");
+        }
+        UserRole role = UserRole.getRole(account.getRole());
+        if (role == UserRole.ROLE_NOOP) {
+            throw new IllegalArgumentException("Unsupported account role");
+        }
+        if (role == UserRole.ROLE_PLATFORM_ADMIN && !Objects.equals(account.getTenantId(), 0L)) {
+            throw new IllegalArgumentException("Platform administrator must belong to system tenant zero");
+        }
     }
 
     /**

--- a/platform-backend/backend-service/src/main/java/cn/flying/service/sse/SseEmitterManager.java
+++ b/platform-backend/backend-service/src/main/java/cn/flying/service/sse/SseEmitterManager.java
@@ -371,6 +371,44 @@ public class SseEmitterManager {
         }
     }
 
+    /**
+     * Completes and removes every connection for one account after session revocation.
+     *
+     * @param tenantId account tenant
+     * @param userId account identifier
+     */
+    public void closeUserConnections(Long tenantId, Long userId) {
+        Map<Long, UserConnections> tenantEmitters = emittersByTenant.get(tenantId);
+        if (tenantEmitters == null) {
+            return;
+        }
+        UserConnections connections = tenantEmitters.get(userId);
+        if (connections == null) {
+            return;
+        }
+        List<Map.Entry<String, SseEmitter>> snapshot;
+        connections.lock().lock();
+        try {
+            snapshot = new ArrayList<>(connections.map().entrySet());
+        } finally {
+            connections.lock().unlock();
+        }
+        snapshot.forEach(entry -> removeConnection(tenantId, userId, entry.getKey(), entry.getValue(), true));
+    }
+
+    /**
+     * Completes all connections owned by a disabled tenant.
+     *
+     * @param tenantId tenant identifier
+     */
+    public void closeTenantConnections(Long tenantId) {
+        Map<Long, UserConnections> tenantEmitters = emittersByTenant.get(tenantId);
+        if (tenantEmitters == null) {
+            return;
+        }
+        new ArrayList<>(tenantEmitters.keySet()).forEach(userId -> closeUserConnections(tenantId, userId));
+    }
+
     @Scheduled(fixedRate = 30000)
     public void sendHeartbeat() {
         if (emittersByTenant.isEmpty()) return;

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/auth/AccountSessionRevocationServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/auth/AccountSessionRevocationServiceTest.java
@@ -1,0 +1,86 @@
+package cn.flying.service.auth;
+
+import cn.flying.common.util.JwtUtils;
+import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.service.sse.SseEmitterManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests account-wide revocation coordination after authorization version changes. */
+@ExtendWith(MockitoExtension.class)
+class AccountSessionRevocationServiceTest {
+
+    @Mock
+    private AccountMapper accountMapper;
+    @Mock
+    private AuthorizationStateService authorizationStateService;
+    @Mock
+    private JwtUtils jwtUtils;
+    @Mock
+    private SseEmitterManager sseEmitterManager;
+
+    /** Increments the database fence before removing all cached and live session state. */
+    @Test
+    void revokesPersistentAndEphemeralSessions() {
+        when(accountMapper.incrementAuthVersion(42L, 7L)).thenReturn(1);
+        AccountSessionRevocationService service = service();
+
+        service.revokeAllSessions(42L, 7L);
+
+        InOrder order = inOrder(accountMapper, authorizationStateService, jwtUtils, sseEmitterManager);
+        order.verify(accountMapper).incrementAuthVersion(42L, 7L);
+        order.verify(authorizationStateService).fenceAccount(42L, 7L);
+        order.verify(jwtUtils).invalidateUserSseTokens(42L, 7L);
+        order.verify(sseEmitterManager).closeUserConnections(42L, 7L);
+        order.verify(authorizationStateService).evictAccount(42L, 7L);
+    }
+
+    /** A missing account cannot be reported as successfully revoked. */
+    @Test
+    void failsClosedWhenPersistentVersionWasNotChanged() {
+        when(accountMapper.incrementAuthVersion(42L, 7L)).thenReturn(0);
+        AccountSessionRevocationService service = service();
+
+        assertThatThrownBy(() -> service.revokeAllSessions(42L, 7L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Account session revocation failed");
+        verify(authorizationStateService, never()).fenceAccount(42L, 7L);
+        verify(authorizationStateService, never()).evictAccount(42L, 7L);
+        verify(jwtUtils, never()).invalidateUserSseTokens(42L, 7L);
+        verify(sseEmitterManager, never()).closeUserConnections(42L, 7L);
+    }
+
+    /** A transaction keeps the invalid authorization fence until completion. */
+    @Test
+    void keepsAuthorizationFencedUntilTransactionCompletion() {
+        AccountSessionRevocationService service = service();
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            service.invalidateAfterVersionChange(42L, 7L);
+
+            verify(authorizationStateService).fenceAccount(42L, 7L);
+            verify(authorizationStateService, never()).evictAccount(42L, 7L);
+            TransactionSynchronizationManager.getSynchronizations().forEach(
+                    synchronization -> synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
+            verify(authorizationStateService).evictAccount(42L, 7L);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    private AccountSessionRevocationService service() {
+        return new AccountSessionRevocationService(
+                accountMapper, authorizationStateService, jwtUtils, sseEmitterManager);
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/auth/AuthorizationStateServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/auth/AuthorizationStateServiceTest.java
@@ -1,0 +1,184 @@
+package cn.flying.service.auth;
+
+import cn.flying.dao.dto.Account;
+import cn.flying.dao.entity.Tenant;
+import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.dao.mapper.TenantMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests fail-closed role, scope, version and tenant lifecycle authorization decisions. */
+@ExtendWith(MockitoExtension.class)
+class AuthorizationStateServiceTest {
+
+    @Mock
+    private AccountMapper accountMapper;
+    @Mock
+    private TenantMapper tenantMapper;
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private AuthorizationStateService service;
+
+    /** Creates the service with an explicit bounded cache and enabled platform identity. */
+    @BeforeEach
+    void setUp() {
+        service = new AuthorizationStateService(accountMapper, tenantMapper, redisTemplate);
+        ReflectionTestUtils.setField(service, "platformIdentityEnabled", true);
+        ReflectionTestUtils.setField(service, "cacheTtl", Duration.ofSeconds(30));
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    /** Accepts only an active current tenant account and writes both bounded cache records. */
+    @Test
+    void acceptsActiveTenantIdentity() {
+        when(accountMapper.selectAuthorizationState(42L, 7L)).thenReturn(account(42L, "admin", 1, 5L, 0));
+        when(tenantMapper.selectAuthorizationState(42L)).thenReturn(tenant(42L, 1, 9L, 0));
+
+        assertThat(service.isTokenAuthorized(7L, 42L, "admin", "tenant", 5L)).isTrue();
+
+        verify(valueOperations).set("tenant:42:auth:account:7", "admin|1|5|0", Duration.ofSeconds(30));
+        verify(valueOperations).set("tenant:42:auth:tenant:current", "1|9|0", Duration.ofSeconds(30));
+    }
+
+    /** Platform recovery remains available even when the tenant-zero business row is disabled. */
+    @Test
+    void platformIdentitySkipsTenantBusinessStatus() {
+        when(accountMapper.selectAuthorizationState(0L, 7L))
+                .thenReturn(account(0L, "platform_admin", 1, 2L, 0));
+
+        assertThat(service.isTokenAuthorized(7L, 0L, "platform_admin", "platform", 2L)).isTrue();
+
+        verify(tenantMapper, never()).selectAuthorizationState(any());
+    }
+
+    /** A legacy tenant role in tenant zero remains tenant-scoped and observes tenant status. */
+    @Test
+    void legacyTenantZeroRoleStillRequiresActiveTenantState() {
+        when(accountMapper.selectAuthorizationState(0L, 8L)).thenReturn(account(0L, "user", 1, 0L, 0));
+        when(tenantMapper.selectAuthorizationState(0L)).thenReturn(tenant(0L, 0, 3L, 0));
+
+        assertThat(service.isTokenAuthorized(8L, 0L, "user", "tenant", 0L)).isFalse();
+    }
+
+    /** Rejects stale authVersion and role/scope confusion without consulting tenant state. */
+    @Test
+    void rejectsStaleOrConfusedClaims() {
+        when(accountMapper.selectAuthorizationState(42L, 7L)).thenReturn(account(42L, "admin", 1, 6L, 0));
+
+        assertThat(service.isTokenAuthorized(7L, 42L, "admin", "tenant", 5L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, 42L, "admin", "platform", 6L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, 42L, "platform_admin", "platform", 6L)).isFalse();
+        verify(tenantMapper, never()).selectAuthorizationState(any());
+    }
+
+    /** Redis failures never downgrade to a database-only allow decision. */
+    @Test
+    void failsClosedWhenRedisIsUnavailable() {
+        when(valueOperations.get(anyString())).thenThrow(new IllegalStateException("redis unavailable"));
+
+        assertThatThrownBy(() -> service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("redis unavailable");
+        verify(accountMapper, never()).selectAuthorizationState(any(), any());
+    }
+
+    /** Corrupt cache content is rejected rather than accepted or silently bypassed. */
+    @Test
+    void failsClosedForCorruptCacheState() {
+        when(valueOperations.get("tenant:42:auth:account:7")).thenReturn("corrupt");
+
+        assertThatThrownBy(() -> service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid cached account authorization state");
+    }
+
+    /** An in-flight version mutation fence never permits a stale token. */
+    @Test
+    void failsClosedWhileAccountVersionMutationIsInFlight() {
+        when(valueOperations.get("tenant:42:auth:account:7")).thenReturn("invalidating");
+
+        assertThatThrownBy(() -> service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid cached account authorization state");
+        verify(accountMapper, never()).selectAuthorizationState(any(), any());
+    }
+
+    /** Mutation fences use the same bounded cache TTL and cannot become permanent locks. */
+    @Test
+    void writesBoundedFailClosedMutationFences() {
+        service.fenceAccount(42L, 7L);
+        service.fenceTenant(42L);
+
+        verify(valueOperations).set("tenant:42:auth:account:7", "invalidating", Duration.ofSeconds(30));
+        verify(valueOperations).set("tenant:42:auth:tenant:current", "invalidating", Duration.ofSeconds(30));
+    }
+
+    /** Disabled platform feature rejects platform claims before any state lookup. */
+    @Test
+    void rejectsPlatformIdentityWhenFeatureIsDisabled() {
+        ReflectionTestUtils.setField(service, "platformIdentityEnabled", false);
+
+        assertThat(service.isTokenAuthorized(7L, 0L, "platform_admin", "platform", 0L)).isFalse();
+        verify(accountMapper, never()).selectAuthorizationState(any(), any());
+    }
+
+    /** Login rejects accounts that predate the mandatory authorization-version contract. */
+    @Test
+    void rejectsLoginWithoutAuthorizationVersion() {
+        Account account = account(42L, "user", 1, null, 0);
+
+        assertThat(service.isLoginAuthorized(account)).isFalse();
+
+        verify(accountMapper, never()).selectAuthorizationState(any(), any());
+        verify(tenantMapper, never()).selectAuthorizationState(any());
+    }
+
+    /** Invalid cache TTLs fail application startup rather than weakening freshness. */
+    @Test
+    void rejectsUnboundedCacheConfiguration() {
+        ReflectionTestUtils.setField(service, "cacheTtl", Duration.ofMinutes(10));
+
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "validateConfiguration"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("security.authorization-state.cache-ttl must be between 1s and 5m");
+    }
+
+    private Account account(Long tenantId, String role, Integer status, Long authVersion, Integer deleted) {
+        Account account = new Account();
+        account.setId(7L);
+        account.setTenantId(tenantId);
+        account.setRole(role);
+        account.setStatus(status);
+        account.setAuthVersion(authVersion);
+        account.setDeleted(deleted);
+        return account;
+    }
+
+    private Tenant tenant(Long tenantId, Integer status, Long version, Integer deleted) {
+        return new Tenant()
+                .setId(tenantId)
+                .setStatus(status)
+                .setVersion(version)
+                .setDeleted(deleted);
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/auth/AuthorizationStateServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/auth/AuthorizationStateServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /** Tests fail-closed role, scope, version and tenant lifecycle authorization decisions. */
@@ -161,6 +162,128 @@ class AuthorizationStateServiceTest {
         assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "validateConfiguration"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("security.authorization-state.cache-ttl must be between 1s and 5m");
+    }
+
+    /** Rejects malformed immutable identity claims before touching external state. */
+    @Test
+    void rejectsMalformedIdentityClaimsBeforeStateLookup() {
+        assertThat(service.isTokenAuthorized(null, 42L, "user", "tenant", 0L)).isFalse();
+        assertThat(service.isTokenAuthorized(0L, 42L, "user", "tenant", 0L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, null, "user", "tenant", 0L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, -1L, "user", "tenant", 0L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", -1L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, 42L, "unknown", null, 0L)).isFalse();
+
+        verifyNoInteractions(accountMapper, tenantMapper);
+    }
+
+    /** Reads valid account and tenant facts from the bounded cache without database access. */
+    @Test
+    void acceptsCachedTenantIdentity() {
+        when(valueOperations.get("tenant:42:auth:account:7")).thenReturn("admin|1|5|0");
+        when(valueOperations.get("tenant:42:auth:tenant:current")).thenReturn("1|9|0");
+
+        assertThat(service.isTokenAuthorized(7L, 42L, "admin", "tenant", 5L)).isTrue();
+
+        verifyNoInteractions(accountMapper, tenantMapper);
+    }
+
+    /** Rejects every inactive, deleted, stale or missing current account representation. */
+    @Test
+    void rejectsInvalidCurrentAccountStates() {
+        when(accountMapper.selectAuthorizationState(42L, 7L)).thenReturn(
+                null,
+                account(42L, "admin", 0, 5L, 0),
+                account(42L, "admin", 1, 5L, 1),
+                account(42L, "admin", 1, null, 0),
+                account(42L, "admin", 1, -1L, 0),
+                account(42L, "user", 1, 5L, 0),
+                account(42L, "admin", 1, 6L, 0));
+
+        for (int index = 0; index < 7; index++) {
+            assertThat(service.isTokenAuthorized(7L, 42L, "admin", "tenant", 5L)).isFalse();
+        }
+        verify(tenantMapper, never()).selectAuthorizationState(any());
+    }
+
+    /** Rejects every inactive, deleted, invalid-version or missing tenant representation. */
+    @Test
+    void rejectsInvalidCurrentTenantStates() {
+        when(accountMapper.selectAuthorizationState(42L, 7L))
+                .thenReturn(account(42L, "admin", 1, 5L, 0));
+        when(tenantMapper.selectAuthorizationState(42L)).thenReturn(
+                null,
+                tenant(42L, 0, 9L, 0),
+                tenant(42L, 1, 9L, 1),
+                tenant(42L, 1, null, 0),
+                tenant(42L, 1, -1L, 0));
+
+        for (int index = 0; index < 5; index++) {
+            assertThat(service.isTokenAuthorized(7L, 42L, "admin", "tenant", 5L)).isFalse();
+        }
+    }
+
+    /** Login and SSE checks reuse the same current-state authorization contract. */
+    @Test
+    void authorizesLoginAndSseThroughCurrentState() {
+        when(accountMapper.selectAuthorizationState(42L, 7L))
+                .thenReturn(account(42L, "user", 1, 5L, 0));
+        when(tenantMapper.selectAuthorizationState(42L)).thenReturn(tenant(42L, 1, 9L, 0));
+
+        assertThat(service.isLoginAuthorized(account(42L, "user", 1, 5L, 0))).isTrue();
+        assertThat(service.isSseIdentityAuthorized(7L, 42L, "user", 5L)).isTrue();
+    }
+
+    /** Cache eviction uses tenant-prefixed keys for both account and tenant state. */
+    @Test
+    void evictsTenantPrefixedAuthorizationState() {
+        service.evictAccount(42L, 7L);
+        service.evictTenant(42L);
+
+        verify(redisTemplate).delete("tenant:42:auth:account:7");
+        verify(redisTemplate).delete("tenant:42:auth:tenant:current");
+    }
+
+    /** Numeric corruption in either cache record fails closed instead of querying the database. */
+    @Test
+    void rejectsNumericCacheCorruption() {
+        when(valueOperations.get("tenant:42:auth:account:7")).thenReturn("user|active|0|0");
+        assertThatThrownBy(() -> service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid cached account authorization state");
+
+        when(valueOperations.get("tenant:42:auth:account:7")).thenReturn("user|1|0|0");
+        when(valueOperations.get("tenant:42:auth:tenant:current")).thenReturn("active|1|0");
+        assertThatThrownBy(() -> service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid cached tenant authorization state");
+    }
+
+    /** A tenant cache record with the wrong field count is rejected without fallback. */
+    @Test
+    void rejectsMalformedTenantCacheShape() {
+        when(valueOperations.get("tenant:42:auth:account:7")).thenReturn("user|1|0|0");
+        when(valueOperations.get("tenant:42:auth:tenant:current")).thenReturn("1|0");
+
+        assertThatThrownBy(() -> service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invalid cached tenant authorization state");
+        verifyNoInteractions(accountMapper, tenantMapper);
+    }
+
+    /** Null, too-short and valid cache TTLs enforce the documented startup bounds. */
+    @Test
+    void validatesAllCacheConfigurationBoundaries() {
+        ReflectionTestUtils.setField(service, "cacheTtl", null);
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "validateConfiguration"))
+                .isInstanceOf(IllegalStateException.class);
+
+        ReflectionTestUtils.setField(service, "cacheTtl", Duration.ofMillis(999));
+        assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(service, "validateConfiguration"))
+                .isInstanceOf(IllegalStateException.class);
+
+        ReflectionTestUtils.setField(service, "cacheTtl", Duration.ofSeconds(1));
+        ReflectionTestUtils.invokeMethod(service, "validateConfiguration");
     }
 
     private Account account(Long tenantId, String role, Integer status, Long authVersion, Integer deleted) {

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/auth/TenantSessionRevocationServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/auth/TenantSessionRevocationServiceTest.java
@@ -2,10 +2,14 @@ package cn.flying.service.auth;
 
 import cn.flying.service.sse.SseEmitterManager;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /** Tests tenant lifecycle cache and live-connection invalidation. */
 class TenantSessionRevocationServiceTest {
@@ -35,5 +39,46 @@ class TenantSessionRevocationServiceTest {
         assertThatThrownBy(() -> service.invalidateAfterLifecycleChange(-1L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Tenant identifier is invalid");
+    }
+
+    /** A transaction keeps the tenant authorization fence in place until completion. */
+    @Test
+    void keepsTenantFencedUntilTransactionCompletion() {
+        AuthorizationStateService authorizationStateService = mock(AuthorizationStateService.class);
+        SseEmitterManager sseEmitterManager = mock(SseEmitterManager.class);
+        TenantSessionRevocationService service = new TenantSessionRevocationService(
+                authorizationStateService, sseEmitterManager);
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            service.invalidateAfterLifecycleChange(42L);
+
+            verify(authorizationStateService).fenceTenant(42L);
+            verify(authorizationStateService, never()).evictTenant(42L);
+            TransactionSynchronizationManager.getSynchronizations().forEach(
+                    synchronization -> synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
+            verify(authorizationStateService).evictTenant(42L);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    /** Fence cleanup failures remain fail-closed and do not escape transaction completion. */
+    @Test
+    void containsFenceCleanupFailureAfterTransaction() {
+        AuthorizationStateService authorizationStateService = mock(AuthorizationStateService.class);
+        SseEmitterManager sseEmitterManager = mock(SseEmitterManager.class);
+        TenantSessionRevocationService service = new TenantSessionRevocationService(
+                authorizationStateService, sseEmitterManager);
+        org.mockito.Mockito.doThrow(new IllegalStateException("redis unavailable"))
+                .when(authorizationStateService).evictTenant(42L);
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            service.invalidateAfterLifecycleChange(42L);
+
+            TransactionSynchronizationManager.getSynchronizations().forEach(
+                    synchronization -> synchronization.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK));
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 }

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/auth/TenantSessionRevocationServiceTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/auth/TenantSessionRevocationServiceTest.java
@@ -1,0 +1,39 @@
+package cn.flying.service.auth;
+
+import cn.flying.service.sse.SseEmitterManager;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+/** Tests tenant lifecycle cache and live-connection invalidation. */
+class TenantSessionRevocationServiceTest {
+
+    /** Fences authorization state before closing every local tenant connection. */
+    @Test
+    void invalidatesTenantSessionsAfterLifecycleChange() {
+        AuthorizationStateService authorizationStateService = mock(AuthorizationStateService.class);
+        SseEmitterManager sseEmitterManager = mock(SseEmitterManager.class);
+        TenantSessionRevocationService service = new TenantSessionRevocationService(
+                authorizationStateService, sseEmitterManager);
+
+        service.invalidateAfterLifecycleChange(42L);
+
+        var order = inOrder(authorizationStateService, sseEmitterManager);
+        order.verify(authorizationStateService).fenceTenant(42L);
+        order.verify(sseEmitterManager).closeTenantConnections(42L);
+        order.verify(authorizationStateService).evictTenant(42L);
+    }
+
+    /** Rejects invalid target tenant identifiers without mutating session state. */
+    @Test
+    void rejectsInvalidTenantIdentifier() {
+        TenantSessionRevocationService service = new TenantSessionRevocationService(
+                mock(AuthorizationStateService.class), mock(SseEmitterManager.class));
+
+        assertThatThrownBy(() -> service.invalidateAfterLifecycleChange(-1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Tenant identifier is invalid");
+    }
+}

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/AccountServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/AccountServiceImplTest.java
@@ -129,6 +129,60 @@ class AccountServiceImplTest {
                     exception.getMessage());
             verify(accountMapper, never()).insert(any(Account.class));
         }
+
+        /** Fails closed when system tenant zero cannot be locked for bootstrap. */
+        @Test
+        void rejectsUnavailableSystemTenant() {
+            when(tenantMapper.lockSystemTenantForPlatformBootstrap()).thenReturn(null);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> accountService.createPlatformAdministrator(USERNAME, EMAIL, ENCODED_PASSWORD));
+
+            assertEquals("System tenant is unavailable for platform administrator bootstrap", exception.getMessage());
+            verify(accountMapper, never()).countPlatformAdministrators();
+        }
+
+        /** Reports a deterministic failure when persistence rejects the new platform identity. */
+        @Test
+        void rejectsFailedPlatformAdministratorInsert() {
+            when(tenantMapper.lockSystemTenantForPlatformBootstrap()).thenReturn(0L);
+            when(accountMapper.countPlatformAdministrators()).thenReturn(0L);
+            when(accountMapper.insert(any(Account.class))).thenReturn(0);
+
+            try (MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                idUtilsMock.when(IdUtils::nextUserId).thenReturn(USER_ID);
+                IllegalStateException exception = assertThrows(IllegalStateException.class,
+                        () -> accountService.createPlatformAdministrator(USERNAME, EMAIL, ENCODED_PASSWORD));
+                assertEquals("Platform administrator bootstrap failed", exception.getMessage());
+            }
+        }
+
+        /** Persists successful-login metadata and rejects absent or stale account rows. */
+        @Test
+        void recordsOnlyExistingSuccessfulLogin() {
+            Account account = createAccount();
+            when(accountMapper.updateLastLoginTime(1L, USER_ID)).thenReturn(1, 0);
+
+            assertDoesNotThrow(() -> accountService.recordSuccessfulLogin(account));
+            assertThrows(IllegalStateException.class, () -> accountService.recordSuccessfulLogin(account));
+            assertThrows(IllegalStateException.class, () -> accountService.recordSuccessfulLogin(null));
+        }
+
+        /** Rejects unsupported identities before any account persistence occurs. */
+        @Test
+        void rejectsInvalidAccountIdentity() {
+            Account unsupported = createAccount();
+            unsupported.setRole("owner");
+            Account misplacedPlatform = createAccount();
+            misplacedPlatform.setRole(UserRole.ROLE_PLATFORM_ADMIN.getRole());
+            misplacedPlatform.setTenantId(1L);
+
+            assertThrows(IllegalArgumentException.class, () -> accountService.save(null));
+            assertThrows(IllegalArgumentException.class, () -> accountService.save(unsupported));
+            assertThrows(IllegalArgumentException.class, () -> accountService.save(misplacedPlatform));
+            verify(accountMapper, never()).insert(unsupported);
+            verify(accountMapper, never()).insert(misplacedPlatform);
+        }
     }
 
     @AfterEach

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/impl/AccountServiceImplTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/impl/AccountServiceImplTest.java
@@ -7,6 +7,8 @@ import cn.flying.common.util.FlowUtils;
 import cn.flying.common.util.IdUtils;
 import cn.flying.dao.dto.Account;
 import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.dao.mapper.TenantMapper;
+import cn.flying.service.auth.AccountSessionRevocationService;
 import cn.flying.dao.vo.auth.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -58,6 +61,12 @@ class AccountServiceImplTest {
     @Mock
     private FlowUtils flow;
 
+    @Mock
+    private AccountSessionRevocationService accountSessionRevocationService;
+
+    @Mock
+    private TenantMapper tenantMapper;
+
     @Spy
     @InjectMocks
     private AccountServiceImpl accountService;
@@ -78,6 +87,48 @@ class AccountServiceImplTest {
         ReflectionTestUtils.setField(accountService, "registrationTenantId", REGISTRATION_TENANT_ID);
         ReflectionTestUtils.setField(accountService, "baseMapper", accountMapper);
         lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("platform bootstrap")
+    class PlatformBootstrap {
+
+        /** Serializes and creates the first platform administrator in tenant zero. */
+        @Test
+        void createsOnlyFirstPlatformAdministrator() {
+            when(tenantMapper.lockSystemTenantForPlatformBootstrap()).thenReturn(0L);
+            when(accountMapper.countPlatformAdministrators()).thenReturn(0L);
+            when(accountMapper.insert(any(Account.class))).thenReturn(1);
+
+            Account created;
+            try (MockedStatic<IdUtils> idUtilsMock = mockStatic(IdUtils.class)) {
+                idUtilsMock.when(IdUtils::nextUserId).thenReturn(USER_ID);
+                created = accountService.createPlatformAdministrator(USERNAME, EMAIL, ENCODED_PASSWORD);
+            }
+
+            assertEquals(0L, created.getTenantId());
+            assertEquals(UserRole.ROLE_PLATFORM_ADMIN.getRole(), created.getRole());
+            assertEquals(1, created.getStatus());
+            assertEquals(0L, created.getAuthVersion());
+            InOrder order = inOrder(tenantMapper, accountMapper);
+            order.verify(tenantMapper).lockSystemTenantForPlatformBootstrap();
+            order.verify(accountMapper).countPlatformAdministrators();
+            order.verify(accountMapper).insert(any(Account.class));
+        }
+
+        /** Duplicate bootstrap attempts fail after taking the shared system-tenant lock. */
+        @Test
+        void rejectsDuplicatePlatformAdministrator() {
+            when(tenantMapper.lockSystemTenantForPlatformBootstrap()).thenReturn(0L);
+            when(accountMapper.countPlatformAdministrators()).thenReturn(1L);
+
+            IllegalStateException exception = assertThrows(IllegalStateException.class,
+                    () -> accountService.createPlatformAdministrator(USERNAME, EMAIL, ENCODED_PASSWORD));
+
+            assertEquals("Platform administrator bootstrap requires an empty platform administrator set",
+                    exception.getMessage());
+            verify(accountMapper, never()).insert(any(Account.class));
+        }
     }
 
     @AfterEach
@@ -122,6 +173,32 @@ class AccountServiceImplTest {
 
             assertThrows(UsernameNotFoundException.class,
                     () -> accountService.loadUserByUsername("nonexistent"));
+        }
+    }
+
+    @Nested
+    @DisplayName("password reset revocation")
+    class PasswordResetRevocation {
+
+        /** Password reset atomically increments authVersion and clears all account sessions. */
+        @Test
+        void resetsPasswordAndRevokesExistingSessions() {
+            EmailResetVO request = new EmailResetVO();
+            request.setEmail(EMAIL);
+            request.setCode(VERIFY_CODE);
+            request.setPassword("New-Synthetic9!Password");
+            Account account = createAccount();
+            when(valueOperations.get(Const.VERIFY_EMAIL_DATA + EMAIL)).thenReturn(VERIFY_CODE);
+            doReturn(account).when(accountService).findAccountByNameOrEmail(EMAIL);
+            when(passwordEncoder.encode("New-Synthetic9!Password")).thenReturn("new-password-hash");
+            when(accountMapper.updatePasswordAndIncrementAuthVersion(1L, USER_ID, "new-password-hash"))
+                    .thenReturn(1);
+
+            String result = accountService.resetEmailAccountPassword(request);
+
+            assertNull(result);
+            verify(accountSessionRevocationService).invalidateAfterVersionChange(1L, USER_ID);
+            verify(stringRedisTemplate).delete(Const.VERIFY_EMAIL_DATA + EMAIL);
         }
     }
 

--- a/platform-backend/backend-service/src/test/java/cn/flying/service/sse/SseEmitterManagerTest.java
+++ b/platform-backend/backend-service/src/test/java/cn/flying/service/sse/SseEmitterManagerTest.java
@@ -112,6 +112,20 @@ class SseEmitterManagerTest {
             assertTrue(manager.isOnline(TENANT_1, USER_1));
             assertEquals(1, manager.getUserConnectionCount(TENANT_1, USER_1));
         }
+
+        /** Closes every live connection owned by one account and tolerates absent targets. */
+        @Test
+        void shouldCloseAllUserConnections() {
+            manager.closeUserConnections(TENANT_1, USER_1);
+            manager.createConnection(TENANT_1, USER_1, "conn-1");
+            manager.createConnection(TENANT_1, USER_1, "conn-2");
+            manager.closeUserConnections(TENANT_1, USER_2);
+
+            manager.closeUserConnections(TENANT_1, USER_1);
+
+            assertFalse(manager.isOnline(TENANT_1, USER_1));
+            assertEquals(0, manager.getUserConnectionCount(TENANT_1, USER_1));
+        }
     }
 
     @Nested
@@ -152,6 +166,20 @@ class SseEmitterManagerTest {
 
             assertNotNull(users);
             assertTrue(users.isEmpty());
+        }
+
+        /** Closing one tenant removes all its users without affecting another tenant. */
+        @Test
+        void shouldCloseOnlyTargetTenantConnections() {
+            manager.closeTenantConnections(999L);
+            manager.createConnection(TENANT_1, USER_1, "conn-1");
+            manager.createConnection(TENANT_1, USER_2, "conn-2");
+            manager.createConnection(TENANT_2, USER_1, "conn-3");
+
+            manager.closeTenantConnections(TENANT_1);
+
+            assertEquals(0, manager.getOnlineCount(TENANT_1));
+            assertTrue(manager.isOnline(TENANT_2, USER_1));
         }
     }
 

--- a/platform-backend/backend-web/src/main/java/cn/flying/bootstrap/PlatformAdministratorBootstrapRunner.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/bootstrap/PlatformAdministratorBootstrapRunner.java
@@ -1,0 +1,128 @@
+package cn.flying.bootstrap;
+
+import cn.flying.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+/**
+ * Performs the explicit one-time creation of the first system-tenant platform administrator.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "platform.bootstrap", name = "enabled", havingValue = "true")
+public class PlatformAdministratorBootstrapRunner implements ApplicationRunner {
+
+    private static final long MAX_PASSWORD_FILE_BYTES = 4096;
+
+    private final AccountService accountService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${platform.bootstrap.username:}")
+    private String username;
+
+    @Value("${platform.bootstrap.email:}")
+    private String email;
+
+    @Value("${platform.bootstrap.password-file:}")
+    private String passwordFile;
+
+    /**
+     * Validates explicit bootstrap configuration, reads the local secret once and creates one account.
+     */
+    @Override
+    public void run(ApplicationArguments args) {
+        validateIdentityConfiguration();
+        char[] password = readPasswordFile();
+        try {
+            validatePassword(password);
+            accountService.createPlatformAdministrator(
+                    username.trim(),
+                    email.trim(),
+                    passwordEncoder.encode(new String(password)));
+        } finally {
+            java.util.Arrays.fill(password, '\0');
+        }
+        log.info("Platform administrator bootstrap completed; disable the bootstrap runner before restart");
+    }
+
+    /** Validates non-secret identity settings without supplying built-in defaults. */
+    private void validateIdentityConfiguration() {
+        if (!StringUtils.hasText(username)
+                || !StringUtils.hasText(email)
+                || !StringUtils.hasText(passwordFile)) {
+            throw new IllegalStateException("Platform administrator bootstrap configuration is incomplete");
+        }
+        if (!email.contains("@") || username.length() > 50 || email.length() > 100) {
+            throw new IllegalStateException("Platform administrator bootstrap identity is invalid");
+        }
+    }
+
+    /** Reads a bounded regular non-symlink password file from the local host. */
+    private char[] readPasswordFile() {
+        Path path = Path.of(passwordFile).toAbsolutePath().normalize();
+        try {
+            if (Files.isSymbolicLink(path)
+                    || !Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS)
+                    || Files.size(path) == 0
+                    || Files.size(path) > MAX_PASSWORD_FILE_BYTES) {
+                throw new IllegalStateException("Platform administrator bootstrap password file is invalid");
+            }
+            validatePosixPermissions(path);
+            return Files.readString(path, StandardCharsets.UTF_8).stripTrailing().toCharArray();
+        } catch (IOException | RuntimeException exception) {
+            if (exception instanceof IllegalStateException illegalStateException) {
+                throw illegalStateException;
+            }
+            throw new IllegalStateException("Platform administrator bootstrap password file is unavailable");
+        }
+    }
+
+    /** Rejects group/other access where POSIX permissions are available. */
+    private void validatePosixPermissions(Path path) throws IOException {
+        try {
+            java.util.Set<java.nio.file.attribute.PosixFilePermission> permissions =
+                    Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS);
+            boolean shared = permissions.stream().anyMatch(permission -> switch (permission) {
+                case GROUP_READ, GROUP_WRITE, GROUP_EXECUTE,
+                        OTHERS_READ, OTHERS_WRITE, OTHERS_EXECUTE -> true;
+                default -> false;
+            });
+            if (shared) {
+                throw new IllegalStateException("Platform administrator bootstrap password file permissions are too broad");
+            }
+        } catch (UnsupportedOperationException exception) {
+            // Non-POSIX filesystems rely on process-level ACLs and the no-symlink regular-file boundary above.
+        }
+    }
+
+    /** Enforces a deterministic minimum password-strength contract without logging secret material. */
+    private void validatePassword(char[] password) {
+        boolean lower = false;
+        boolean upper = false;
+        boolean digit = false;
+        boolean symbol = false;
+        for (char value : password) {
+            lower |= Character.isLowerCase(value);
+            upper |= Character.isUpperCase(value);
+            digit |= Character.isDigit(value);
+            symbol |= !Character.isLetterOrDigit(value);
+        }
+        if (password.length < 16 || !lower || !upper || !digit || !symbol) {
+            throw new IllegalStateException("Platform administrator bootstrap password does not meet policy");
+        }
+    }
+}

--- a/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/config/SecurityConfiguration.java
@@ -16,6 +16,7 @@ import cn.flying.security.CustomMethodSecurityExpressionHandler;
 import cn.flying.service.AccountService;
 import cn.flying.service.LoginSecurityService;
 import cn.flying.service.PermissionService;
+import cn.flying.service.auth.AuthorizationStateService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Resource;
 import jakarta.servlet.http.HttpServletRequest;
@@ -81,6 +82,9 @@ public class SecurityConfiguration {
     @Resource
     PrometheusScrapeSecurity prometheusScrapeSecurity;
 
+    @Resource
+    AuthorizationStateService authorizationStateService;
+
     /**
      * 针对于 SpringSecurity 6 的新版配置方法
      * @param http 配置器
@@ -118,6 +122,17 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/public/proof-keys/*/versions/*").permitAll()
                         .requestMatchers("/api/v1/images/download/images/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/shares/*/info").permitAll()
+                        // Narrow authentication endpoints shared by tenant and platform identities.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/info").hasAnyRole(
+                                UserRole.ROLE_DEFAULT.getRole(),
+                                UserRole.ROLE_ADMINISTER.getRole(),
+                                UserRole.ROLE_MONITOR.getRole(),
+                                UserRole.ROLE_PLATFORM_ADMIN.getRole())
+                        .requestMatchers("/api/v1/auth/tokens/refresh", "/api/v1/auth/logout").hasAnyRole(
+                                UserRole.ROLE_DEFAULT.getRole(),
+                                UserRole.ROLE_ADMINISTER.getRole(),
+                                UserRole.ROLE_MONITOR.getRole(),
+                                UserRole.ROLE_PLATFORM_ADMIN.getRole())
                         // SSE 短期令牌发行需要用户已认证
                         .requestMatchers("/api/v1/auth/tokens/sse").hasAnyRole(
                                 UserRole.ROLE_DEFAULT.getRole(),
@@ -144,6 +159,8 @@ public class SecurityConfiguration {
                         .requestMatchers("/api/v1/system/logs/**", "/api/v1/audit/**").hasAnyRole(
                                 UserRole.ROLE_ADMINISTER.getRole(),
                                 UserRole.ROLE_MONITOR.getRole())
+                        // Platform routes are a separate route family and never accept tenant roles.
+                        .requestMatchers("/api/v1/platform/**").hasRole(UserRole.ROLE_PLATFORM_ADMIN.getRole())
                         // 其他所有请求需要任意角色
                         .anyRequest().hasAnyRole(
                                 UserRole.ROLE_DEFAULT.getRole(),
@@ -293,6 +310,18 @@ public class SecurityConfiguration {
         User user = (User) authentication.getPrincipal();
         Account account = service.findAccountByNameOrEmail(user.getUsername());
 
+        try {
+            if (!authorizationStateService.isLoginAuthorized(account)) {
+                writer.write(Result.error(ResultEnum.USER_LOGIN_ERROR, tracePayload(request, null)).toJson());
+                return;
+            }
+        } catch (RuntimeException exception) {
+            log.error("Login authorization state unavailable: exceptionType={}",
+                    exception.getClass().getSimpleName());
+            writer.write(Result.error(ResultEnum.SERVICE_UNAVAILABLE, tracePayload(request, null)).toJson());
+            return;
+        }
+
         // 清除登录失败记录
         if (username != null && !username.isEmpty()) {
             loginSecurityService.clearLoginFailure(username);
@@ -300,12 +329,15 @@ public class SecurityConfiguration {
 
         // 确保使用Long类型的用户ID
         Long userId = account.getId();
-        String jwt = utils.createJwt(user, account.getUsername(), userId, account.getTenantId());
+        Long authVersion = account.getAuthVersion();
+        String jwt = utils.createJwt(user, account.getUsername(), userId, account.getTenantId(), authVersion);
 
         if(jwt == null) {
             writer.write(Result.error(ResultEnum.PERMISSION_LIMIT, tracePayload(request, null)).toJson());
         } else {
+            service.recordSuccessfulLogin(account);
             AuthorizeVO vo = account.asViewObject(AuthorizeVO.class, o -> o.setToken(jwt));
+            vo.setScope(UserRole.getRole(account.getRole()).scope());
             vo.setExpire(utils.expireTime());
             writer.write(Result.success(vo).toJson());
         }

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/AccountController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/AccountController.java
@@ -2,6 +2,7 @@ package cn.flying.controller;
 
 import cn.flying.common.annotation.OperationLog;
 import cn.flying.common.constant.Result;
+import cn.flying.common.constant.UserRole;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.ControllerUtils;
 import cn.flying.dao.dto.Account;
@@ -48,7 +49,9 @@ public class AccountController {
     @OperationLog(module = "用户模块", operationType = "查询", description = "获取用户信息")
     public Result<AccountVO> getAccountInfo(@RequestAttribute(Const.ATTR_USER_ID) Long userId) {
         Account account = accountService.findAccountById(userId);
-        return Result.success(account.asViewObject(AccountVO.class));
+        AccountVO view = account.asViewObject(AccountVO.class);
+        view.setScope(UserRole.getRole(account.getRole()).scope());
+        return Result.success(view);
     }
 
     /**
@@ -65,7 +68,9 @@ public class AccountController {
             @RequestAttribute(Const.ATTR_USER_ID) Long userId,
             @RequestBody @Valid UpdateUserVO vo) {
         Account account = accountService.updateUserInfo(userId, vo);
-        return Result.success(account.asViewObject(AccountVO.class));
+        AccountVO view = account.asViewObject(AccountVO.class);
+        view.setScope(UserRole.getRole(account.getRole()).scope());
+        return Result.success(view);
     }
 
     /**

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/AuthorizeController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/AuthorizeController.java
@@ -11,6 +11,8 @@ import cn.flying.dao.vo.auth.EmailResetVO;
 import cn.flying.dao.vo.auth.RefreshTokenVO;
 import cn.flying.dao.vo.auth.SseTokenVO;
 import cn.flying.service.AccountService;
+import cn.flying.service.auth.AuthorizationStateService;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,6 +45,7 @@ public class AuthorizeController {
     private final AccountService accountService;
     private final ControllerUtils utils;
     private final JwtUtils jwtUtils;
+    private final AuthorizationStateService authorizationStateService;
 
     /**
      * 请求邮件验证码（REST 新路径）。
@@ -114,7 +117,28 @@ public class AuthorizeController {
     @Operation(summary = "刷新访问令牌（REST）")
     public Result<RefreshTokenVO> refreshAccessToken(HttpServletRequest request) {
         String headerToken = request.getHeader("Authorization");
-        String newToken = jwtUtils.refreshJwt(headerToken);
+        DecodedJWT decoded = jwtUtils.resolveJwt(headerToken);
+        if (decoded == null) {
+            return Result.error(cn.flying.common.constant.ResultEnum.PERMISSION_TOKEN_EXPIRED, null);
+        }
+        try {
+            if (!authorizationStateService.isTokenAuthorized(
+                    jwtUtils.toId(decoded),
+                    jwtUtils.toTenantId(decoded),
+                    jwtUtils.toRole(decoded),
+                    jwtUtils.toScope(decoded),
+                    jwtUtils.toAuthVersion(decoded))) {
+                return Result.error(cn.flying.common.constant.ResultEnum.PERMISSION_TOKEN_EXPIRED, null);
+            }
+        } catch (RuntimeException exception) {
+            return Result.error(cn.flying.common.constant.ResultEnum.SERVICE_UNAVAILABLE, null);
+        }
+        String newToken;
+        try {
+            newToken = jwtUtils.refreshJwt(headerToken);
+        } catch (RuntimeException exception) {
+            return Result.error(cn.flying.common.constant.ResultEnum.SERVICE_UNAVAILABLE, null);
+        }
         if (newToken == null) {
             return Result.error(cn.flying.common.constant.ResultEnum.PERMISSION_TOKEN_EXPIRED, null);
         }
@@ -134,8 +158,9 @@ public class AuthorizeController {
         Long userId = (Long) request.getAttribute(Const.ATTR_USER_ID);
         Long tenantId = (Long) request.getAttribute(Const.ATTR_TENANT_ID);
         String role = (String) request.getAttribute(Const.ATTR_USER_ROLE);
+        Long authVersion = (Long) request.getAttribute(Const.ATTR_AUTH_VERSION);
 
-        String sseToken = jwtUtils.createSseToken(userId, tenantId, role);
+        String sseToken = jwtUtils.createSseToken(userId, tenantId, role, authVersion);
         return Result.success(new SseTokenVO(sseToken, Const.SSE_TOKEN_TTL));
     }
 

--- a/platform-backend/backend-web/src/main/java/cn/flying/controller/SseController.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/controller/SseController.java
@@ -7,6 +7,7 @@ import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.JwtUtils;
 import cn.flying.service.sse.SseEmitterManager;
+import cn.flying.service.auth.AuthorizationStateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -39,6 +40,8 @@ public class SseController {
 
     private final JwtUtils jwtUtils;
 
+    private final AuthorizationStateService authorizationStateService;
+
     /**
      * 建立 SSE 连接（使用短期令牌）
      * 该端点使用一次性短期令牌进行认证，不使用常规 JWT
@@ -61,18 +64,18 @@ public class SseController {
                     name = "X-Tenant-ID",
                     in = ParameterIn.HEADER,
                     description = "可设置自定义请求头的客户端使用的Redis namespace提示，不作为可信租户身份",
-                    schema = @Schema(type = "integer", format = "int64", minimum = "1")),
+                    schema = @Schema(type = "integer", format = "int64", minimum = "0")),
             @Parameter(
                     name = "x-tenant-id",
                     in = ParameterIn.QUERY,
                     description = "Redis namespace提示；与旧tenantId参数二选一，不作为可信租户身份",
-                    schema = @Schema(type = "integer", format = "int64", minimum = "1")),
+                    schema = @Schema(type = "integer", format = "int64", minimum = "0")),
             @Parameter(
                     name = "tenantId",
                     in = ParameterIn.QUERY,
                     description = "旧客户端兼容的Redis namespace提示；建议改用x-tenant-id",
                     deprecated = true,
-                    schema = @Schema(type = "integer", format = "int64", minimum = "1"))
+                    schema = @Schema(type = "integer", format = "int64", minimum = "0"))
     })
     public ResponseEntity<SseEmitter> connect(
             @RequestParam("token") String sseToken,
@@ -100,6 +103,18 @@ public class SseController {
             return ResponseEntity.status(401).build();
         }
 
+        try {
+            if (!authorizationStateService.isSseIdentityAuthorized(
+                    identity.userId(), identity.tenantId(), identity.role(), identity.authVersion())) {
+                log.warn("SSE 连接失败: 当前授权状态无效");
+                return ResponseEntity.status(401).build();
+            }
+        } catch (RuntimeException exception) {
+            log.error("SSE 连接失败: 授权状态存储不可用, exceptionType={}",
+                    exception.getClass().getSimpleName());
+            return ResponseEntity.status(503).build();
+        }
+
         establishTrustedIdentity(request, identity);
         String connectionId = UUID.randomUUID().toString().replace("-", "");
 
@@ -113,21 +128,22 @@ public class SseController {
     /**
      * 解析并校验 Redis 中的一次性短令牌身份载荷。
      *
-     * @param userInfo 短令牌载荷 [userId, tenantId, role]
+     * @param userInfo 短令牌载荷 [userId, tenantId, role, authVersion]
      * @return 完整且受支持的身份；载荷损坏时返回 null
      */
     private SseIdentity parseSseIdentity(String[] userInfo) {
-        if (userInfo == null || userInfo.length != 3) {
+        if (userInfo == null || userInfo.length != 4) {
             return null;
         }
         try {
             long userId = Long.parseLong(userInfo[0]);
             long tenantId = Long.parseLong(userInfo[1]);
+            long authVersion = Long.parseLong(userInfo[3]);
             UserRole role = UserRole.getRole(userInfo[2]);
-            if (userId <= 0 || tenantId <= 0 || role == UserRole.ROLE_NOOP) {
+            if (userId <= 0 || tenantId < 0 || authVersion < 0 || !role.isTenantRole()) {
                 return null;
             }
-            return new SseIdentity(userId, tenantId, role.getRole());
+            return new SseIdentity(userId, tenantId, role.getRole(), authVersion);
         } catch (NumberFormatException e) {
             return null;
         }
@@ -144,6 +160,7 @@ public class SseController {
         request.setAttribute(Const.ATTR_TENANT_ID, identity.tenantId());
         request.setAttribute(Const.ATTR_USER_ID, identity.userId());
         request.setAttribute(Const.ATTR_USER_ROLE, identity.role());
+        request.setAttribute(Const.ATTR_AUTH_VERSION, identity.authVersion());
         MDC.put(Const.ATTR_TENANT_ID, identity.tenantId().toString());
         MDC.put(Const.ATTR_USER_ID, identity.userId().toString());
         MDC.put(Const.ATTR_USER_ROLE, identity.role());
@@ -152,7 +169,7 @@ public class SseController {
     /**
      * 短令牌中经校验的 SSE 身份。
      */
-    private record SseIdentity(Long userId, Long tenantId, String role) {
+    private record SseIdentity(Long userId, Long tenantId, String role, Long authVersion) {
     }
 
     @OperationLog(module = "实时推送", operationType = "删除", description = "断开SSE连接")

--- a/platform-backend/backend-web/src/main/java/cn/flying/filter/JwtAuthenticationFilter.java
+++ b/platform-backend/backend-web/src/main/java/cn/flying/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.ErrorPayloadFactory;
 import cn.flying.common.util.JwtUtils;
+import cn.flying.service.auth.AuthorizationStateService;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.annotation.Resource;
 import jakarta.servlet.FilterChain;
@@ -47,6 +48,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Resource
     JwtUtils utils;
 
+    @Resource
+    AuthorizationStateService authorizationStateService;
+
     /**
      * 解析并校验 JWT，设置安全上下文与租户相关的日志上下文。
      */
@@ -73,10 +77,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = utils.toId(jwt);
                 String userRole = utils.toRole(jwt);
                 Long jwtTenantId = utils.toTenantId(jwt);
+                String scope = utils.toScope(jwt);
+                Long authVersion = utils.toAuthVersion(jwt);
 
                 // 验证 JWT 中的 tenantId 与请求头一致（防止跨租户攻击）
                 if (!validateTenantMatch(headerTenantId, jwtTenantId, userId, response)) {
                     SecurityContextHolder.clearContext();
+                    return;
+                }
+
+
+                try {
+                    if (!authorizationStateService.isTokenAuthorized(
+                            userId, jwtTenantId, userRole, scope, authVersion)) {
+                        SecurityContextHolder.clearContext();
+                        sendAuthenticationFailure(response, HttpServletResponse.SC_UNAUTHORIZED,
+                                ResultEnum.PERMISSION_TOKEN_INVALID);
+                        return;
+                    }
+                } catch (RuntimeException exception) {
+                    log.error("Authorization state validation unavailable: exceptionType={}",
+                            exception.getClass().getSimpleName());
+                    SecurityContextHolder.clearContext();
+                    sendAuthenticationFailure(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                            ResultEnum.SERVICE_UNAVAILABLE);
                     return;
                 }
 
@@ -96,6 +120,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // Store in request attributes
                 request.setAttribute(Const.ATTR_USER_ID, userId);
                 request.setAttribute(Const.ATTR_USER_ROLE, userRole);
+                request.setAttribute(Const.ATTR_AUTH_SCOPE, scope);
+                request.setAttribute(Const.ATTR_AUTH_VERSION, authVersion);
                 // 租户ID已由 TenantFilter 设置，这里不覆盖
 
                 // Set MDC for logging
@@ -119,6 +145,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             MDC.remove(Const.ATTR_TENANT_ID);
             TenantContext.clear();
         }
+    }
+
+    /** Writes a credential-free authentication failure response. */
+    private void sendAuthenticationFailure(
+            HttpServletResponse response,
+            int status,
+            ResultEnum resultEnum) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json;charset=utf-8");
+        ErrorPayload payload = ErrorPayloadFactory.of(MDC.get(Const.TRACE_ID), null);
+        PrintWriter writer = response.getWriter();
+        writer.write(Result.error(resultEnum, payload).toJson());
+        writer.flush();
     }
 
     /**

--- a/platform-backend/backend-web/src/main/resources/application.yml
+++ b/platform-backend/backend-web/src/main/resources/application.yml
@@ -76,6 +76,21 @@ record-platform:
   rpc:
     blockchain-token: ${BLOCKCHAIN_RPC_TOKEN}
 
+# Platform identity is opt-in until V1.21.0 is migrated and bootstrap is complete.
+security:
+  platform-identity:
+    enabled: ${PLATFORM_IDENTITY_ENABLED:false}
+  authorization-state:
+    cache-ttl: ${AUTHORIZATION_STATE_CACHE_TTL:30s}
+
+# One-time local password-file bootstrap. Never place password content in configuration.
+platform:
+  bootstrap:
+    enabled: ${PLATFORM_BOOTSTRAP_ENABLED:false}
+    username: ${PLATFORM_BOOTSTRAP_USERNAME:}
+    email: ${PLATFORM_BOOTSTRAP_EMAIL:}
+    password-file: ${PLATFORM_BOOTSTRAP_PASSWORD_FILE:}
+
 # springdoc-openapi项目配置
 springdoc:
   swagger-ui:

--- a/platform-backend/backend-web/src/main/resources/db/migration/V1.21.0__platform_identity_tenant_status.sql
+++ b/platform-backend/backend-web/src/main/resources/db/migration/V1.21.0__platform_identity_tenant_status.sql
@@ -1,0 +1,16 @@
+-- Add authorization state required by platform identities and tenant lifecycle enforcement.
+ALTER TABLE `account`
+    ADD COLUMN `status` TINYINT NOT NULL DEFAULT 1 COMMENT 'Authorization status: 1-active, 0-disabled' AFTER `role`,
+    ADD COLUMN `auth_version` BIGINT NOT NULL DEFAULT 0 COMMENT 'Account-wide session revocation version' AFTER `status`,
+    ADD COLUMN `last_login_time` DATETIME NULL DEFAULT NULL COMMENT 'Last successful login time' AFTER `auth_version`,
+    ADD INDEX `idx_account_authorization_state` (`tenant_id`, `id`, `deleted`, `status`, `role`, `auth_version`),
+    ADD INDEX `idx_account_tenant_status_role` (`tenant_id`, `deleted`, `status`, `role`),
+    ADD CONSTRAINT `chk_account_platform_admin_tenant`
+        CHECK (`role` <> 'platform_admin' OR `tenant_id` = 0);
+
+ALTER TABLE `tenant`
+    ADD COLUMN `version` BIGINT NOT NULL DEFAULT 0 COMMENT 'Tenant lifecycle version' AFTER `status`,
+    ADD COLUMN `disabled_reason` VARCHAR(255) NULL DEFAULT NULL COMMENT 'Sanitized disable reason' AFTER `version`,
+    ADD COLUMN `disabled_at` DATETIME NULL DEFAULT NULL COMMENT 'Disable time' AFTER `disabled_reason`,
+    ADD COLUMN `disabled_by` BIGINT NULL DEFAULT NULL COMMENT 'Platform actor account ID' AFTER `disabled_at`,
+    ADD INDEX `idx_tenant_authorization_state` (`id`, `status`, `version`);

--- a/platform-backend/backend-web/src/test/java/cn/flying/bootstrap/PlatformAdministratorBootstrapRunnerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/bootstrap/PlatformAdministratorBootstrapRunnerTest.java
@@ -1,0 +1,95 @@
+package cn.flying.bootstrap;
+
+import cn.flying.service.AccountService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests the disabled-by-default, local password-file platform bootstrap boundary. */
+@ExtendWith(MockitoExtension.class)
+class PlatformAdministratorBootstrapRunnerTest {
+
+    private static final String PASSWORD = "Synthetic-Platform9!Password";
+
+    @Mock
+    private AccountService accountService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @TempDir
+    Path tempDir;
+
+    /** Reads a restrictive local file and passes only its BCrypt result to the account service. */
+    @Test
+    void createsPlatformAdministratorFromPasswordFile() throws Exception {
+        Path passwordFile = tempDir.resolve("platform-password");
+        Files.writeString(passwordFile, PASSWORD + System.lineSeparator());
+        restrictIfPosix(passwordFile);
+        when(passwordEncoder.encode(PASSWORD)).thenReturn("synthetic-bcrypt-hash");
+        PlatformAdministratorBootstrapRunner runner = runner(passwordFile);
+
+        runner.run(null);
+
+        verify(accountService).createPlatformAdministrator(
+                "platform-operator", "platform-operator@example.test", "synthetic-bcrypt-hash");
+    }
+
+    /** Refuses group/other-readable password files on POSIX filesystems. */
+    @Test
+    void rejectsBroadPosixPermissionsWithoutExposingPassword() throws Exception {
+        Path passwordFile = tempDir.resolve("shared-password");
+        Files.writeString(passwordFile, PASSWORD);
+        assumeTrue(Files.getFileAttributeView(passwordFile, PosixFileAttributeView.class) != null);
+        Files.setPosixFilePermissions(passwordFile, PosixFilePermissions.fromString("rw-r--r--"));
+        PlatformAdministratorBootstrapRunner runner = runner(passwordFile);
+
+        assertThatThrownBy(() -> runner.run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Platform administrator bootstrap password file permissions are too broad")
+                .hasMessageNotContaining(PASSWORD);
+    }
+
+    /** Refuses incomplete configuration before reading any local file. */
+    @Test
+    void rejectsIncompleteConfiguration() {
+        PlatformAdministratorBootstrapRunner runner = new PlatformAdministratorBootstrapRunner(
+                accountService, passwordEncoder);
+        ReflectionTestUtils.setField(runner, "username", "");
+        ReflectionTestUtils.setField(runner, "email", "");
+        ReflectionTestUtils.setField(runner, "passwordFile", "");
+
+        assertThatThrownBy(() -> runner.run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Platform administrator bootstrap configuration is incomplete");
+    }
+
+    /** Creates a configured runner without embedding password content in configuration. */
+    private PlatformAdministratorBootstrapRunner runner(Path passwordFile) {
+        PlatformAdministratorBootstrapRunner runner = new PlatformAdministratorBootstrapRunner(
+                accountService, passwordEncoder);
+        ReflectionTestUtils.setField(runner, "username", "platform-operator");
+        ReflectionTestUtils.setField(runner, "email", "platform-operator@example.test");
+        ReflectionTestUtils.setField(runner, "passwordFile", passwordFile.toString());
+        return runner;
+    }
+
+    /** Applies owner-only permissions where the host filesystem supports POSIX attributes. */
+    private void restrictIfPosix(Path passwordFile) throws Exception {
+        if (Files.getFileAttributeView(passwordFile, PosixFileAttributeView.class) != null) {
+            Files.setPosixFilePermissions(passwordFile, PosixFilePermissions.fromString("rw-------"));
+        }
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/bootstrap/PlatformAdministratorBootstrapRunnerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/bootstrap/PlatformAdministratorBootstrapRunnerTest.java
@@ -76,6 +76,47 @@ class PlatformAdministratorBootstrapRunnerTest {
                 .hasMessage("Platform administrator bootstrap configuration is incomplete");
     }
 
+    /** Refuses malformed identity metadata before reading the password file. */
+    @Test
+    void rejectsInvalidIdentityConfiguration() {
+        PlatformAdministratorBootstrapRunner runner = new PlatformAdministratorBootstrapRunner(
+                accountService, passwordEncoder);
+        ReflectionTestUtils.setField(runner, "username", "platform-operator");
+        ReflectionTestUtils.setField(runner, "email", "invalid-email");
+        ReflectionTestUtils.setField(runner, "passwordFile", "unused");
+
+        assertThatThrownBy(() -> runner.run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Platform administrator bootstrap identity is invalid");
+    }
+
+    /** Refuses empty and unavailable secret files without exposing their content. */
+    @Test
+    void rejectsInvalidPasswordFiles() throws Exception {
+        Path emptyFile = tempDir.resolve("empty-password");
+        Files.createFile(emptyFile);
+        restrictIfPosix(emptyFile);
+
+        assertThatThrownBy(() -> runner(emptyFile).run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Platform administrator bootstrap password file is invalid");
+        assertThatThrownBy(() -> runner(tempDir.resolve("missing-password")).run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Platform administrator bootstrap password file is invalid");
+    }
+
+    /** Refuses a readable secret that does not meet the deterministic password policy. */
+    @Test
+    void rejectsWeakPassword() throws Exception {
+        Path passwordFile = tempDir.resolve("weak-password");
+        Files.writeString(passwordFile, "only-lowercase");
+        restrictIfPosix(passwordFile);
+
+        assertThatThrownBy(() -> runner(passwordFile).run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Platform administrator bootstrap password does not meet policy");
+    }
+
     /** Creates a configured runner without embedding password content in configuration. */
     private PlatformAdministratorBootstrapRunner runner(Path passwordFile) {
         PlatformAdministratorBootstrapRunner runner = new PlatformAdministratorBootstrapRunner(

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/PrometheusScrapeSecurityTest.java
@@ -13,6 +13,7 @@ import cn.flying.filter.TenantFilter;
 import cn.flying.service.AccountService;
 import cn.flying.service.LoginSecurityService;
 import cn.flying.service.PermissionService;
+import cn.flying.service.auth.AuthorizationStateService;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -110,6 +111,7 @@ class PrometheusScrapeSecurityTest {
             factory.registerSingleton("jwtUtils", mock(JwtUtils.class));
             factory.registerSingleton("loginSecurityService", mock(LoginSecurityService.class));
             factory.registerSingleton("permissionService", mock(PermissionService.class));
+            factory.registerSingleton("authorizationStateService", mock(AuthorizationStateService.class));
         });
         context.register(TestConfiguration.class);
         context.refresh();
@@ -267,6 +269,35 @@ class PrometheusScrapeSecurityTest {
         longRequest.addHeader("X-Tenant-ID", "42");
         assertEquals(200, perform(longRequest).getStatus());
         verify(jwt).resolveJwt(longBearer);
+    }
+
+    /** Proves platform and tenant bearer identities cannot cross route families. */
+    @Test
+    void separatesPlatformAndTenantRouteFamilies() throws Exception {
+        start(false, "not-a-hash");
+        configureJwt("platform_admin", 0L, "platform", 3L);
+        configureJwt("admin", 42L, "tenant", 4L);
+
+        MockHttpServletRequest platformRoute = request("GET", "/api/v1/platform/tenants", "Bearer platform_admin");
+        platformRoute.addHeader("X-Tenant-ID", "0");
+        assertEquals(200, perform(platformRoute).getStatus());
+
+        MockHttpServletRequest platformOnTenant = request("GET", "/api/v1/files", "Bearer platform_admin");
+        platformOnTenant.addHeader("X-Tenant-ID", "0");
+        assertEquals(403, perform(platformOnTenant).getStatus());
+
+        MockHttpServletRequest tenantOnPlatform = request("GET", "/api/v1/platform/tenants", "Bearer admin");
+        tenantOnPlatform.addHeader("X-Tenant-ID", "42");
+        assertEquals(403, perform(tenantOnPlatform).getStatus());
+
+        MockHttpServletRequest tenantRoute = request("GET", "/api/v1/files", "Bearer admin");
+        tenantRoute.addHeader("X-Tenant-ID", "42");
+        assertEquals(200, perform(tenantRoute).getStatus());
+
+        MockHttpServletRequest wrongPlatformHeader = request(
+                "GET", "/api/v1/platform/tenants", "Bearer platform_admin");
+        wrongPlatformHeader.addHeader("X-Tenant-ID", "42");
+        assertEquals(403, perform(wrongPlatformHeader).getStatus());
     }
 
     /** Disable the new feature without changing the prior operator-only endpoint behavior. */
@@ -455,13 +486,22 @@ class PrometheusScrapeSecurityTest {
 
     /** Supply decoded tokens at the JWT boundary while exercising the production role/tenant filter. */
     private void configureJwt(String role) {
+        configureJwt(role, 42L, "tenant", 0L);
+    }
+
+    /** Supplies one exact role/scope/tenant token and an accepting current-state decision. */
+    private void configureJwt(String role, Long tenantId, String scope, Long authVersion) {
         JwtUtils jwt = context.getBean(JwtUtils.class);
         DecodedJWT token = mock(DecodedJWT.class);
         when(jwt.resolveJwt("Bearer " + role)).thenReturn(token);
         when(jwt.toId(token)).thenReturn(7L);
-        when(jwt.toTenantId(token)).thenReturn(42L);
+        when(jwt.toTenantId(token)).thenReturn(tenantId);
         when(jwt.toRole(token)).thenReturn(role);
+        when(jwt.toScope(token)).thenReturn(scope);
+        when(jwt.toAuthVersion(token)).thenReturn(authVersion);
         when(jwt.toUser(token)).thenReturn(User.withUsername("business-" + role).password("unused").roles(role).build());
+        when(context.getBean(AuthorizationStateService.class)
+                .isTokenAuthorized(7L, tenantId, role, scope, authVersion)).thenReturn(true);
     }
 
     /** Supply only application dependencies; the scrape manager must stay private to its filter. */

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
@@ -147,4 +147,28 @@ class SecurityConfigurationTest {
         assertFalse(applicationYaml.contains("forward-headers-strategy: native"));
         assertFalse(applicationYaml.contains("forward-headers-strategy: framework"));
     }
+
+    /** Keeps platform identity and its password-file bootstrap explicitly disabled by default. */
+    @Test
+    void shouldDefaultPlatformIdentityAndBootstrapToDisabled() throws Exception {
+        String applicationYaml = Files.readString(Path.of("src/main/resources/application.yml"));
+
+        assertTrue(applicationYaml.contains("enabled: ${PLATFORM_IDENTITY_ENABLED:false}"));
+        assertTrue(applicationYaml.contains("enabled: ${PLATFORM_BOOTSTRAP_ENABLED:false}"));
+        assertTrue(applicationYaml.contains("password-file: ${PLATFORM_BOOTSTRAP_PASSWORD_FILE:}"));
+        assertFalse(applicationYaml.contains("platform-admin-password"));
+    }
+
+    /** Places the platform route family before the tenant catch-all and keeps both role sets disjoint. */
+    @Test
+    void shouldSeparatePlatformAndTenantRouteFamilies() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/cn/flying/config/SecurityConfiguration.java"));
+        int platformMatcher = source.indexOf(".requestMatchers(\"/api/v1/platform/**\")");
+        int tenantCatchAll = source.indexOf(".anyRequest().hasAnyRole(");
+
+        assertTrue(platformMatcher > 0);
+        assertTrue(tenantCatchAll > platformMatcher);
+        String tenantRule = source.substring(tenantCatchAll, source.indexOf(")\n                )", tenantCatchAll));
+        assertFalse(tenantRule.contains("ROLE_PLATFORM_ADMIN"));
+    }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
@@ -1,17 +1,32 @@
 package cn.flying.config;
 
+import cn.flying.common.constant.ResultEnum;
+import cn.flying.common.util.JwtUtils;
+import cn.flying.dao.dto.Account;
+import cn.flying.service.AccountService;
+import cn.flying.service.LoginSecurityService;
+import cn.flying.service.auth.AuthorizationStateService;
 import cn.flying.test.support.JwtTestSupport;
 import com.auth0.jwt.JWT;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * SecurityConfiguration 单元测试。
@@ -183,5 +198,70 @@ class SecurityConfigurationTest {
         assertTrue(tenantCatchAll > platformMatcher);
         String tenantRule = source.substring(tenantCatchAll, source.indexOf(")\n                )", tenantCatchAll));
         assertFalse(tenantRule.contains("ROLE_PLATFORM_ADMIN"));
+    }
+
+    /** Login fails closed when current authorization state is stale or unavailable. */
+    @Test
+    void shouldFailClosedBeforeIssuingLoginToken() throws Exception {
+        SecurityConfiguration configuration = new SecurityConfiguration();
+        AccountService accountService = mock(AccountService.class);
+        AuthorizationStateService authorizationStateService = mock(AuthorizationStateService.class);
+        LoginSecurityService loginSecurityService = mock(LoginSecurityService.class);
+        JwtUtils jwtUtils = mock(JwtUtils.class);
+        ReflectionTestUtils.setField(configuration, "service", accountService);
+        ReflectionTestUtils.setField(configuration, "authorizationStateService", authorizationStateService);
+        ReflectionTestUtils.setField(configuration, "loginSecurityService", loginSecurityService);
+        ReflectionTestUtils.setField(configuration, "utils", jwtUtils);
+        Account account = new Account();
+        account.setId(1L);
+        account.setTenantId(1L);
+        account.setUsername("operator");
+        account.setRole("user");
+        account.setAuthVersion(0L);
+        when(accountService.findAccountByNameOrEmail("operator")).thenReturn(account);
+        when(authorizationStateService.isLoginAuthorized(account))
+                .thenReturn(false)
+                .thenThrow(new IllegalStateException("redis unavailable"))
+                .thenReturn(true, true);
+        when(jwtUtils.createJwt(any(), eq("operator"), eq(1L), eq(1L), eq(0L)))
+                .thenReturn(null, "jwt-token");
+        when(jwtUtils.expireTime()).thenReturn(new Date(1700000000000L));
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(User.withUsername("operator")
+                .password("unused")
+                .roles("user")
+                .build());
+
+        MockHttpServletResponse staleResponse = invokeLoginSuccess(configuration, authentication);
+        MockHttpServletResponse unavailableResponse = invokeLoginSuccess(configuration, authentication);
+        MockHttpServletResponse rateLimitedResponse = invokeLoginSuccess(configuration, authentication);
+        MockHttpServletResponse successResponse = invokeLoginSuccess(configuration, authentication);
+
+        assertThat(staleResponse.getContentAsString()).contains("\"code\":" + ResultEnum.USER_LOGIN_ERROR.getCode());
+        assertThat(unavailableResponse.getContentAsString())
+                .contains("\"code\":" + ResultEnum.SERVICE_UNAVAILABLE.getCode());
+        assertThat(rateLimitedResponse.getContentAsString())
+                .contains("\"code\":" + ResultEnum.PERMISSION_LIMIT.getCode());
+        assertThat(successResponse.getContentAsString())
+                .contains("\"code\":" + ResultEnum.SUCCESS.getCode())
+                .contains("\"token\":\"jwt-token\"")
+                .contains("\"scope\":\"tenant\"");
+        verify(accountService).recordSuccessfulLogin(account);
+    }
+
+    /** Invokes the private login-success handler with a writable mock servlet response. */
+    private MockHttpServletResponse invokeLoginSuccess(
+            SecurityConfiguration configuration,
+            Authentication authentication) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ReflectionTestUtils.invokeMethod(
+                configuration,
+                "handleLoginSuccess",
+                "operator",
+                authentication,
+                response.getWriter(),
+                request);
+        return response;
     }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/config/SecurityConfigurationTest.java
@@ -1,5 +1,7 @@
 package cn.flying.config;
 
+import cn.flying.test.support.JwtTestSupport;
+import com.auth0.jwt.JWT;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -7,6 +9,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,6 +17,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * SecurityConfiguration 单元测试。
  */
 class SecurityConfigurationTest {
+
+    /** Keeps the shared controller-integration token aligned with mandatory production identity claims. */
+    @Test
+    void shouldGenerateCurrentAuthorizationClaimsForControllerIntegrationTests() {
+        var token = JWT.decode(JwtTestSupport.generateToken());
+
+        assertThat(token.getClaim("scope").asString()).isEqualTo("tenant");
+        assertThat(token.getClaim("authVersion").asLong()).isZero();
+        assertThat(token.getClaim("authorities").asList(String.class)).containsExactly("ROLE_user");
+    }
 
     /**
      * 验证生产 context-path 下的登录请求仍会被识别为登录接口。

--- a/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/contract/OpenApiContractExportTest.java
@@ -76,6 +76,7 @@ import cn.flying.service.proof.ProofBundleService;
 import cn.flying.service.proof.signed.SignedProofArchiveService;
 import cn.flying.service.proof.signed.ProofSigningProviderRegistry;
 import cn.flying.service.sse.SseEmitterManager;
+import cn.flying.service.auth.AuthorizationStateService;
 import cn.flying.security.TrustedClientIpResolver;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,6 +145,9 @@ class OpenApiContractExportTest {
 
     @MockitoBean
     private AccountService accountService;
+
+    @MockitoBean
+    private AuthorizationStateService authorizationStateService;
 
     @MockitoBean
     private ControllerUtils controllerUtils;
@@ -369,6 +373,14 @@ class OpenApiContractExportTest {
                 "/api/v1/public/proofs/{proofId}/status")).isTrue();
         assertThat(rootNode.path("paths").has(
                 "/api/v1/public/proof-keys/{keyId}/versions/{keyVersion}")).isTrue();
+        JsonNode accountSchema = rootNode.path("components").path("schemas").path("AccountVO");
+        assertThat(accountSchema.path("properties").has("scope")).isTrue();
+        assertThat(accountSchema.path("required")).anySatisfy(value ->
+                assertThat(value.asText()).isEqualTo("scope"));
+        assertThat(accountSchema.path("properties").path("scope").path("enum"))
+                .extracting(JsonNode::asText)
+                .containsExactly("tenant", "platform");
+        assertThat(accountSchema.path("properties").has("status")).isTrue();
         assertPublicOperation(
                 rootNode,
                 "/api/v1/shares/{shareCode}/info",

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/ControllerCoverageBoostTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/ControllerCoverageBoostTest.java
@@ -266,6 +266,33 @@ class ControllerCoverageBoostTest {
         assertEquals(ResultEnum.SUCCESS.getCode(), changePasswordRest.getCode());
     }
 
+    /** Covers refresh failure-closed decisions for stale state and unavailable dependencies. */
+    @Test
+    void shouldFailClosedForInvalidRefreshAuthorizationState() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer old-token");
+        when(jwtUtils.resolveJwt("Bearer old-token")).thenReturn(decodedJwt);
+        when(jwtUtils.toId(decodedJwt)).thenReturn(1L);
+        when(jwtUtils.toTenantId(decodedJwt)).thenReturn(2L);
+        when(jwtUtils.toRole(decodedJwt)).thenReturn("user");
+        when(jwtUtils.toScope(decodedJwt)).thenReturn("tenant");
+        when(jwtUtils.toAuthVersion(decodedJwt)).thenReturn(0L);
+        when(authorizationStateService.isTokenAuthorized(1L, 2L, "user", "tenant", 0L))
+                .thenReturn(false)
+                .thenThrow(new IllegalStateException("redis unavailable"))
+                .thenReturn(true);
+        when(jwtUtils.refreshJwt("Bearer old-token"))
+                .thenThrow(new IllegalStateException("redis unavailable"));
+
+        Result<RefreshTokenVO> stale = authorizeController.refreshAccessToken(request);
+        Result<RefreshTokenVO> stateUnavailable = authorizeController.refreshAccessToken(request);
+        Result<RefreshTokenVO> refreshUnavailable = authorizeController.refreshAccessToken(request);
+
+        assertEquals(ResultEnum.PERMISSION_TOKEN_EXPIRED.getCode(), stale.getCode());
+        assertEquals(ResultEnum.SERVICE_UNAVAILABLE.getCode(), stateUnavailable.getCode());
+        assertEquals(ResultEnum.SERVICE_UNAVAILABLE.getCode(), refreshUnavailable.getCode());
+    }
+
     /**
      * 覆盖消息与会话新接口。
      */

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/ControllerCoverageBoostTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/ControllerCoverageBoostTest.java
@@ -133,6 +133,10 @@ class ControllerCoverageBoostTest {
     private PermissionService permissionService;
     @Mock
     private cn.flying.common.util.JwtUtils jwtUtils;
+    @Mock
+    private cn.flying.service.auth.AuthorizationStateService authorizationStateService;
+    @Mock
+    private com.auth0.jwt.interfaces.DecodedJWT decodedJwt;
 
     private AuthorizeController authorizeController;
     private AccountController accountController;
@@ -159,7 +163,7 @@ class ControllerCoverageBoostTest {
 
         ControllerUtils controllerUtils = new ControllerUtils();
 
-        authorizeController = new AuthorizeController(accountService, controllerUtils, jwtUtils);
+        authorizeController = new AuthorizeController(accountService, controllerUtils, jwtUtils, authorizationStateService);
         accountController = new AccountController(accountService, controllerUtils);
         messageController = new MessageController(messageService);
         conversationController = new ConversationController(conversationService, messageService);
@@ -213,6 +217,13 @@ class ControllerCoverageBoostTest {
 
         MockHttpServletRequest refreshRequest = new MockHttpServletRequest();
         refreshRequest.addHeader("Authorization", "Bearer old-token");
+        when(jwtUtils.resolveJwt("Bearer old-token")).thenReturn(decodedJwt).thenReturn(null);
+        when(jwtUtils.toId(decodedJwt)).thenReturn(1L);
+        when(jwtUtils.toTenantId(decodedJwt)).thenReturn(2L);
+        when(jwtUtils.toRole(decodedJwt)).thenReturn("user");
+        when(jwtUtils.toScope(decodedJwt)).thenReturn("tenant");
+        when(jwtUtils.toAuthVersion(decodedJwt)).thenReturn(0L);
+        when(authorizationStateService.isTokenAuthorized(1L, 2L, "user", "tenant", 0L)).thenReturn(true);
         when(jwtUtils.refreshJwt("Bearer old-token")).thenReturn("new-token").thenReturn(null);
         when(jwtUtils.expireTime()).thenReturn(new Date(1700000000000L));
         Result<RefreshTokenVO> refreshSuccess = authorizeController.refreshAccessToken(refreshRequest);
@@ -225,7 +236,8 @@ class ControllerCoverageBoostTest {
         sseRequest.setAttribute(Const.ATTR_USER_ID, 1L);
         sseRequest.setAttribute(Const.ATTR_TENANT_ID, 2L);
         sseRequest.setAttribute(Const.ATTR_USER_ROLE, "user");
-        when(jwtUtils.createSseToken(1L, 2L, "user")).thenReturn("sse-token");
+        sseRequest.setAttribute(Const.ATTR_AUTH_VERSION, 0L);
+        when(jwtUtils.createSseToken(1L, 2L, "user", 0L)).thenReturn("sse-token");
         Result<SseTokenVO> sseResult = authorizeController.issueSseToken(sseRequest);
         assertEquals(ResultEnum.SUCCESS.getCode(), sseResult.getCode());
         assertEquals("sse-token", sseResult.getData().getSseToken());

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseAuditTenantIsolationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseAuditTenantIsolationIT.java
@@ -177,7 +177,7 @@ class SseAuditTenantIsolationIT extends BaseControllerIntegrationTest {
     private String createValidToken() {
         String validToken = TenantContext.callWithTenant(
                 TRUSTED_TENANT_ID,
-                () -> jwtUtils.createSseToken(SSE_USER_ID, TRUSTED_TENANT_ID, "user"));
+                () -> jwtUtils.createSseToken(SSE_USER_ID, TRUSTED_TENANT_ID, "user", 0L));
         sseRedisKey(TRUSTED_TENANT_ID, validToken);
         return validToken;
     }

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerIntegrationTest.java
@@ -53,7 +53,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should establish SSE connection with valid token")
         void connect_shouldEstablishConnectionWithValidToken() throws Exception {
             String validSseToken = "valid_sse_token";
-            doReturn(new String[]{"100", "1", "user"})
+            doReturn(new String[]{"100", "1", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -71,7 +71,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         void connect_shouldIgnoreClientSuppliedConnectionId() throws Exception {
             String validSseToken = "valid_sse_token";
             String connectionId = "custom_connection_123";
-            doReturn(new String[]{"100", "1", "user"})
+            doReturn(new String[]{"100", "1", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -119,7 +119,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should return 401 for malformed user ID in token")
         void connect_shouldReturn401ForMalformedUserId() throws Exception {
             String malformedToken = "malformed_token";
-            doReturn(new String[]{"invalid_user_id", "1", "user"})
+            doReturn(new String[]{"invalid_user_id", "1", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(malformedToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -133,7 +133,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should generate connectionId if not provided")
         void connect_shouldGenerateConnectionIdIfNotProvided() throws Exception {
             String validSseToken = "valid_sse_token";
-            doReturn(new String[]{"100", "1", "user"})
+            doReturn(new String[]{"100", "1", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -154,7 +154,7 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         @DisplayName("GET /connect - Should reject tenant hint mismatch")
         void connect_shouldRejectTenantHintMismatch() throws Exception {
             String mismatchedToken = "mismatched_token";
-            doReturn(new String[]{"100", "2", "user"})
+            doReturn(new String[]{"100", "2", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(mismatchedToken);
 
             mockMvc.perform(get(BASE_URL + "/connect")
@@ -252,9 +252,9 @@ class SseControllerIntegrationTest extends BaseControllerIntegrationTest {
         void shouldSupportMultipleConnectionsForSameUser() throws Exception {
             String validSseToken1 = "valid_sse_token_1";
             String validSseToken2 = "valid_sse_token_2";
-            doReturn(new String[]{"100", "1", "user"})
+            doReturn(new String[]{"100", "1", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken1);
-            doReturn(new String[]{"100", "1", "user"})
+            doReturn(new String[]{"100", "1", "user", "0"})
                     .when(jwtUtils).validateAndConsumeSseToken(validSseToken2);
 
             mockMvc.perform(get(BASE_URL + "/connect")

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerTest.java
@@ -168,4 +168,36 @@ class SseControllerTest {
         assertThat(MDC.get(Const.ATTR_USER_ID)).isNull();
         assertThat(MDC.get(Const.ATTR_USER_ROLE)).isNull();
     }
+
+    /** Rejects a consumed short token when the account or tenant is no longer authorized. */
+    @Test
+    @DisplayName("connect should reject stale current authorization state")
+    void connectShouldRejectStaleAuthorizationState() {
+        when(jwtUtils.validateAndConsumeSseToken("stale-token"))
+                .thenReturn(new String[]{"100", "1", "user", "7"});
+        when(authorizationStateService.isSseIdentityAuthorized(100L, 1L, "user", 7L))
+                .thenReturn(false);
+
+        ResponseEntity<SseEmitter> response = controller.connect(
+                "stale-token", 1L, new MockHttpServletRequest());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(401);
+        verify(sseEmitterManager, never()).createConnection(anyLong(), anyLong(), anyString());
+    }
+
+    /** Returns service unavailable when current authorization storage cannot be checked. */
+    @Test
+    @DisplayName("connect should fail closed when authorization state is unavailable")
+    void connectShouldFailClosedWhenAuthorizationStateUnavailable() {
+        when(jwtUtils.validateAndConsumeSseToken("state-failure-token"))
+                .thenReturn(new String[]{"100", "1", "user", "7"});
+        when(authorizationStateService.isSseIdentityAuthorized(100L, 1L, "user", 7L))
+                .thenThrow(new IllegalStateException("redis unavailable"));
+
+        ResponseEntity<SseEmitter> response = controller.connect(
+                "state-failure-token", 1L, new MockHttpServletRequest());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(503);
+        verify(sseEmitterManager, never()).createConnection(anyLong(), anyLong(), anyString());
+    }
 }

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SseControllerTest.java
@@ -4,6 +4,7 @@ import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.JwtUtils;
 import cn.flying.service.sse.SseEmitterManager;
+import cn.flying.service.auth.AuthorizationStateService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +39,9 @@ class SseControllerTest {
     @Mock
     private JwtUtils jwtUtils;
 
+    @Mock
+    private AuthorizationStateService authorizationStateService;
+
     private SseController controller;
 
     /**
@@ -44,7 +49,10 @@ class SseControllerTest {
      */
     @BeforeEach
     void setUp() {
-        controller = new SseController(sseEmitterManager, jwtUtils);
+        controller = new SseController(sseEmitterManager, jwtUtils, authorizationStateService);
+        lenient().when(authorizationStateService.isSseIdentityAuthorized(
+                        anyLong(), anyLong(), anyString(), anyLong()))
+                .thenReturn(true);
     }
 
     /**
@@ -65,7 +73,7 @@ class SseControllerTest {
         when(jwtUtils.validateAndConsumeSseToken("valid-token"))
                 .thenAnswer(invocation -> {
                     assertThat(TenantContext.getTenantId()).isEqualTo(1L);
-                    return new String[]{"100", "1", "user"};
+                    return new String[]{"100", "1", "user", "7"};
                 });
         when(sseEmitterManager.createConnection(eq(1L), eq(100L), anyString()))
                 .thenReturn(new SseEmitter(60000L));
@@ -82,6 +90,8 @@ class SseControllerTest {
         assertThat(request.getAttribute(Const.ATTR_TENANT_ID)).isEqualTo(1L);
         assertThat(request.getAttribute(Const.ATTR_USER_ID)).isEqualTo(100L);
         assertThat(request.getAttribute(Const.ATTR_USER_ROLE)).isEqualTo("user");
+        assertThat(request.getAttribute(Const.ATTR_AUTH_VERSION)).isEqualTo(7L);
+        verify(authorizationStateService).isSseIdentityAuthorized(100L, 1L, "user", 7L);
         assertThat(TenantContext.getTenantId()).isEqualTo(1L);
         assertThat(MDC.get(Const.ATTR_TENANT_ID)).isEqualTo("1");
         assertThat(MDC.get(Const.ATTR_USER_ID)).isEqualTo("100");
@@ -95,7 +105,7 @@ class SseControllerTest {
     @DisplayName("connect should reject a token tenant that differs from the hint")
     void connectShouldRejectTokenTenantMismatch() {
         when(jwtUtils.validateAndConsumeSseToken("mismatched-token"))
-                .thenReturn(new String[]{"100", "2", "user"});
+                .thenReturn(new String[]{"100", "2", "user", "7"});
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         ResponseEntity<SseEmitter> response = controller.connect("mismatched-token", 1L, request);
@@ -118,7 +128,7 @@ class SseControllerTest {
     @DisplayName("connect should reject a corrupted token role")
     void connectShouldRejectCorruptedTokenRole() {
         when(jwtUtils.validateAndConsumeSseToken("corrupted-token"))
-                .thenReturn(new String[]{"100", "1", "owner"});
+                .thenReturn(new String[]{"100", "1", "owner", "7"});
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         ResponseEntity<SseEmitter> response = controller.connect(

--- a/platform-backend/backend-web/src/test/java/cn/flying/controller/SysAuditControllerTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/controller/SysAuditControllerTest.java
@@ -68,6 +68,9 @@ public class SysAuditControllerTest {
     @MockitoBean
     private cn.flying.common.util.JwtUtils jwtUtils;
 
+    @MockitoBean
+    private cn.flying.service.auth.AuthorizationStateService authorizationStateService;
+
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(

--- a/platform-backend/backend-web/src/test/java/cn/flying/filter/JwtAuthenticationFilterTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/filter/JwtAuthenticationFilterTest.java
@@ -4,6 +4,7 @@ import cn.flying.common.constant.ResultEnum;
 import cn.flying.common.tenant.TenantContext;
 import cn.flying.common.util.Const;
 import cn.flying.common.util.JwtUtils;
+import cn.flying.service.auth.AuthorizationStateService;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.servlet.FilterChain;
@@ -48,6 +49,9 @@ class JwtAuthenticationFilterTest {
 
     @Mock
     private DecodedJWT decodedJWT;
+
+    @Mock
+    private AuthorizationStateService authorizationStateService;
 
     @InjectMocks
     private JwtAuthenticationFilter filter;
@@ -104,6 +108,10 @@ class JwtAuthenticationFilterTest {
             when(jwtUtils.toId(decodedJWT)).thenReturn(123L);
             when(jwtUtils.toRole(decodedJWT)).thenReturn("user");
             when(jwtUtils.toTenantId(decodedJWT)).thenReturn(1L);
+            when(jwtUtils.toScope(decodedJWT)).thenReturn("tenant");
+            when(jwtUtils.toAuthVersion(decodedJWT)).thenReturn(0L);
+            when(authorizationStateService.isTokenAuthorized(123L, 1L, "user", "tenant", 0L))
+                    .thenReturn(true);
 
             UserDetails userDetails = User.builder()
                     .username("testuser")
@@ -221,6 +229,10 @@ class JwtAuthenticationFilterTest {
             request.setAttribute(Const.ATTR_TENANT_ID, 1L);
             when(jwtUtils.toTenantId(decodedJWT)).thenReturn(1L);
             when(jwtUtils.toRole(decodedJWT)).thenReturn("user");
+            when(jwtUtils.toScope(decodedJWT)).thenReturn("tenant");
+            when(jwtUtils.toAuthVersion(decodedJWT)).thenReturn(0L);
+            when(authorizationStateService.isTokenAuthorized(123L, 1L, "user", "tenant", 0L))
+                    .thenReturn(true);
 
             UserDetails userDetails = User.builder()
                     .username("testuser")
@@ -250,22 +262,55 @@ class JwtAuthenticationFilterTest {
         }
 
         @Test
-        @DisplayName("should allow when neither JWT nor header has tenant (public endpoint)")
-        void shouldAllowWhenNeitherHasTenant() throws ServletException, IOException {
+        @DisplayName("should reject a protected identity token with no tenant claim")
+        void shouldRejectWhenJwtHasNoTenant() throws ServletException, IOException {
             // No header tenant ID set (public endpoint scenario)
             when(jwtUtils.toTenantId(decodedJWT)).thenReturn(null);
             when(jwtUtils.toRole(decodedJWT)).thenReturn("user");
 
-            UserDetails userDetails = User.builder()
-                    .username("testuser")
-                    .password("******")
-                    .authorities("ROLE_user")
-                    .build();
-            when(jwtUtils.toUser(decodedJWT)).thenReturn(userDetails);
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(401, response.getStatus());
+            verify(filterChain, never()).doFilter(request, response);
+        }
+
+        /** Rejects a stale authVersion with the same non-enumerating token response. */
+        @Test
+        void shouldRejectStaleAuthorizationState() throws ServletException, IOException {
+            request.setAttribute(Const.ATTR_TENANT_ID, 1L);
+            when(jwtUtils.toTenantId(decodedJWT)).thenReturn(1L);
+            when(jwtUtils.toRole(decodedJWT)).thenReturn("user");
+            when(jwtUtils.toScope(decodedJWT)).thenReturn("tenant");
+            when(jwtUtils.toAuthVersion(decodedJWT)).thenReturn(3L);
+            when(authorizationStateService.isTokenAuthorized(123L, 1L, "user", "tenant", 3L))
+                    .thenReturn(false);
 
             filter.doFilterInternal(request, response, filterChain);
 
-            verify(filterChain).doFilter(request, response);
+            assertEquals(401, response.getStatus());
+            assertTrue(response.getContentAsString().contains(
+                    String.valueOf(ResultEnum.PERMISSION_TOKEN_INVALID.getCode())));
+            verify(filterChain, never()).doFilter(request, response);
+        }
+
+        /** Dependency failure returns a fixed unavailable response without leaking state details. */
+        @Test
+        void shouldFailClosedWhenAuthorizationStoreIsUnavailable() throws ServletException, IOException {
+            request.setAttribute(Const.ATTR_TENANT_ID, 1L);
+            when(jwtUtils.toTenantId(decodedJWT)).thenReturn(1L);
+            when(jwtUtils.toRole(decodedJWT)).thenReturn("user");
+            when(jwtUtils.toScope(decodedJWT)).thenReturn("tenant");
+            when(jwtUtils.toAuthVersion(decodedJWT)).thenReturn(3L);
+            when(authorizationStateService.isTokenAuthorized(123L, 1L, "user", "tenant", 3L))
+                    .thenThrow(new IllegalStateException("redis://secret-host/account/123"));
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            assertEquals(503, response.getStatus());
+            assertTrue(response.getContentAsString().contains(
+                    String.valueOf(ResultEnum.SERVICE_UNAVAILABLE.getCode())));
+            assertFalse(response.getContentAsString().contains("secret-host"));
+            verify(filterChain, never()).doFilter(request, response);
         }
     }
 
@@ -311,6 +356,10 @@ class JwtAuthenticationFilterTest {
             when(jwtUtils.toId(decodedJWT)).thenReturn(123L);
             when(jwtUtils.toRole(decodedJWT)).thenReturn("user");
             when(jwtUtils.toTenantId(decodedJWT)).thenReturn(1L);
+            when(jwtUtils.toScope(decodedJWT)).thenReturn("tenant");
+            when(jwtUtils.toAuthVersion(decodedJWT)).thenReturn(0L);
+            when(authorizationStateService.isTokenAuthorized(123L, 1L, "user", "tenant", 0L))
+                    .thenReturn(true);
 
             UserDetails userDetails = User.builder()
                     .username("testuser")

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayMigrationVersionTest.java
@@ -54,10 +54,27 @@ class FlywayMigrationVersionTest {
         assertTrue(migrationFiles.contains("V1.19.0__automated_key_rotation.sql"));
         assertTrue(migrationFiles.contains("V1.20.0__runtime_crypto_agility.sql"));
         assertTrue(migrationFiles.contains("V1.20.1__filter_sensitive_operation_view.sql"));
+        assertTrue(migrationFiles.contains("V1.21.0__platform_identity_tenant_status.sql"));
         assertFalse(migrationFiles.contains("V1.5.0__add_account_nickname.sql"));
         assertFalse(migrationFiles.contains("V1.7.3__integrity_alert.sql"));
 
         validateUniqueMigrationVersions(migrationFiles);
+    }
+
+    /** Verifies V1.21 adds only new identity columns and never re-adds released tenant columns. */
+    @Test
+    void shouldAddPlatformIdentityThroughOneForwardMigration() throws IOException {
+        String sql = Files.readString(resolveMigrationDir().resolve(
+                "V1.21.0__platform_identity_tenant_status.sql"));
+        String normalizedSql = sql.replaceAll("\\s+", " ").trim();
+
+        assertTrue(normalizedSql.contains("ADD COLUMN `status` TINYINT NOT NULL DEFAULT 1"));
+        assertTrue(normalizedSql.contains("ADD COLUMN `auth_version` BIGINT NOT NULL DEFAULT 0"));
+        assertTrue(normalizedSql.contains("ADD COLUMN `version` BIGINT NOT NULL DEFAULT 0"));
+        assertTrue(normalizedSql.contains("CHECK (`role` <> 'platform_admin' OR `tenant_id` = 0)"));
+        assertFalse(normalizedSql.contains("ADD COLUMN `update_time`"));
+        assertFalse(normalizedSql.contains("ADD COLUMN `deleted`"));
+        assertFalse(normalizedSql.matches("(?is).*DROP\\s+(TABLE|COLUMN).*"));
     }
 
     /**

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayReleasedMigrationCompatibilityIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/FlywayReleasedMigrationCompatibilityIT.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Testcontainers(disabledWithoutDocker = false)
 class FlywayReleasedMigrationCompatibilityIT {
 
-    private static final String LATEST_VERSION = "1.20.1";
+    private static final String LATEST_VERSION = "1.21.0";
     private static final String RELEASED_VERSION = "1.7.0";
     private static final String RELEASED_V1_SHA256 =
             "2d62aa70b0f58851579db62034ad12556409201a3cd2e7ad036d709348150645";
@@ -52,7 +52,7 @@ class FlywayReleasedMigrationCompatibilityIT {
     private static final int KNOWN_REWRITTEN_NICKNAME_FLYWAY_CHECKSUM = 529309880;
     private static final int KNOWN_REWRITTEN_SOFT_DELETE_FLYWAY_CHECKSUM = 1607980540;
     private static final int KNOWN_REWRITTEN_INTEGRITY_FLYWAY_CHECKSUM = 2100652293;
-    private static final int KNOWN_REWRITTEN_MIGRATION_COUNT = 39;
+    private static final int KNOWN_REWRITTEN_MIGRATION_COUNT = 40;
 
     @Container
     private static final MySQLContainer<?> MYSQL =

--- a/platform-backend/backend-web/src/test/java/cn/flying/migration/PlatformIdentityMigrationIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/migration/PlatformIdentityMigrationIT.java
@@ -1,0 +1,131 @@
+package cn.flying.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Executes V1.21 platform identity migration and constraints against real MySQL 8. */
+@Testcontainers(disabledWithoutDocker = false)
+class PlatformIdentityMigrationIT {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+            .withDatabaseName("platform_identity_migration")
+            .withUsername("test")
+            .withPassword("test");
+
+    /** Cleans the isolated database before every migration path. */
+    @BeforeEach
+    void cleanDatabase() {
+        flyway(null, true).clean();
+    }
+
+    /** Existing tenant accounts receive active status/version defaults without duplicate released columns. */
+    @Test
+    void upgradesExistingRowsWithoutDataLoss() throws SQLException {
+        flyway("1.20.1", false).migrate();
+        try (Connection connection = connection()) {
+            connection.createStatement().executeUpdate("""
+                    INSERT INTO tenant (id, name, code, status, deleted, create_time, update_time)
+                    VALUES (42, 'Tenant 42', 'tenant-42', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    """);
+            connection.createStatement().executeUpdate("""
+                    INSERT INTO account (id, tenant_id, username, password, email, role, deleted)
+                    VALUES (4201, 42, 'legacy-admin', '$2a$10$synthetic', 'legacy-admin@example.test', 'admin', 0)
+                    """);
+        }
+
+        Flyway upgraded = flyway(null, false);
+        upgraded.migrate();
+
+        assertThat(upgraded.info().current().getVersion().getVersion()).isEqualTo("1.21.0");
+        try (Connection connection = connection();
+             var statement = connection.createStatement()) {
+            try (var rows = statement.executeQuery("""
+                    SELECT status, auth_version, last_login_time
+                      FROM account WHERE id = 4201
+                    """)) {
+                assertThat(rows.next()).isTrue();
+                assertThat(rows.getInt("status")).isEqualTo(1);
+                assertThat(rows.getLong("auth_version")).isZero();
+                assertThat(rows.getObject("last_login_time")).isNull();
+            }
+            try (var rows = statement.executeQuery("""
+                    SELECT status, version, disabled_reason, disabled_at, disabled_by
+                      FROM tenant WHERE id = 42
+                    """)) {
+                assertThat(rows.next()).isTrue();
+                assertThat(rows.getInt("status")).isEqualTo(1);
+                assertThat(rows.getLong("version")).isZero();
+                assertThat(rows.getObject("disabled_reason")).isNull();
+                assertThat(rows.getObject("disabled_at")).isNull();
+                assertThat(rows.getObject("disabled_by")).isNull();
+            }
+            try (var rows = statement.executeQuery("""
+                    SELECT COUNT(*) AS column_count
+                      FROM information_schema.columns
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'tenant'
+                       AND column_name = 'update_time'
+                    """)) {
+                rows.next();
+                assertThat(rows.getInt("column_count")).isEqualTo(1);
+            }
+        }
+    }
+
+    /** Database constraint rejects platform administrators outside system tenant zero. */
+    @Test
+    void enforcesPlatformAdministratorTenantBinding() throws SQLException {
+        flyway(null, false).migrate();
+        try (Connection connection = connection()) {
+            assertThatThrownBy(() -> connection.createStatement().executeUpdate("""
+                    INSERT INTO account
+                        (id, tenant_id, username, password, email, role, status, auth_version, deleted)
+                    VALUES
+                        (4202, 42, 'invalid-platform', '$2a$10$synthetic',
+                         'invalid-platform@example.test', 'platform_admin', 1, 0, 0)
+                    """))
+                    .isInstanceOf(SQLException.class);
+
+            int inserted = connection.createStatement().executeUpdate("""
+                    INSERT INTO account
+                        (id, tenant_id, username, password, email, role, status, auth_version, deleted)
+                    VALUES
+                        (4203, 0, 'valid-platform', '$2a$10$synthetic',
+                         'valid-platform@example.test', 'platform_admin', 1, 0, 0)
+                    """);
+            assertThat(inserted).isEqualTo(1);
+        }
+    }
+
+    /** Builds Flyway for the isolated real database and optional target version. */
+    private Flyway flyway(String targetVersion, boolean cleanEnabled) {
+        var builder = Flyway.configure()
+                .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+                .locations("classpath:db/migration")
+                .validateOnMigrate(true)
+                .cleanDisabled(!cleanEnabled);
+        if (targetVersion != null) {
+            builder.target(MigrationVersion.fromVersion(targetVersion));
+        }
+        return builder.load();
+    }
+
+    /** Opens a JDBC connection to the test container. */
+    private Connection connection() throws SQLException {
+        return DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/service/auth/AuthorizationStateRedisIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/service/auth/AuthorizationStateRedisIT.java
@@ -1,0 +1,109 @@
+package cn.flying.service.auth;
+
+import cn.flying.dao.dto.Account;
+import cn.flying.dao.entity.Tenant;
+import cn.flying.dao.mapper.AccountMapper;
+import cn.flying.dao.mapper.TenantMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Proves authVersion and tenant-status cache invalidation against a real Redis server. */
+@Testcontainers(disabledWithoutDocker = false)
+class AuthorizationStateRedisIT {
+
+    @Container
+    private static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    private static LettuceConnectionFactory connectionFactory;
+    private static StringRedisTemplate redisTemplate;
+
+    /** Connects a real StringRedisTemplate to the isolated container. */
+    @BeforeAll
+    static void connectRedis() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(
+                REDIS.getHost(), REDIS.getMappedPort(6379));
+        connectionFactory = new LettuceConnectionFactory(configuration);
+        connectionFactory.afterPropertiesSet();
+        connectionFactory.start();
+        redisTemplate = new StringRedisTemplate(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+    }
+
+    /** Clears prior test state. */
+    @BeforeEach
+    void clearRedis() {
+        redisTemplate.execute((RedisCallback<Void>) connection -> {
+            connection.serverCommands().flushDb();
+            return null;
+        });
+    }
+
+    /** Releases Lettuce resources. */
+    @AfterAll
+    static void disconnectRedis() {
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
+        }
+    }
+
+    /** Eviction makes account and tenant authorization mutations visible on the next request. */
+    @Test
+    void observesVersionAndTenantStatusAfterExplicitEviction() {
+        AccountMapper accountMapper = mock(AccountMapper.class);
+        TenantMapper tenantMapper = mock(TenantMapper.class);
+        AtomicReference<Account> account = new AtomicReference<>(account(0L));
+        AtomicReference<Tenant> tenant = new AtomicReference<>(tenant(1));
+        when(accountMapper.selectAuthorizationState(42L, 7L)).thenAnswer(invocation -> account.get());
+        when(tenantMapper.selectAuthorizationState(42L)).thenAnswer(invocation -> tenant.get());
+
+        AuthorizationStateService service = new AuthorizationStateService(accountMapper, tenantMapper, redisTemplate);
+        ReflectionTestUtils.setField(service, "platformIdentityEnabled", true);
+        ReflectionTestUtils.setField(service, "cacheTtl", Duration.ofMinutes(1));
+
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L)).isTrue();
+        account.set(account(1L));
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L)).isTrue();
+        service.evictAccount(42L, 7L);
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", 0L)).isFalse();
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", 1L)).isTrue();
+
+        tenant.set(tenant(0));
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", 1L)).isTrue();
+        service.evictTenant(42L);
+        assertThat(service.isTokenAuthorized(7L, 42L, "user", "tenant", 1L)).isFalse();
+    }
+
+    private Account account(Long authVersion) {
+        Account account = new Account();
+        account.setId(7L);
+        account.setTenantId(42L);
+        account.setRole("user");
+        account.setStatus(1);
+        account.setAuthVersion(authVersion);
+        account.setDeleted(0);
+        return account;
+    }
+
+    private Tenant tenant(Integer status) {
+        return new Tenant().setId(42L).setStatus(status).setVersion(1L).setDeleted(0);
+    }
+}

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/attestation/AttestationBatchProductionIT.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/attestation/AttestationBatchProductionIT.java
@@ -16,6 +16,7 @@ import cn.flying.service.attestation.AttestationBatchProductionRunResult;
 import cn.flying.service.attestation.AttestationBatchProductionService;
 import cn.flying.service.attestation.AttestationCandidateAdmissionResult;
 import cn.flying.service.attestation.AttestationCandidateClaim;
+import cn.flying.service.auth.AuthorizationStateService;
 import cn.flying.test.BaseIntegrationTest;
 import cn.flying.test.support.JwtTestSupport;
 import org.junit.jupiter.api.AfterEach;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
@@ -37,6 +39,9 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -71,11 +76,17 @@ class AttestationBatchProductionIT extends BaseIntegrationTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @MockitoBean
+    private AuthorizationStateService authorizationStateService;
+
     /**
      * 启用测试内生产路径，并把阈值限制为单文件/单 batch。
      */
     @BeforeEach
     void setUpProduction() {
+        lenient().when(authorizationStateService.isTokenAuthorized(
+                        anyLong(), anyLong(), anyString(), anyString(), anyLong()))
+                .thenReturn(true);
         TenantContext.setTenantId(TENANT_ID);
         properties.setEnabled(true);
         properties.setMinBatchSize(1);

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/support/BaseControllerIntegrationTest.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/support/BaseControllerIntegrationTest.java
@@ -15,6 +15,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import cn.flying.test.BaseIntegrationTest;
+import cn.flying.service.auth.AuthorizationStateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 
 @AutoConfigureMockMvc
 public abstract class BaseControllerIntegrationTest extends BaseIntegrationTest {
@@ -27,9 +34,26 @@ public abstract class BaseControllerIntegrationTest extends BaseIntegrationTest 
     @Autowired
     protected ObjectMapper objectMapper;
 
+    @MockitoBean
+    protected AuthorizationStateService authorizationStateService;
+
     protected Long testUserId = JwtTestSupport.DEFAULT_USER_ID;
     protected Long testTenantId = JwtTestSupport.DEFAULT_TENANT_ID;
     protected String testToken = JwtTestSupport.generateToken();
+
+    /**
+     * Keeps legacy controller integration tests focused on route/role behavior.
+     * Current-state authorization itself is covered by dedicated filter and Redis integration tests.
+     */
+    @BeforeEach
+    void stubCurrentAuthorizationState() {
+        lenient().when(authorizationStateService.isTokenAuthorized(
+                        anyLong(), anyLong(), anyString(), anyString(), anyLong()))
+                .thenReturn(true);
+        lenient().when(authorizationStateService.isSseIdentityAuthorized(
+                        anyLong(), anyLong(), anyString(), anyLong()))
+                .thenReturn(true);
+    }
 
     protected void setTestUser(Long userId, Long tenantId) {
         this.testUserId = userId;

--- a/platform-backend/backend-web/src/test/java/cn/flying/test/support/JwtTestSupport.java
+++ b/platform-backend/backend-web/src/test/java/cn/flying/test/support/JwtTestSupport.java
@@ -14,6 +14,9 @@ import java.util.UUID;
  */
 public class JwtTestSupport {
 
+    private static final String TENANT_SCOPE = "tenant";
+    private static final long DEFAULT_AUTH_VERSION = 0L;
+
     private static final String TEST_JWT_KEY = "ci-integration-jwt-key-32chars-xK9mN2pL5qR8vW3y";
     private static final String ISSUER = "record-platform";
     private static final String AUDIENCE = "record-platform-api";
@@ -57,6 +60,8 @@ public class JwtTestSupport {
                 .withClaim("id", userId)
                 .withClaim("tenantId", tenantId)
                 .withClaim("name", username)
+                .withClaim("scope", TENANT_SCOPE)
+                .withClaim("authVersion", DEFAULT_AUTH_VERSION)
                 .withClaim("authorities", authorities)
                 .withExpiresAt(expire)
                 .withIssuedAt(now)
@@ -74,6 +79,8 @@ public class JwtTestSupport {
                 .withClaim("id", userId)
                 .withClaim("tenantId", DEFAULT_TENANT_ID)
                 .withClaim("name", DEFAULT_USERNAME)
+                .withClaim("scope", TENANT_SCOPE)
+                .withClaim("authVersion", DEFAULT_AUTH_VERSION)
                 .withClaim("authorities", Arrays.asList("ROLE_" + DEFAULT_ROLE))
                 .withExpiresAt(expiredAt)
                 .withIssuedAt(new Date(now.getTime() - 3600000))
@@ -90,6 +97,8 @@ public class JwtTestSupport {
                 .withAudience(AUDIENCE)
                 .withClaim("id", userId)
                 .withClaim("name", username)
+                .withClaim("scope", TENANT_SCOPE)
+                .withClaim("authVersion", DEFAULT_AUTH_VERSION)
                 .withClaim("authorities", Arrays.asList("ROLE_" + role))
                 .withExpiresAt(expire)
                 .withIssuedAt(now)

--- a/platform-frontend/src/lib/api/types/auth.ts
+++ b/platform-frontend/src/lib/api/types/auth.ts
@@ -5,6 +5,7 @@
 export interface AuthorizeVO {
   username: string;
   role: string;
+  scope: "tenant" | "platform";
   token: string;
   expire: string; // ISO datetime
 }
@@ -21,6 +22,9 @@ export interface AccountVO {
   email?: string;
   avatar?: string;
   role: string;
+  scope: "tenant" | "platform";
+  /** 授权状态：1-启用，0-禁用 */
+  status?: number;
   registerTime: string;
   nickname?: string;
   /** 软删除标记：0-正常，1-已禁用 */

--- a/platform-frontend/src/lib/api/types/generated.ts
+++ b/platform-frontend/src/lib/api/types/generated.ts
@@ -3046,6 +3046,16 @@ export interface components {
             registerTime?: string;
             /** @description 角色 */
             role?: string;
+            /**
+             * @description 身份作用域：tenant 或 platform
+             * @enum {string}
+             */
+            scope: "tenant" | "platform";
+            /**
+             * Format: int32
+             * @description 授权状态：1-启用，0-禁用
+             */
+            status?: number;
             /** @description 用户名 */
             username?: string;
         };

--- a/tools/ci/tests/test_service_readiness.py
+++ b/tools/ci/tests/test_service_readiness.py
@@ -207,12 +207,15 @@ print('200')
     def test_hanging_request_respects_wait_budget(self) -> None:
         """The request timeout is clamped to the remaining startup budget."""
         self.running("storage")
-        self.env.update(PROBE_HANG="true", HEALTH_CHECK_REQUEST_TIMEOUT="30", HEALTH_CHECK_TIMEOUT="1")
+        self.env.update(PROBE_HANG="true", HEALTH_CHECK_REQUEST_TIMEOUT="30", HEALTH_CHECK_TIMEOUT="2")
         started = time.monotonic()
         self.assertNotEqual(0, self.command("start", "storage").returncode)
-        self.assertLess(time.monotonic() - started, 3)
-        probe = self.probes()[-1]
-        self.assertEqual("1", probe[probe.index("--max-time") + 1])
+        self.assertLess(time.monotonic() - started, 4)
+        probes = self.probes()
+        self.assertTrue(probes)
+        request_timeout = int(probes[-1][probes[-1].index("--max-time") + 1])
+        self.assertGreaterEqual(request_timeout, 1)
+        self.assertLessEqual(request_timeout, 2)
 
     def test_http_error_and_invalid_timing_fail(self) -> None:
         """HTTP errors and invalid timing settings cannot produce success."""


### PR DESCRIPTION
## 变更范围

- 新增 platform_admin 平台身份，并以 role、scope=platform、tenant_id=0 三重约束隔离租户身份
- 新增账户状态、auth_version、最近登录时间及租户版本/停用元数据的 V1.21.0 前向迁移
- 在登录、JWT 过滤、刷新与 SSE 握手中持续校验当前账户/租户授权状态，Redis 故障失败关闭
- 为密码变更、会话撤销和租户生命周期变更提供事务内授权栅栏、缓存与 SSE 清理能力
- 新增默认关闭、读取本地密码文件的一次性平台管理员 bootstrap
- 同步 OpenAPI、前端类型、部署文档、ROADMAP 和 TESTING 快照

## 安全边界

- tenant_id=0 本身不授予平台权限；legacy tenant 0 的 user/admin/monitor 仍是 tenant scope
- platform_admin 仅允许 tenant_id=0，数据库和服务层双重校验
- JWT 必须携带完整身份声明和显式 authVersion；旧令牌、旧三段 SSE 令牌和多/未知角色失败关闭
- bootstrap 不含默认凭据，不读取环境变量中的密码正文，不记录密钥或 token

## 本地验证

- 后端聚焦测试：167 项通过
- 后端全量测试：backend-service 1483 项、backend-web 576 项通过；0 failure/error
- 前端：svelte-check 0 error/0 warning；51 files / 612 tests；lint、Prettier、production build 全部通过
- OpenAPI 导出 3 项通过；generated.ts 重复生成 SHA-256 一致
- 文档 consistency evidence 通过

## CI 门禁

本机没有 Docker CLI；PlatformIdentityMigrationIT、AuthorizationStateRedisIT、FlywayReleasedMigrationCompatibilityIT 的显式本地运行因 Docker environment unavailable 阻塞，不属于断言失败。PR CI 必须在 Docker 环境执行并通过真实 MySQL/Redis 验收后再合并。